### PR TITLE
Syntax highlighting for locals and watches

### DIFF
--- a/install_gadget.py
+++ b/install_gadget.py
@@ -56,17 +56,17 @@ GADGETS = {
     },
     'do': lambda name, root: InstallCppTools( name, root ),
     'all': {
-      'version': '0.23.1',
+      'version': '0.26.2',
     },
     'linux': {
       'file_name': 'cpptools-linux.vsix',
       'checksum':
-        'c0f424bd6d5e016d70126587c80b92d981729c708ce524f2cce4c3f524b41d71'
+        '767aed01f0c0b5eb9e9eff96aba47b576d153d2b2d9fc28e306722ea45a02ff5'
     },
     'macos': {
       'file_name': 'cpptools-osx.vsix',
       'checksum':
-        '431692395ba243ea20428e083d5df3201a0dbda31a66eab7729da0f377def5fd',
+        '6fd52562e1e53287c0e9b94813709c6fab487c16ff3054eda6233d6c0241eb0e',
     },
     'windows': {
       'file_name': 'cpptools-win32.vsix',
@@ -523,6 +523,10 @@ parser.add_argument( '--force-all',
                      action = 'store_true',
                      help = 'Enable all unsupported completers' )
 
+parser.add_argument( '--no-gadget-config',
+                     action = 'store_true',
+                     help = "Don't write the .gagets.json, just install" )
+
 done_languages = set()
 for name, gadget in GADGETS.items():
   lang = gadget[ 'language' ]
@@ -616,9 +620,18 @@ for name, gadget in GADGETS.items():
     print( "FAILED installing {}: {}".format( name, e ) )
 
 
-with open( install.GetGadgetConfigFile( os.path.dirname( __file__ ) ),
-           'w' ) as f:
-  json.dump( { 'adapters': all_adapters }, f, indent=2, sort_keys=True )
+adapter_config = json.dumps ( { 'adapters': all_adapters },
+                              indent=2,
+                              sort_keys=True )
+
+if args.no_gadget_config:
+  print( "" )
+  print( "Would write the following gadgets: " )
+  print( adapter_config )
+else:
+  with open( install.GetGadgetConfigFile( os.path.dirname( __file__ ) ),
+             'w' ) as f:
+    f.write( adapter_config )
 
 if failed:
   raise RuntimeError( 'Failed to install gadgets: {}'.format(

--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -27,6 +27,7 @@ class CodeView( object ):
 
     self._terminal_window = None
     self._terminal_buffer_number = None
+    self.current_syntax = None
 
     self._logger = logging.getLogger( __name__ )
     utils.SetUpLogging( self._logger )
@@ -93,6 +94,9 @@ class CodeView( object ):
                                    frame[ 'line' ],
                                    frame[ 'source' ][ 'path' ] ) )
 
+    self.current_syntax = utils.ToUnicode(
+      vim.current.buffer.options[ 'syntax' ] )
+
     return True
 
   def Clear( self ):
@@ -102,6 +106,7 @@ class CodeView( object ):
       self._signs[ 'vimspectorPC' ] = None
 
     self._UndisplaySigns()
+    self.current_syntax = None
 
   def Reset( self ):
     self.ClearBreakpoints()

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -427,6 +427,7 @@ class DebugSession( object ):
       return False
 
     if frame:
+      self._variablesView.SetSyntax( self._codeView.current_syntax )
       self._variablesView.LoadScopes( frame )
       self._variablesView.EvaluateWatches()
     else:

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -434,3 +434,9 @@ def GetBufferFilepath( buf ):
     return ''
 
   return os.path.normpath( buf.name )
+
+
+def ToUnicode( b ):
+  if isinstance( b, bytes ):
+    return b.decode( 'utf-8' )
+  return b

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -31,6 +31,7 @@ class VariablesView( object ):
     self._vars = View( variables_win, {}, self._DrawScopes )
     self._watch = View( watches_win, {}, self._DrawWatches )
     self._connection = connection
+    self._current_syntax = ''
 
     # Allows us to hit <CR> to expand/collapse variables
     with utils.LetCurrentWindow( self._vars.win ):
@@ -91,6 +92,7 @@ class VariablesView( object ):
       utils.ClearBuffer( self._vars.win.buffer )
     with utils.ModifiableScratchBuffer( self._watch.win.buffer ):
       utils.ClearBuffer( self._watch.win.buffer )
+    self._current_syntax = ''
 
   def ConnectionUp( self, connection ):
     self._connection = connection
@@ -373,3 +375,19 @@ class VariablesView( object ):
         'context': 'hover',
       }
     }, failure_handler )
+
+
+  def SetSyntax( self, syntax ):
+    if not syntax:
+      syntax = ''
+
+    if self._current_syntax == syntax:
+      return
+
+    self._current_syntax = syntax
+
+    with utils.LetCurrentWindow( self._vars.win ):
+      vim.command( 'set syntax={}'.format( utils.Escape( syntax ) ) )
+
+    with utils.LetCurrentWindow( self._watch.win ):
+      vim.command( 'set syntax={}'.format( utils.Escape( syntax ) ) )


### PR DESCRIPTION
This enabled syntax highlighting for locals window and watches window. This just aids readability a little. It always uses the syntax of the "code" window, whatever that happens to be.