### PR TITLE
upgrade cpptools to 0.26.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,10 +551,32 @@ Current tested with the following debug adapters.
 
 * C++: [vscode-cpptools](https://github.com/Microsoft/vscode-cpptools)
 
+---
+
 ***NOTE FOR macOS USERS***: Currently VSCode cpptools does *not* work on macOS
-(see this issue: https://github.com/microsoft/vscode-cpptools/issues/3829).
-Therefore it is highly recommended to use `lldb-vscode`, which comes with llvm.
-Here's how:
+out of the box.
+See [this issue]( https://github.com/microsoft/vscode-cpptools/issues/3829)
+for the full details. 
+
+To resolve it:
+
+* Install [my build](https://github.com/puremourning/lldb-mi/releases) of
+  `lldb-mi`. Instructions
+  [here](https://github.com/microsoft/vscode-cpptools/issues/3829#issuecomment-578454043).
+* Add the following to the `configuration` section of your `.vimspector.json`
+  (below):
+
+```
+{
+  "configurations": {
+    "<name>: Launch": {
+      "adapter": "vscode-cpptools",
+      "configuration": {
+        "miDebuggerPath": "/path/to/my/build/of/lldb-mi",
+        ...
+```
+
+An alternative is to to use `lldb-vscode`, which comes with llvm.  Here's how:
 
 * Install llvm with HomeBrew: `brew install llvm`
 * Create a file named
@@ -586,8 +608,10 @@ Here's how:
 }
 ```
 
+---
+
 Example `.vimspector.json` (works with both `vscode-cpptools` and `lldb-vscode`.
-For `lldb-vscode` replace the name of the adapter with `lldb-vscode`):
+For `lldb-vscode` replace the name of the adapter with `lldb-vscode`:
 
 ```
 {

--- a/install_gadget.py
+++ b/install_gadget.py
@@ -56,17 +56,17 @@ GADGETS = {
     },
     'do': lambda name, root: InstallCppTools( name, root ),
     'all': {
-      'version': '0.26.2',
+      'version': '0.26.3',
     },
     'linux': {
       'file_name': 'cpptools-linux.vsix',
       'checksum':
-        '767aed01f0c0b5eb9e9eff96aba47b576d153d2b2d9fc28e306722ea45a02ff5'
+        'd660367fbedd6acaffcc233c1d41ef280ff79aeba81846b86bf9bd97b4887379'
     },
     'macos': {
       'file_name': 'cpptools-osx.vsix',
       'checksum':
-        '6fd52562e1e53287c0e9b94813709c6fab487c16ff3054eda6233d6c0241eb0e',
+        'ca0793dd1dfd70757491da80cf04b2b15631048b572de2ebe3864f9eed96dff9',
     },
     'windows': {
       'file_name': 'cpptools-win32.vsix',


### PR DESCRIPTION
This sort-of fixes macOS issues when used with my lldb-mi.