### PR TITLE
Support neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Alternatively, you can clone the repo and select which gadgets are installed:
 
 Vimspector requires:
 
-* Vim (*not neovim*) version 8.1 with at least patch 1264
+* Vim version 8.1 with at least patch 1264, or Neovim 0.4.3
 * One of the following operating systems:
   * Linux
   * macOS Mojave or pater
@@ -149,15 +149,10 @@ author. PRs are welcome.
 
 Which Linux versions? I only test on Ubuntu 18.04 and later and RHEL 7.
 
-Why not neovim? A few fiddly reasons (not philosophy):
+### Neovim differences
 
-* neovim doesn't implement some features Vimspector relies on
-* neovim's Python API is not compatible with Vim's
-* I don't personally use or test with neovim, and doing so doubles the 
-effort required.
-
-If enough people +1 [this issue](https://github.com/puremourning/vimspector/issues/29),
-I will consider it.
+neovim doesn't implement some features Vimspector relies on (WinBar and prompt
+buffers), so you have to use `:Vimspector*` commands (see [Usage][#usage]).
 
 ## Language dependencies
 
@@ -382,12 +377,26 @@ minimise this, or at least announce on Gitter.
 
 By default, vimspector does not change any of your mappings. Mappings are very
 personal and so you should work out what you like and use vim's powerful mapping
-features to set your own mappings. For example, if you want `<F5>` to
-start/continue debugging, add this to some appropriate place, such as your
-`vimrc` (hint: run `:e $MYVIMRC`).
+features to set your own mappings. To that end, Vimspector defines the following
+`<Plug>` mappings:
+
+* `<Plug>VimspectorContinue`
+* `<Plug>VimspectorStop`
+* `<Plug>VimspectorRestart`
+* `<Plug>VimspectorPause`
+* `<Plug>VimspectorToggleBreakpoint`
+* `<Plug>VimspectorAddFunctionBreakpoint`
+* `<Plug>VimspectorStepOver`
+* `<Plug>VimspectorStepInto`
+* `<Plug>VimspectorStepOut`
+
+These map 1-1 with the API functions below.
+
+For example, if you want `<F5>` to start/continue debugging, add this to some
+appropriate place, such as your `vimrc` (hint: run `:e $MYVIMRC`).
 
 ```viml
-nnoremap <F5> :call vimspector#Continue()<CR>
+nmap <F5> <Plug>VimspectorContinue
 ```
 
 That said, many people are familiar with particular debuggers, so the following
@@ -470,11 +479,13 @@ breakpoint.
 
 ## Watches
 
-The watches window is a prompt buffer. Enter insert mode to add a 
-new watch expression.
+The watches window is a prompt buffer, where that's available. Enter insert mode
+to add a new watch expression.
 
 * Add watches to the variables window by entering insert mode and
   typing the expression. Commit with `<CR>`.
+* Alternatively, use `:VimspectorWatch <expression>`. Tab-completion for
+  expression is available in some debug adapters.
 * Expand result with `<CR>`.
 * Delete with `<DEL>`.
 
@@ -486,15 +497,20 @@ new watch expression.
 ## Program Output
 
 * In the outputs window use the WinBar to select the output channel.
+* Alternatively, use `:VimspectorShowOutput <category>`. Use command-line
+  completion to see the categories.
 * The debugee prints to the stdout channel.
 * Other channels may be useful for debugging.
 
 ### Console
 
-The console window is a prompt buffer and can be used as an interactive
-CLI for the debug adapter. Support for this varies amongt adapters.
+The console window is a prompt buffer, where that's available, and can be used
+as an interactive CLI for the debug adapter. Support for this varies amongt
+adapters.
 
-* Enter insert mode to enter a command to evaluate
+* Enter insert mode to enter a command to evaluate. 
+* Alternatively, `:VimspectorEval <expression>`. Completion is available with
+  some debug adapters.
 * Commit the request with `<CR>`
 * The request and subsequent result are printed.
 
@@ -504,7 +520,8 @@ NOTE: See also [Watches](#watches) above.
 
 To close the debugger, use:
 
-* `Reset` button when mouse support is enabled in vim (`set mouse=a`)
+* `Reset` WinBar button (`set mouse=a`)
+* `:VimspectorReset` when the WinBar is not available.
 * `call vimspector#Reset()`
 
 # Debug adapter configuration


### PR DESCRIPTION
Fixes #29 

* Remove `bindeval`: Instead, require a send function in the job/channel API, and marshal the arguments through global variables.
* Abstract terminal API
* Abstract job API

TODO:

* [x] Fix `SetUpCommandBuffer` so that the output of the command actually appears in the buffer in neovim. Don't understand why [this](https://github.com/puremourning/vimspector/pull/77/files#diff-1a311eda164eb1ffe57e4804f77da460R124) doesn't work
* [x] Abstract channel api
* [x] replace WinBar in code view ? Or just rely on mappings ? Maybe a help window ?
* [x] replace winbar in output view with `:VimspectorShowOutput <tab complete cetegory>`
* [x] find a way to make `:Vimspector...` commands discoverable ?
* [x] add `:VimspectorEval <tab complete expr>` and `:VimspectorWatch <tab complete expr>`
* [x] add `:VimscpectorReset`

Might decide nvim is "best effort" basis only. If not, will need to:

* [ ] add neovim jobs to CI (docker images, versions, yada yada)
* [ ] port the whole test framework to neovim
* [ ] write a lot more tests. there aren't enough tests to support 2 runtimes yet. 

Known issues:

* [ ] can't set environment variables when starting jobs in neovim (only in neovim master)

But, here's vimspector "working" in neovim:

[![asciicast](https://asciinema.org/a/73kkZlqrUhPRxjgx0QWMKBr0A.svg)](https://asciinema.org/a/73kkZlqrUhPRxjgx0QWMKBr0A)