### PR TITLE
Import vim

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,19 +38,34 @@ Vim.
 NOTE: Windows is not supported. There is a branch with windows support, which
 you can contribute to, rather than opening an issue.
 
-* Output of `vim --version`
+* Version of Vimspector: (e.g. output of `git rev-parse HEAD` if cloned or the
+  name of the tarball used to install otherwise)
+
+* Output of `vim --version` or `nvim --version`
 
 ```
 paste here
 ```
 
-* Output of `which vim`:
+* Output of `which vim` or `which nvim`:
 
 ```
 paste here
 ```
 
 * Output of `:py3 pass`:
+
+```
+paste here
+```
+
+* Output of `:py3 import vim`:
+
+```
+paste here
+```
+
+* For neovim: output of `:checkhealth`
 
 ```
 paste here

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,11 @@ of the following reasons:
 * The issue does not represent a Vimspector bug or feature request
 * etc.
 
+Issue titles are important. It's not usually helpful to write a title like
+`Issue with Vimspector` or `Issue configuring` or even pasting an error message.
+Spend a minute to come up with a consise summary of the problem. This helps with
+management of issues, with triage, and above all with searching.
+
 But above all else, please *please* complete the issue template. I know it is a
 little tedious to get all the various diagnostics, but you *must* provide them,
 *even if you think they are irrelevant*. This is important, because the

--- a/autoload/vimspector/internal/state.vim
+++ b/autoload/vimspector/internal/state.vim
@@ -27,6 +27,7 @@ function! vimspector#internal#state#Reset() abort
     let prefix='neo'
   endif
     py3 << EOF
+import vim
 from vimspector import debug_session
 _vimspector_session = debug_session.DebugSession( vim.eval( 'prefix' ) )
 EOF


### PR DESCRIPTION
Import the vim module

In Vim, the vim module is always imported by magic in the global scope,
but the docs suggest that you're supposed to import it anyway.

In NeoVim it's never imported so we were relying on some other plugins
having already imported it.

Fixes #101 