### PR TITLE
Fix: Remove balloon '...' in windows != code_window

### DIFF
--- a/autoload/vimspector/internal/balloon.vim
+++ b/autoload/vimspector/internal/balloon.vim
@@ -19,13 +19,14 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 " }}}
 
+" Returns: py.ShowBalloon( winnr, expresssion )
 function! vimspector#internal#balloon#BalloonExpr() abort
   " winnr + 1 because for *no good reason* winnr is 0 based here unlike
   " everywhere else
   " int() because for *no good reason* winnr is a string.
-  py3 _vimspector_session.ShowBalloon( int( vim.eval( 'v:beval_winnr' ) ) + 1,
-        \ vim.eval( 'v:beval_text' ) )
-  return '...'
+  return py3eval('_vimspector_session.ShowBalloon('
+        \ . 'int( vim.eval( "v:beval_winnr" ) ) + 1,'
+        \ . 'vim.eval( "v:beval_text" ) )' )
 endfunction
 
 " Boilerplate {{{

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -359,16 +359,22 @@ class DebugSession( object ):
     self._variablesView.DeleteWatch()
 
   def ShowBalloon( self, winnr, expression ):
-    if self._stackTraceView.GetCurrentFrame() is None:
-      return
+    """Proxy: ballonexpr -> variables.ShowBallon"""
+    frame = self._stackTraceView.GetCurrentFrame()
+    # Check if RIP is in a frame
+    if frame is None:
+      self._logger.debug( 'Balloon: Not in a stack frame' )
+      return ''
 
-    if winnr == int( self._codeView._window.number ):
-      self._variablesView.ShowBalloon( self._stackTraceView.GetCurrentFrame(),
-                                       expression )
-    else:
+    # Check if cursor in code window
+    if winnr != int( self._codeView._window.number ):
       self._logger.debug( 'Winnr %s is not the code window %s',
                           winnr,
                           self._codeView._window.number )
+      return ''
+
+    # Return variable aware function
+    return self._variablesView.ShowBalloon( frame, expression )
 
   def ExpandFrameOrThread( self ):
     self._stackTraceView.ExpandFrameOrThread()

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -346,8 +346,9 @@ class VariablesView( object ):
     draw()
 
   def ShowBalloon( self, frame, expression ):
+    """Callback to display variable under cursor `:h ballonexpr`"""
     if not self._connection:
-      return
+      return ''
 
     def handler( message ):
       # TODO: this result count be expandable, but we have no way to allow the
@@ -366,7 +367,7 @@ class VariablesView( object ):
       display = [ reason ]
       utils.DisplayBaloon( self._is_term, display )
 
-
+    # Send async request
     self._connection.DoRequest( handler, {
       'command': 'evaluate',
       'arguments': {
@@ -375,6 +376,9 @@ class VariablesView( object ):
         'context': 'hover',
       }
     }, failure_handler )
+
+    # Return working (meanwhile)
+    return '...'
 
 
   def SetSyntax( self, syntax ):


### PR DESCRIPTION
Remove the ... balloon in non code windows

Problem: In non-code window, user see a '...' balloon even if python knows it does not need to work
Solution: use `pyeval` in vim so that python's knowledge is getting back from the stack as return value