### PR TITLE
C sharp samsung

### DIFF
--- a/install_gadget.py
+++ b/install_gadget.py
@@ -142,23 +142,6 @@ GADGETS = {
       },
     }
   },
-  'vscode-mono-debug': {
-    'language': 'csharp',
-    'enabled': False,
-    'download': {
-      'url': 'https://marketplace.visualstudio.com/_apis/public/gallery/'
-             'publishers/ms-vscode/vsextensions/mono-debug/${version}/'
-             'vspackage',
-      'target': 'vscode-mono-debug.tar.gz',
-      'format': 'tar',
-    },
-    'all': {
-      'file_name': 'vscode-mono-debug.vsix',
-      'version': '0.15.8',
-      'checksum':
-          '723eb2b621b99d65a24f215cb64b45f5fe694105613a900a03c859a62a810470',
-    }
-  },
   'vscode-bash-debug': {
     'language': 'bash',
     'download': {

--- a/install_gadget.py
+++ b/install_gadget.py
@@ -142,6 +142,23 @@ GADGETS = {
       },
     }
   },
+  'vscode-mono-debug': {
+    'language': 'csharp',
+    'enabled': False,
+    'download': {
+      'url': 'https://marketplace.visualstudio.com/_apis/public/gallery/'
+             'publishers/ms-vscode/vsextensions/mono-debug/${version}/'
+             'vspackage',
+      'target': 'vscode-mono-debug.tar.gz',
+      'format': 'tar',
+    },
+    'all': {
+      'file_name': 'vscode-mono-debug.vsix',
+      'version': '0.15.8',
+      'checksum':
+          '723eb2b621b99d65a24f215cb64b45f5fe694105613a900a03c859a62a810470',
+    }
+  },
   'vscode-bash-debug': {
     'language': 'bash',
     'download': {

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -615,7 +615,7 @@ class DebugSession( object ):
       self._stackTraceView.LoadThreads( True )
 
 
-  def OnEvent_capabiilities( self, msg ):
+  def OnEvent_capabilities( self, msg ):
     self._server_capabilities.update(
       ( msg.get( 'body' ) or {} ).get( 'capabilities' ) or {} )
 

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -113,7 +113,7 @@ class VariablesView( object ):
              old_scopes[ i ][ 'name' ] == scope[ 'name' ] ):
           scope[ '_expanded' ] = old_scopes[ i ].get( '_expanded', False )
           scope[ '_old_variables' ] = old_scopes[ i ].get( '_variables', [] )
-        elif not 'expensive' in scope or not scope[ 'expensive' ]:
+        elif not scope.get( 'expensive' ):
           # Expand any non-expensive scope unless manually collapsed
           scope[ '_expanded' ] = True
 

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -113,7 +113,7 @@ class VariablesView( object ):
              old_scopes[ i ][ 'name' ] == scope[ 'name' ] ):
           scope[ '_expanded' ] = old_scopes[ i ].get( '_expanded', False )
           scope[ '_old_variables' ] = old_scopes[ i ].get( '_variables', [] )
-        elif not scope[ 'expensive' ]:
+        elif not 'expensive' in scope or not scope[ 'expensive' ]:
           # Expand any non-expensive scope unless manually collapsed
           scope[ '_expanded' ] = True
 


### PR DESCRIPTION
@puremourning, these are my changes for #35.

I made three changes here:
1. When doing requests to lookup variable requests, if the individual variable response elements do not have an 'expensive' key just assume they are not. Currently it is throwing a key error there.
2. Fixed what I think was probably a typo in the event handler for `OnEvent_capabilities`that was making so the capabilities never got set and were not respected afterwards. In this case it was `supportsConfigurationDoneRequest`.
3. I added back in the mono debugger adapter. I know I mentioned this earlier and that might have led to some confusion. I don't think you need to remove this as this is a openly licensed debug adapter (I believe. I haven't done extensive research though so correct me if I'm wrong.) I checked this back in under the impression that I misspoke and that  you removed it thinking it was the proprietary  microsoft dotnet runtime debugger. If this is not the case and you had another reason, I will gladly revert the commit. Sorry for the confusion here.