### PR TITLE
Document closing the debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For a tutorial and usage overview, take a look at the
       * [Variables and scopes](#variables-and-scopes)
       * [Watches](#watches)
       * [Stack Traces](#stack-traces)
-      * [Program Output:](#program-output)
+      * [Program Output](#program-output)
          * [Console](#console)
    * [Debug adapter configuration](#debug-adapter-configuration)
       * [Supported Languages](#supported-languages-1)
@@ -473,7 +473,7 @@ new watch expression.
 * In the threads window, use `<CR>` to expand/collapse.
 * Use `<CR>` on a stack frame to jump to it.
 
-## Program Output:
+## Program Output
 
 * In the outputs window use the WinBar to select the output channel.
 * The debugee prints to the stdout channel.

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ CLI for the debug adapter. Support for this varies amongt adapters.
 * Commit the request with `<CR>`
 * The request and subsequent result are printed.
 
-NOTE: See also [Watches][#watches] above.
+NOTE: See also [Watches](#watches) above.
 
 ## Closing debugger
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ For a tutorial and usage overview, take a look at the
       * [Stack Traces](#stack-traces)
       * [Program Output](#program-output)
          * [Console](#console)
+      * [Closing debugger](#closing-debugger)
    * [Debug adapter configuration](#debug-adapter-configuration)
       * [Supported Languages](#supported-languages-1)
       * [Partially supported](#partially-supported)
@@ -489,6 +490,13 @@ CLI for the debug adapter. Support for this varies amongt adapters.
 * The request and subsequent result are printed.
 
 NOTE: See also [Watches][#watches] above.
+
+## Closing debugger
+
+To close the debugger, use:
+
+* `Reset` button when mouse support is enabled in vim (`set mouse=a`)
+* `call vimspector#Reset()`
 
 # Debug adapter configuration
 


### PR DESCRIPTION
Thank you for this project!

After trying this out, I couldn't figure out how to return close the debugger, which turned out to be pretty simple. I suggest to document it as a part of a regular debugging flow.

This PR also includes a couple of other fixes to readme.