### PR TITLE
A selection of misc fixes and enhancements from ongoing usage

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -26,6 +26,15 @@ def Settings( **kwargs ):
             }
           ]
         }
+      },
+      'capabilities': {
+        'textDocument': {
+          'completion': {
+            'completionItem': {
+              'snippetSupport': True
+            }
+          }
+        }
       }
     }
 

--- a/install_gadget.py
+++ b/install_gadget.py
@@ -107,6 +107,26 @@ GADGETS = {
       }
     },
   },
+  'vscode-java-debug': {
+    'language': 'java',
+    'enabled': False,
+    'download': {
+      'url': 'https://github.com/microsoft/vscode-java-debug/releases/download/'
+             '${version}/${file_name}',
+    },
+    'all': {
+      'version': '0.23.0',
+      'file_name': 'vscode-java-debug-0.23.0.vsix',
+      'checksum':
+        '',
+    },
+    'adapters': {
+      "vscode-java": {
+        "name": "vscode-java",
+        "port": "ask",
+      }
+    },
+  },
   'tclpro': {
     'language': 'tcl',
     'repo': {

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -508,8 +508,8 @@ class DebugSession( object ):
 
     # TODO: Use the 'tarminate' request if supportsTerminateRequest set
 
+  
   def _PrepareAttach( self, adapter_config, launch_config ):
-
     atttach_config = adapter_config.get( 'attach' )
 
     if not atttach_config:
@@ -520,13 +520,9 @@ class DebugSession( object ):
       # e.g. expand variables when we use them, not all at once. This would
       # remove the whole %PID% hack.
       remote = atttach_config[ 'remote' ]
-      ssh = [ 'ssh' ]
+      ssh = self._GetSSHCommand( remote )
 
-      if 'account' in remote:
-        ssh.append( remote[ 'account' ] + '@' + remote[ 'host' ] )
-      else:
-        ssh.append( remote[ 'host' ] )
-
+      # FIXME: Why does this not use self._GetCommands ?
       cmd = ssh + remote[ 'pidCommand' ]
 
       self._logger.debug( 'Getting PID: %s', cmd )
@@ -574,12 +570,7 @@ class DebugSession( object ):
 
     if 'remote' in run_config:
       remote = run_config[ 'remote' ]
-      ssh = [ 'ssh' ]
-      if 'account' in remote:
-        ssh.append( remote[ 'account' ] + '@' + remote[ 'host' ] )
-      else:
-        ssh.append( remote[ 'host' ] )
-
+      ssh = self._GetSSHCommand( remote )
       commands = self._GetCommands( remote, 'run' )
 
       for index, command in enumerate( commands ):
@@ -597,6 +588,16 @@ class DebugSession( object ):
         self._logger.debug( 'Running remote app: %s', full_cmd )
         self._outputView.RunJobWithOutput( 'Remote{}'.format( index ),
                                            full_cmd )
+
+
+  def _GetSSHCommand( self, remote ):
+    ssh = [ 'ssh' ] + remote.get( 'ssh', {} ).get( 'args', [] )
+    if 'account' in remote:
+      ssh.append( remote[ 'account' ] + '@' + remote[ 'host' ] )
+    else:
+      ssh.append( remote[ 'host' ] )
+
+    return ssh
 
 
   def _GetCommands( self, remote, pfx ):

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -473,10 +473,11 @@ class DebugSession( object ):
     if 'cwd' not in self._adapter:
       self._adapter[ 'cwd' ] = os.getcwd()
 
+    vim.vars[ '_vimspector_adapter_spec' ] = self._adapter
     channel_send_func = vim.bindeval(
-      "vimspector#internal#{}#StartDebugSession( {} )".format(
-        self._connection_type,
-        json.dumps( self._adapter ) ) )
+        "vimspector#internal#{}#StartDebugSession( "
+        "  g:_vimspector_adapter_spec "
+        ")".format( self._connection_type ) )
 
     if channel_send_func is None:
       self._logger.error( "Unable to start debug server" )

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -509,7 +509,7 @@ class DebugSession( object ):
 
     # TODO: Use the 'tarminate' request if supportsTerminateRequest set
 
-  
+
   def _PrepareAttach( self, adapter_config, launch_config ):
     atttach_config = adapter_config.get( 'attach' )
 

--- a/python3/vimspector/output.py
+++ b/python3/vimspector/output.py
@@ -115,10 +115,6 @@ class OutputView( object ):
     self._ShowOutput( category )
 
   def Evaluate( self, frame, expression ):
-    if not frame:
-      self.Print( 'Console', 'There is no current stack frame' )
-      return
-
     console = self._buffers[ 'Console' ].buf
     utils.AppendToBuffer( console, 'Evaluating: ' + expression )
 
@@ -132,14 +128,18 @@ class OutputView( object ):
 
       utils.AppendToBuffer( console, '  Result: ' + result )
 
-    self._connection.DoRequest( print_result, {
+    request = {
       'command': 'evaluate',
       'arguments': {
         'expression': expression,
         'context': 'repl',
-        'frameId': frame[ 'id' ],
       }
-    } )
+    }
+
+    if frame:
+      request[ 'arguments' ][ 'frameId' ] = frame[ 'id' ]
+
+    self._connection.DoRequest( print_result, request )
 
   def _ToggleFlag( self, category, flag ):
     if self._buffers[ category ].flag != flag:

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -172,8 +172,9 @@ class StackTraceView( object ):
       if 'line' in frame and frame[ 'line' ] > 0:
         self._currentFrame = frame
         return self._session.SetCurrentFrame( self._currentFrame )
+      return False
 
-    source = frame.get( 'source', {} )
+    source = frame.get( 'source' ) or {}
     if source.get( 'sourceReference', 0 ) > 0:
       def handle_resolved_source( resolved_source ):
         frame[ 'source' ] = resolved_source

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -323,6 +323,7 @@ def SetBufferContents( buf, lines, modified=False ):
 def IsCurrent( window, buf ):
   return vim.current.window == window and vim.current.window.buffer == buf
 
+
 def ExpandReferencesInObject( obj, mapping, user_choices ):
   if isinstance( obj, dict ):
     ExpandReferencesInDict( obj, mapping, user_choices )
@@ -335,6 +336,7 @@ def ExpandReferencesInObject( obj, mapping, user_choices ):
     obj = ExpandReferencesInString( obj, mapping, user_choices )
 
   return obj
+
 
 def ExpandReferencesInString( orig_s, mapping, user_choices):
   s = os.path.expanduser( orig_s )
@@ -368,6 +370,7 @@ def ExpandReferencesInString( orig_s, mapping, user_choices):
       break
 
   return s
+
 
 # TODO: Should we just run the substitution on the whole JSON string instead?
 # That woul dallow expansion in bool and number values, such as ports etc. ?

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -323,58 +323,57 @@ def SetBufferContents( buf, lines, modified=False ):
 def IsCurrent( window, buf ):
   return vim.current.window == window and vim.current.window.buffer == buf
 
+def ExpandReferencesInObject( obj, mapping, user_choices ):
+  if isinstance( obj, dict ):
+    ExpandReferencesInDict( obj, mapping, user_choices )
+  elif isinstance( obj, list ):
+    for i, _ in enumerate( obj ):
+      # FIXME: We are assuming that it is a list of string, but could be a
+      # list of list of a list of dict, etc.
+      obj[ i ] = ExpandReferencesInObject( obj[ i ], mapping, user_choices )
+  elif isinstance( obj, str ):
+    obj = ExpandReferencesInString( obj, mapping, user_choices )
+
+  return obj
+
+def ExpandReferencesInString( orig_s, mapping, user_choices):
+  s = os.path.expanduser( orig_s )
+  s = os.path.expandvars( s )
+
+  # Parse any variables passed in in mapping, and ask for any that weren't,
+  # storing the result in mapping
+  bug_catcher = 0
+  while bug_catcher < 100:
+    ++bug_catcher
+
+    try:
+      s = string.Template( s ).substitute( mapping )
+      break
+    except KeyError as e:
+      # HACK: This is seemingly the only way to get the key. str( e ) returns
+      # the key surrounded by '' for unknowable reasons.
+      key = e.args[ 0 ]
+      default_value = user_choices.get( key, None )
+      mapping[ key ] = AskForInput( 'Enter value for {}: '.format( key ),
+                                    default_value )
+      user_choices[ key ] = mapping[ key ]
+      _logger.debug( "Value for %s not set in %s (from %s): set to %s",
+                     key,
+                     s,
+                     orig_s,
+                     mapping[ key ] )
+    except ValueError as e:
+      UserMessage( 'Invalid $ in string {}: {}'.format( s, e ),
+                   persist = True )
+      break
+
+  return s
 
 # TODO: Should we just run the substitution on the whole JSON string instead?
 # That woul dallow expansion in bool and number values, such as ports etc. ?
 def ExpandReferencesInDict( obj, mapping, user_choices ):
-  def expand_refs_in_string( orig_s ):
-    s = os.path.expanduser( orig_s )
-    s = os.path.expandvars( s )
-
-    # Parse any variables passed in in mapping, and ask for any that weren't,
-    # storing the result in mapping
-    bug_catcher = 0
-    while bug_catcher < 100:
-      ++bug_catcher
-
-      try:
-        s = string.Template( s ).substitute( mapping )
-        break
-      except KeyError as e:
-        # HACK: This is seemingly the only way to get the key. str( e ) returns
-        # the key surrounded by '' for unknowable reasons.
-        key = e.args[ 0 ]
-        default_value = user_choices.get( key, None )
-        mapping[ key ] = AskForInput( 'Enter value for {}: '.format( key ),
-                                      default_value )
-        user_choices[ key ] = mapping[ key ]
-        _logger.debug( "Value for %s not set in %s (from %s): set to %s",
-                       key,
-                       s,
-                       orig_s,
-                       mapping[ key ] )
-      except ValueError as e:
-        UserMessage( 'Invalid $ in string {}: {}'.format( s, e ),
-                     persist = True )
-        break
-
-    return s
-
-  def expand_refs_in_object( obj ):
-    if isinstance( obj, dict ):
-      ExpandReferencesInDict( obj, mapping, user_choices )
-    elif isinstance( obj, list ):
-      for i, _ in enumerate( obj ):
-        # FIXME: We are assuming that it is a list of string, but could be a
-        # list of list of a list of dict, etc.
-        obj[ i ] = expand_refs_in_object( obj[ i ] )
-    elif isinstance( obj, str ):
-      obj = expand_refs_in_string( obj )
-
-    return obj
-
   for k in obj.keys():
-    obj[ k ] = expand_refs_in_object( obj[ k ] )
+    obj[ k ] = ExpandReferencesInObject( obj[ k ], mapping, user_choices )
 
 
 def ParseVariables( variables_list, mapping, user_choices ):
@@ -416,7 +415,9 @@ def ParseVariables( variables_list, mapping, user_choices ):
           raise ValueError(
             "Unsupported variable defn {}: Missing 'shell'".format( n ) )
       else:
-        new_variables[ n ] = v
+        new_variables[ n ] = ExpandReferencesInObject( v,
+                                                       mapping,
+                                                       user_choices )
 
   return new_variables
 

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -143,10 +143,12 @@ class VariablesView( object ):
 
   def AddWatch( self, frame, expression ):
     watch = {
-        'expression': expression,
-        'frameId': frame[ 'id' ],
-        'context': 'watch',
+      'expression': expression,
+      'context': 'watch',
     }
+    if frame:
+      watch[ 'frameId' ] = frame[ 'id' ]
+
     self._watches.append( watch )
     self.EvaluateWatches()
 
@@ -395,3 +397,5 @@ class VariablesView( object ):
 
     with utils.LetCurrentWindow( self._watch.win ):
       vim.command( 'set syntax={}'.format( utils.Escape( syntax ) ) )
+
+# vim: sw=2


### PR DESCRIPTION
* Allow arbitrary ssh arguments, such as specifying a key, or other options
* Fix `frame` being optional 
* Fix go which sometimes fails to work when setting breakpoints in advance
* Fix some issues when servers don't provide `source` or `line` (looking at you java)
* Expand vars in vars. This allows more composition of config.
* Fix true/false when in adapter config's configuration defaults (i.e. don't use json.dumps, use a global)