### PR TITLE
Improve workflow for launching vimspector from scripts

### DIFF
--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -268,7 +268,6 @@ class DebugSession( object ):
       return fct(self, *args, **kwargs)
     return wrapper
 
-  @IfConnected
   def OnChannelData( self, data ):
     self._connection.OnData( data )
 
@@ -279,7 +278,6 @@ class DebugSession( object ):
       self._outputView.Print( 'server', data )
 
 
-  @IfConnected
   def OnRequestTimeout( self, timer_id ):
     self._connection.OnRequestTimeout( timer_id )
 
@@ -365,20 +363,25 @@ class DebugSession( object ):
   def Pause( self ):
     self._stackTraceView.Pause()
 
+  @IfConnected
   def ExpandVariable( self ):
     self._variablesView.ExpandVariable()
 
+  @IfConnected
   def AddWatch( self, expression ):
     self._variablesView.AddWatch( self._stackTraceView.GetCurrentFrame(),
                                   expression )
 
+  @IfConnected
   def EvaluateConsole( self, expression ):
     self._outputView.Evaluate( self._stackTraceView.GetCurrentFrame(),
                                expression )
 
+  @IfConnected
   def DeleteWatch( self ):
     self._variablesView.DeleteWatch()
 
+  @IfConnected
   def ShowBalloon( self, winnr, expression ):
     """Proxy: ballonexpr -> variables.ShowBallon"""
     frame = self._stackTraceView.GetCurrentFrame()
@@ -397,6 +400,7 @@ class DebugSession( object ):
     # Return variable aware function
     return self._variablesView.ShowBalloon( frame, expression )
 
+  @IfConnected
   def ExpandFrameOrThread( self ):
     self._stackTraceView.ExpandFrameOrThread()
 

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -171,6 +171,12 @@ class DebugSession( object ):
       # working directory.
       'cwd': os.getcwd(),
     }
+
+    # Pretend that vars passed to the launch command were typed in by the user
+    # (they may have been in theory)
+    USER_CHOICES.update( launch_variables )
+    self._variables.update( launch_variables )
+
     self._variables.update(
       utils.ParseVariables( adapter.get( 'variables', {} ),
                             self._variables,
@@ -180,12 +186,6 @@ class DebugSession( object ):
                             self._variables,
                             USER_CHOICES ) )
 
-    # Pretend that vars passed to the launch command were typed in by the user
-    # (they may have been in theory)
-    # TODO: Is it right that we do this _after_ ParseVariables, rather than
-    # before ?
-    USER_CHOICES.update( launch_variables )
-    self._variables.update( launch_variables )
 
     utils.ExpandReferencesInDict( configuration,
                                   self._variables,

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -605,8 +605,10 @@ class DebugSession( object ):
         self._outputView.RunJobWithOutput( 'Remote', cmd )
     else:
       if atttach_config[ 'pidSelect' ] == 'ask':
-        pid = utils.AskForInput( 'Enter PID to attach to: ' )
-        launch_config[ atttach_config[ 'pidProperty' ] ] = pid
+        prop = atttach_config[ 'pidProperty' ]
+        if prop not in launch_config:
+          pid = utils.AskForInput( 'Enter PID to attach to: ' )
+          launch_config[ prop ] = pid
         return
       elif atttach_config[ 'pidSelect' ] == 'none':
         return

--- a/support/test/example/attach.vim
+++ b/support/test/example/attach.vim
@@ -1,0 +1,13 @@
+if argc() < 2
+  echom 'Usage:' v:argv[ 0 ] 'processName binary'
+  cquit!
+endif
+
+setfiletype cpp
+call vimspector#LaunchWithSettings( #{
+      \ configuration: "C++ - Attach Local Process",
+      \ processName: argv( 0 ),
+      \ binary: argv( 1 ),
+      \ } )
+
+1,2argd

--- a/support/test/example/cpp.json
+++ b/support/test/example/cpp.json
@@ -1,0 +1,24 @@
+{
+  "configurations": {
+    "C++ - Attach Local Process": {
+      "adapter": "vscode-cpptools",
+      "variables": {
+        "PID": {
+          "shell": [ "GetPIDForProcess", "${processName}" ]
+        }
+      },
+      "configuration": {
+        "name": "test",
+        "request": "attach",
+        "program": "${binary}",
+        "processId": "${PID}",
+
+        "type": "cppdbg",
+        "stopAtEntry": true,
+        "setupCommands": [
+          { "text": "source ${initFile}", "ignoreFailures": true }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This allows things like PID to connect to to be specified directly in the launch options, e.g. from `LaunchWithSettings` and/or by using a `variables` block and running a `shell` command.

Include an example of how you might make a command line script to launch directly into vimspector with `vim -S script.vim`.

Loosely related to #97 

Fixes some issue with #85 