### PR TITLE
Allow variables to reference other variables in other layers

### DIFF
--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -113,9 +113,11 @@ class DebugSession( object ):
       'gadgetDir': install.GetGadgetDir( VIMSPECTOR_HOME, install.GetOS() )
     }
     self._variables.update(
-      utils.ParseVariables( adapter.get( 'variables', {} ) ) )
+      utils.ParseVariables( adapter.get( 'variables', {} ),
+                            self._variables ) )
     self._variables.update(
-      utils.ParseVariables( configuration.get( 'variables', {} ) ) )
+      utils.ParseVariables( configuration.get( 'variables', {} ),
+                            self._variables ) )
     self._variables.update( launch_variables )
 
     utils.ExpandReferencesInDict( configuration, self._variables )

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -107,10 +107,40 @@ class DebugSession( object ):
     # TODO: Do we want some form of persistence ? e.g. self._staticVariables,
     # set from an api call like SetLaunchParam( 'var', 'value' ), perhaps also a
     # way to load .vimspector.local.json which just sets variables
+    #
+    # Additional vars as defined by VSCode:
+    #
+    # ${workspaceFolder} - the path of the folder opened in VS Code
+    # ${workspaceFolderBasename} - the name of the folder opened in VS Code
+    #                              without any slashes (/)
+    # ${file} - the current opened file
+    # ${relativeFile} - the current opened file relative to workspaceFolder
+    # ${fileBasename} - the current opened file's basename
+    # ${fileBasenameNoExtension} - the current opened file's basename with no
+    #                              file extension
+    # ${fileDirname} - the current opened file's dirname
+    # ${fileExtname} - the current opened file's extension
+    # ${cwd} - the task runner's current working directory on startup
+    # ${lineNumber} - the current selected line number in the active file
+    # ${selectedText} - the current selected text in the active file
+    # ${execPath} - the path to the running VS Code executable
+
+    current_file = utils.GetBufferFilepath( vim.current.buffer )
+
     self._variables = {
       'dollar': '$', # HACK. Hote '$$' also works.
       'workspaceRoot': self._workspace_root,
-      'gadgetDir': install.GetGadgetDir( VIMSPECTOR_HOME, install.GetOS() )
+      'workspaceFolder': self._workspace_root,
+      'gadgetDir': install.GetGadgetDir( VIMSPECTOR_HOME, install.GetOS() ),
+      'file': current_file,
+      'relativeFile': os.path.relpath( current_file, self._workspace_root ),
+      'fileBasename': os.path.basename( current_file ),
+      'fileBasenameNoExtension':
+        os.path.splitext( os.path.basename( current_file ) )[ 0 ],
+      'fileDirname': os.path.dirname( current_file ),
+      'fileExtname':
+        os.path.splitext( os.path.basename( current_file ) )[ 1 ],
+      'cwd': os.getcwd(),
     }
     self._variables.update(
       utils.ParseVariables( adapter.get( 'variables', {} ),

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -380,3 +380,10 @@ def DisplayBaloon( is_term, display ):
 
   vim.eval( "balloon_show( {0} )".format(
     json.dumps( display ) ) )
+
+
+def GetBufferFilepath( buf ):
+  if not buf.name:
+    return ''
+
+  return os.path.normpath( buf.name )

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -343,7 +343,7 @@ def ExpandReferencesInDict( obj, mapping, **kwargs ):
     obj[ k ] = expand_refs_in_object( obj[ k ] )
 
 
-def ParseVariables( variables ):
+def ParseVariables( variables, mapping, **kwargs ):
   new_variables = {}
   for n, v in variables.items():
     if isinstance( v, dict ):
@@ -353,7 +353,7 @@ def ParseVariables( variables ):
 
         new_v = v.copy()
         # Bit of a hack. Allows environment variables to be used.
-        ExpandReferencesInDict( new_v, {} )
+        ExpandReferencesInDict( new_v, mapping, **kwargs )
 
         env = os.environ.copy()
         env.update( new_v.get( 'env' ) or {} )

--- a/tests/testdata/cpp/simple/.vimspector.json
+++ b/tests/testdata/cpp/simple/.vimspector.json
@@ -5,7 +5,7 @@
       "configuration": {
         "type": "cppdbg",
         "request": "launch",
-        "program": "${workspaceRoot}/simple",
+        "program": "${workspaceRoot}/${fileBasenameNoExtension}",
         "args": [],
         "cwd": "${workspaceRoot}",
         "environment": [],


### PR DESCRIPTION
This allows a configuration variable to reference, say `${workspaceRoot}`, e.g.:

```
   "configurations": {
     "python - launch nosetests": {
       "adapter": "vscode-python",
       "variables": {
         "python_path": {
           "shell": [
             "python",
             "${workspaceRoot}/run_tests.py",
             "--dump-path"
           ]
         }
       },
```