### PR TITLE
Add a --no-ssl flag that switches off certificate verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ README.md.toc.*
 .DS_Store
 *.vimspector.log
 support/test/csharp/*.exe*
+.neomake.log

--- a/install_gadget.py
+++ b/install_gadget.py
@@ -511,7 +511,10 @@ def DownloadFileTo( url, destination, file_name = None, checksum = None, sslchec
   print( "Downloading {} to {}/{}".format( url, destination, file_name ) )
 
   if not sslcheck:
-    kwargs = {"context":  ssl._create_unverified_context()}
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    kwargs = { "context":  context }
   else:
     kwargs = {}
 
@@ -669,10 +672,9 @@ for name, gadget in GADGETS.items():
            '(when supplying --all)'.format( name, lang ) )
 
 parser.add_argument(
-    "--no-ssl",
+    "--no-check-certificate",
     action = "store_true",
-    help = "Switch the gadget download ssl certificate verification"
-    "off (use only in you have a self-signed certificate in your chain)"
+    help = "Do not verify SSL certificates for file downloads."
 )
 
 args = parser.parse_args()
@@ -706,7 +708,7 @@ for name, gadget in GADGETS.items():
       destination = os.path.join( gadget_dir, 'download', name, v[ 'version' ] )
 
       url = string.Template( gadget[ 'download' ][ 'url' ] ).substitute( v )
-      verify_cert_off = getattr(args, "no_ssl")
+      verify_cert_off = args.no_check_certificate
 
       file_path = DownloadFileTo(
         url,

--- a/install_gadget.py
+++ b/install_gadget.py
@@ -35,6 +35,7 @@ import sys
 import json
 import functools
 import time
+import ssl
 
 try:
   from io import BytesIO # for Python 3
@@ -484,7 +485,7 @@ def UrlOpen( *args, **kwargs ):
   return urllib2.urlopen( *args, **kwargs )
 
 
-def DownloadFileTo( url, destination, file_name = None, checksum = None ):
+def DownloadFileTo( url, destination, file_name = None, checksum = None, sslcheck = True):
   if not file_name:
     file_name = url.split( '/' )[ -1 ]
 
@@ -509,7 +510,12 @@ def DownloadFileTo( url, destination, file_name = None, checksum = None ):
 
   print( "Downloading {} to {}/{}".format( url, destination, file_name ) )
 
-  with contextlib.closing( UrlOpen( r ) ) as u:
+  if not sslcheck:
+    kwargs = {"context":  ssl._create_unverified_context()}
+  else:
+    kwargs = {}
+
+  with contextlib.closing( UrlOpen( r, **kwargs ) ) as u:
     with open( file_path, 'wb' ) as f:
       f.write( u.read() )
 
@@ -662,6 +668,13 @@ for name, gadget in GADGETS.items():
     help = "Don't install the {} debug adapter for {} support "
            '(when supplying --all)'.format( name, lang ) )
 
+parser.add_argument(
+    "--no-ssl",
+    action = "store_true",
+    help = "Switch the gadget download ssl certificate verification"
+    "off (use only in you have a self-signed certificate in your chain)"
+)
+
 args = parser.parse_args()
 
 if args.force_all and not args.all:
@@ -693,12 +706,14 @@ for name, gadget in GADGETS.items():
       destination = os.path.join( gadget_dir, 'download', name, v[ 'version' ] )
 
       url = string.Template( gadget[ 'download' ][ 'url' ] ).substitute( v )
+      verify_cert_off = getattr(args, "no_ssl")
 
       file_path = DownloadFileTo(
         url,
         destination,
         file_name = gadget[ 'download' ].get( 'target' ),
-        checksum = v.get( 'checksum' ) )
+        checksum = v.get( 'checksum' ),
+        sslcheck = not verify_cert_off)
       root = os.path.join( destination, 'root' )
       ExtractZipTo( file_path,
                     root,


### PR DESCRIPTION
Hi @puremourning! 

First of all, thank you so much for the plugin! Man, is it awesome! I thing I had never realized how much struggle it had been to use all kinds of different debuggers (we code in like 5 languages simultaneously)!

This pr is a tiny contribution that might help unfortunate people like myself to bypass the insanity of the certificate chanis that our IT had installed, and which neither JVM (fixed that with some sweat and tears) nor python (no luck after a day of bashing my head against the display) can verify.
Basically, it adds a "--no-ssl" flag which switches off the certificate validation. This helps bypass the self-signed certificates in the chains (in any case, we are downloading from MS's git repo).

I will be more than happy if you choose to accept this pr. Thanks in advance,

axrt