### PR TITLE
Remember user choices

### DIFF
--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -34,6 +34,9 @@ VIMSPECTOR_HOME = os.path.abspath( os.path.join( os.path.dirname( __file__ ),
                                                  '..',
                                                  '..' ) )
 
+# cache of what the user entered for any option we ask them
+USER_CHOICES = {}
+
 
 class DebugSession( object ):
   def __init__( self ):
@@ -148,14 +151,26 @@ class DebugSession( object ):
     }
     self._variables.update(
       utils.ParseVariables( adapter.get( 'variables', {} ),
-                            self._variables ) )
+                            self._variables,
+                            USER_CHOICES ) )
     self._variables.update(
       utils.ParseVariables( configuration.get( 'variables', {} ),
-                            self._variables ) )
+                            self._variables,
+                            USER_CHOICES ) )
+
+    # Pretend that vars passed to the launch command were typed in by the user
+    # (they may have been in theory)
+    # TODO: Is it right that we do this _after_ ParseVariables, rather than
+    # before ?
+    USER_CHOICES.update( launch_variables )
     self._variables.update( launch_variables )
 
-    utils.ExpandReferencesInDict( configuration, self._variables )
-    utils.ExpandReferencesInDict( adapter, self._variables )
+    utils.ExpandReferencesInDict( configuration,
+                                  self._variables,
+                                  USER_CHOICES )
+    utils.ExpandReferencesInDict( adapter,
+                                  self._variables,
+                                  USER_CHOICES )
 
     if not adapter:
       utils.UserMessage( 'No adapter configured for {}'.format(

--- a/support/test/python/simple_python/main.py
+++ b/support/test/python/simple_python/main.py
@@ -4,7 +4,10 @@
 class TestClass( object ):
   def __init__( self, value ):
     self._var = value
-    self.DoSomething()
+    try:
+      self.DoSomething()
+    except ValueError:
+      pass
 
   def DoSomething( self ):
     for i in range( 0, 100 ):
@@ -12,6 +15,8 @@ class TestClass( object ):
         print( '{0} is less than the value'.format( i ) )
       else:
         print( '{0} might be more'.format( i ) )
+
+    raise ValueError( 'Done' )
 
 
 def Main():


### PR DESCRIPTION
There are 2 things we ask for input for:

- input variables
- exception breakpoint filters

It's irritating to have to repeat yourself when going through the
edit/debug loop.

Howver, cacheing has some quirks and disadvantages - they key one being
when to clear the cache. To resolve this we take two slightly different
approaches:

1. For input variables, we remember the choice of the user, but present
that only as the default, so they can just hit enter to accept it. We
already rememeber the choices for the length of the debug session (i.e.
across 'restart' calls).

2. For exception breakpoints, we remember the choices for as long as the
current session is running.

This allows users to hit the 'restart' button without being prompted at
all.

Meanwhile, we also remove the (broken) support for exception breakpoint
matchers and state the server default for exception breakpoint filters.

---

Fixes https://github.com/puremourning/vimspector/issues/53 (mostly). There's no way to set exception breakpoint info in vimspector.json currently. We could add that in a separate PR maybe.

cc @doronbehar.
