### PR TITLE
Source request

### DIFF
--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -306,6 +306,16 @@ def ClearBuffer( buf ):
   buf[ : ] = None
 
 
+def SetBufferContents( buf, lines, modified=False ):
+  try:
+    if not isinstance( lines, list ):
+      lines = lines.splitlines()
+
+    buf[:] = lines
+  finally:
+    buf.options[ 'modified' ] = modified
+
+
 def IsCurrent( window, buf ):
   return vim.current.window == window and vim.current.window.buffer == buf
 


### PR DESCRIPTION
`lldb-vscode` can be used directly from vimspector, but it requires the use of `sourceReference` as its break on start is really on start deep in the library.

It turns out that the use of the `source` request and `sourceReference` is actually not optional in the spec. Our solution is simple enough: request when jumping to a frame. 

Yet more cringy race conditions and hacky async requests in this PR, but the result is quiet satisfying:

![image](https://user-images.githubusercontent.com/10584846/67639958-6d3b0480-f8ee-11e9-9506-d1884613806d.png)

Haven't tried the other adapters yet.
