### PR TITLE
Switch to macOS 10.14 in CI (10.13 will be disabled soon)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,8 @@ stages:
       displayName: 'Run the tests'
       env:
         VIMSPECTOR_MIMODE: gdb
+        VIMSPECTOR_TEST_STDOUT: true
+        VIMSPECTOR_MI_DEBUGGER: ""
 
     - bash: ./make_package linux $(Build.SourceVersion)
       displayName: 'Package'
@@ -72,11 +74,11 @@ stages:
 
   - job: 'macos'
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.14'
     steps:
     - bash: |
         brew unlink node@6
-        brew install macvim node@10
+        brew install macvim node@10 tcl-tk
         brew link --force --overwrite node@10
       displayName: 'Install vim and node'
 
@@ -99,6 +101,9 @@ stages:
       displayName: 'Run the tests'
       env:
         VIMSPECTOR_MIMODE: lldb
+        VIMSPECTOR_TEST_STDOUT: true
+        VIMSPECTOR_MI_DEBUGGER: ""
+        LLDB_DEBUGSERVER_PATH: "/Library/Developer/CommandLineTools/Library/PrivateFrameworks/LLDB.framework/Resources/debugserver"
 
     - bash: ./make_package macos $(Build.SourceVersion)
       displayName: 'Package'

--- a/install_gadget.py
+++ b/install_gadget.py
@@ -118,7 +118,7 @@ GADGETS = {
       'version': '0.23.0',
       'file_name': 'vscode-java-debug-0.23.0.vsix',
       'checksum':
-        '',
+        'f98a35c8dd4f3079ecd9657b04f1edbfea04c364c0fbf7eee1285f942782710b',
     },
     'adapters': {
       "vscode-java": {
@@ -141,7 +141,7 @@ GADGETS = {
       'version': '0.2.31',
       'file_name': 'georgewfraser.vscode-javac-0.2.31.vsix.gz',
       'checksum':
-        '',
+        '5b0248ec1198d3ece9a9c6b9433b30c22e308f0ae6e4c7bd09cd943c454e3e1d',
     },
     'adapters': {
       "vscode-javac": {
@@ -238,7 +238,8 @@ GADGETS = {
     'all': {
       'file_name': 'bash-debug-0.3.6.vsix',
       'version': 'v0.3.6',
-      'checksum': '',
+      'checksum':
+        '502ee5732851fc4f309294fc296a291b1a114008a1fbcb232f3763be2b8d9c1f',
     },
     'do': lambda name, root: InstallBashDebug( name, root ),
     'adapters': {

--- a/tests/testdata/cpp/simple/.vimspector.json
+++ b/tests/testdata/cpp/simple/.vimspector.json
@@ -9,10 +9,14 @@
         "args": [],
         "cwd": "${workspaceRoot}",
         "environment": [],
-        "externalConsole": true,
+        "externalConsole": false,
         "stopAtEntry": true,
         "stopOnEntry": true,
-        "MImode": "${VIMSPECTOR_MIMODE}"
+        "MImode": "${VIMSPECTOR_MIMODE}",
+        "miDebuggerPath": "${VIMSPECTOR_MI_DEBUGGER}",
+        "logging": {
+          "engineLogging": true
+        }
       },
       "breakpoints": {
         "exception": {


### PR DESCRIPTION
Let's see what azure thinks. We know cpptools is broken in 10.15.