### PR TITLE
run_tests should build the test programs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,9 +15,6 @@ jobs:
   - bash: vim --version
     displayName: 'Print vim version information'
 
-  - bash: cd tests/testdata/cpp/simple && make
-    displayName: 'Build test cpp program'
-
   - bash: ./run_tests
     displayName: 'Run the tests'
     env:
@@ -35,9 +32,6 @@ jobs:
 
   - bash: vim --version
     displayName: 'Print vim version information'
-
-  - bash: cd tests/testdata/cpp/simple && make
-    displayName: 'Build test cpp program'
 
   - bash: ./run_tests
     displayName: 'Run the tests'

--- a/run_tests
+++ b/run_tests
@@ -3,6 +3,14 @@
 RUN_VIM="vim --noplugin --clean --not-a-term"
 RUN_TEST="${RUN_VIM} -S run_test.vim"
 
+echo "%SETUP - Building test programs..."
+set -e
+  pushd tests/testdata/cpp/simple
+    make clean simple
+  popd
+set +e
+echo "%DONE - built test programs"
+
 pushd tests > /dev/null
 
 echo "Running Vimspector Vim tests"


### PR DESCRIPTION
rather than only in CI. This means you just ./run_tests to run them locally.