### PR TITLE
Check connection before some operation (`next`) to avoid Python errors in vim messages

### DIFF
--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -228,16 +228,21 @@ def Escape( msg ):
   return msg.replace( "'", "''" )
 
 
-def UserMessage( msg, persist=False ):
+def UserMessage( msg, persist=False, error=False):
   if persist:
     _logger.warning( 'User Msg: ' + msg )
   else:
     _logger.info( 'User Msg: ' + msg )
 
-  vim.command( 'redraw' )
   cmd = 'echom' if persist else 'echo'
-  for line in msg.split( '\n' ):
-    vim.command( "{0} '{1}'".format( cmd, Escape( line ) ) )
+  vim.command( 'redraw' )
+  try:
+    if error:
+      vim.command("echohl WarningMsg")
+    for line in msg.split( '\n' ):
+      vim.command( "{0} '{1}'".format( cmd, Escape( line ) ) )
+  finally:
+    vim.command('echohl None') if error else None
   vim.command( 'redraw' )
 
 


### PR DESCRIPTION
Fixing  #83:  Silencing the message with early return from function and little echo warning

__Note:__ I encapsulated the check in a function decorator: This may seem overkill but at first I did not and ended with :

```python
  def StepOver( self ):
    if (not self._connection
        and utils.MessageNoConnection( )
        or self._stackTraceView.GetCurrentThreadId() is None):
      return
    ...
```

```python
  @utils.IfConnected
  def StepOver( self ):
    if self._stackTraceView.GetCurrentThreadId() is None:
      return
    ...
```
As many functions need the check, for readability and avoiding boolean magic, I preferred the second.


PS: I didn't already say, so my groupie's turn:
@puremourning your plugin is awesome !
1. Finally a debugger on vim (of course thk microsoft too)
2. Very well written
    1. __code:__ small functions, sparse: just missing comments other than T.O.D.O and F.I.X.M.E ;-)
    2. __architecture:__ one vim enter, one py enter, one util, everyone in his class. Actually I am still amazed writing these lines because it seems easy once done but thinking of the path, well you got out of troubles spectacularly.
    3. __workflow:__ adding issues, pulls to your own project, and a super test, issue framework on github
3. It works well ! So you already did it ! Congrats.