### PR TITLE
Switch to debugpy rather than vscode-python

### DIFF
--- a/.vintrc.yml
+++ b/.vintrc.yml
@@ -1,0 +1,3 @@
+cmdargs:
+  color: true
+  severity: style_problem

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -38,6 +38,13 @@ def Settings( **kwargs ):
       }
     }
 
+  if kwargs[ 'language' ] == 'python':
+    return {
+      'sys_path': [
+        p.join( PATH_TO_THIS_DIR, 'python3' )
+      ]
+    }
+
   if IgnoreExtraConf:
     raise IgnoreExtraConf()
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,29 @@ For more infomration on the test framework, see
 [this article](https://vimways.org/2019/a-test-to-attest-to/), authored by the
 Vimspector creator.
 
+### Code Style
+
+The code style of the Python code is "YCM" style, because that's how I like it.
+[`flake8`][] is used to check for certain errors and code style.
+
+The code style of the Vimscript is largely the same, and it is linted by
+[`vint`][].
+
+To run them:
+
+* (optional) Create and activate a virtual env:
+  `python3 -m venv venv ; source venv/bin/activate`
+* Install the development dependencies: `pip install -r dev_requirements.txt`
+* Run `flake8`: `flake8 python3/ *.py`
+* Run `vint`: `vint autoload/ plugin/ tests/`
+
+They're also run by CI, so please check for lint failures. The canonical
+definition of the command to run is the command run in CI, i.e. in
+`azure-pipelines.yml`.
+
 # Code of conduct
 
 Please see [code of conduct](CODE_OF_CONDUCT.md).
+
+[vint]: https://github.com/Vimjas/vint
+[flake8]: https://flake8.pycqa.org/en/latest/

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For a tutorial and usage overview, take a look at the
    * [Debug adapter configuration](#debug-adapter-configuration)
       * [C, C  , Rust, etc.](#c-c-rust-etc)
       * [Python](#python)
-         * [Alternative: Use debugpy directly](#alternative-use-debugpy-directly)
+         * [Legacy: vscode-python](#legacy-vscode-python)
       * [TCL](#tcl)
       * [C♯](#c)
       * [Go](#go)
@@ -55,7 +55,7 @@ For a tutorial and usage overview, take a look at the
    * [FAQ](#faq)
    * [License](#license)
 
-<!-- Added by: ben, at: Sat  1 Feb 2020 00:08:19 GMT -->
+<!-- Added by: ben, at: Sat  8 Feb 2020 21:12:02 GMT -->
 
 <!--te-->
 
@@ -188,19 +188,26 @@ There is no workaroud for the lack of balloons; you'll just have to use
 
 ## Language dependencies
 
-The debug adapters themselves have certain runtime dependencies:
+The debug adapters themselves have certain runtime dependencies. They are
+categorised as follows:
 
-| Language         | Status       | Switch                       | Adapter           | Dependencies           |
-|------------------|--------------|------------------------------|-------------------|------------------------|
-| C, C++, etc.     | Supported    | `--all` or ` --enable-c`     | vscode-cpptools   | mono-core              |
-| Python           | Supported    | `--all` or `--enable-python` | vscode-python     | Node 10, Python 2.7 or Python 3 |
-| TCL              | Experimental | `--all` or `--enable-tcl`    | tclpro            | TCL 8.5                |
-| Bourne Shell     | Experimental | `--all` or `--enable-bash`   | vscode-bash-debug | Bash v??               |
-| C# (dotnet core) | Experimental | `--force-enable-csharp`      | netcoredbg        | DotNet core            |
-| C# (mono)        | Experimental | `--force-enable-csharp`      | vscode-mono-debug | Mono                   |
-| Go               | Experimental | `--enable-go`                | vscode-go         | Go, [Delve][]          |
-| Node.js          | Experimental | `--force-enable-node`        | vscode-node-debug2 | 6 < Node < 12, Npm    |
-| Javascript       | Experimental | `--force-enable-chrome`      | debugger-for-chrome | Chrome |
+* `Tested` : Fully supported, Vimspector regression tests cover them
+* `Supported` : Fully supported, frequently used and manually tested
+* `Experimental`: Working, but not frequently used and rarely tested
+* `Legacy`: No longer supported, please migrate your config
+
+| Language         | Status       | Switch                         | Adapter             | Dependencies                    |
+|------------------|--------------|--------------------------------|---------------------|---------------------------------|
+| C, C++, etc.     | Tested       | `--all` or `--enable-c`        | vscode-cpptools     | mono-core                       |
+| Python           | Tested       | `--all` or `--enable-python`   | debugpy             | Python 2.7 or Python 3          |
+| Go               | Tested       | `--enable-go`                  | vscode-go           | Go, [Delve][]                   |
+| TCL              | Supported    | `--all` or `--enable-tcl`      | tclpro              | TCL 8.5                         |
+| Bourne Shell     | Supported    | `--all` or `--enable-bash`     | vscode-bash-debug   | Bash v??                        |
+| Node.js          | Supported    | `--force-enable-node`          | vscode-node-debug2  | 6 < Node < 12, Npm              |
+| Javascript       | Supported    | `--force-enable-chrome`        | debugger-for-chrome | Chrome                          |
+| C# (dotnet core) | Experimental | `--force-enable-csharp`        | netcoredbg          | DotNet core                     |
+| C# (mono)        | Experimental | `--force-enable-csharp`        | vscode-mono-debug   | Mono                            |
+| Python.legacy    | Legacy       | `--force-enable-python.legacy` | vscode-python       | Node 10, Python 2.7 or Python 3 |
 
 For other languages, you'll need some other way to install the gadget.
 
@@ -696,16 +703,43 @@ For `lldb-vscode` replace the name of the adapter with `lldb-vscode`:
 
 ## Python
 
-NOTE: Please see the alternative approach below, as this will become the
-standard approach in future.
+* Python: [debugpy][]
+* Requires `install_gadget.py --enable-python`, this requires a working compiler
+to build a C python extension for performance.
 
-* Python: [vscode-python](https://github.com/Microsoft/vscode-python)
+**Migrating from `vscode-python`**: change `"adapter": "vscode-python"` to
+`"adapter": "debugpy"`.
+
+```json
+{
+  "configurations": {
+    "<name>: Launch": {
+      "adapter": "debugpy",
+      "configuration": {
+        "name": "<name>: Launch",
+        "type": "python",
+        "request": "launch",
+        "cwd": "<working directory>",
+        "python": "/path/to/python/interpreter/to/use",
+        "stopOnEntry": true,
+        "console": "externalTerminal",
+        "debugOptions": [],
+        "program": "<path to main python file>",
+      }
+    }
+    ...
+  }
+}
+```
+
+### Legacy: vscode-python
+
+* No longer installed by default - please pass `--force-enable-python.legacy` if
+  you just want to continue using your working setup.
+* [vscode-python](https://github.com/Microsoft/vscode-python)
 * NOTE: You must be running `node` 10. See [this issue](https://github.com/puremourning/vimspector/issues/105)
 
-I recommend installing `nvm` and then `nvm use 10` prior to starting your Vim
-session.
-
-```
+```json
 {
   "configurations": {
     "<name>: Launch": {
@@ -725,43 +759,6 @@ session.
   }
 }
 ```
-
-### Alternative: Use debugpy directly
-
-If you can't get a node 10 environment set up for whatver reason, then you can
-avoid that issue by using `debugpy` (formerly `ptvsd`) directly.
-
-Here's how:
-
-1. Instal `debugpy`: `pip install debugpy`
-2. Create `/path/to/vimspector/gadgets/<os>/.gadgets.d/debugpy.json`:
-
-```json
-{
-  "adapters": {
-    "debugpy": {
-      "command": [
-        "python",
-        "-m",
-        "debugpy.adapter"
-      ],
-      "name": "debugpy",
-      "configuration": {
-        "python": "python"
-      }
-    }
-  }
-}
-```
-
-Then in theory you should just have to change `"adapter": "vscode-python"` to
-`"adapter": "debugpy"`.
-
-See `support/test/python/simple_python/.vimspector.json` as an example.
-
-NOTE: This will likely become the default in future, and vscode-python will be
-phased out.
-
 
 ## TCL
 
@@ -1039,3 +1036,4 @@ Copyright © 2018 Ben Jackson
 [vimspector-ref]: https://puremourning.github.io/vimspector/configuration.html
 [vimspector-ref-var]: https://puremourning.github.io/vimspector/configuration.html#replacements-and-variables
 [vimspector-ref-exception]: https://puremourning.github.io/vimspector/configuration.html#exception-breakpoints
+[debugpy]: https://github.com/microsoft/debugpy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ stages:
      - bash: pip3 install -r dev_requirements.txt
        displayName: "Install requirements"
 
-     - bash: $HOME/.local/bin/vint autoload/ plugin/
+     - bash: $HOME/.local/bin/vint autoload/ plugin/ tests/
        displayName: "Run vint"
 
   - job: 'linux'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,11 @@ stages:
     steps:
     - bash: |
         brew unlink node@6
-        brew install macvim node@10 tcl-tk llvm
+        brew update
+        for p in macvim node@10 tcl-tk llvm; do
+          brew install $p
+          brew outdated $p || brew install $p
+        done
         brew link --force --overwrite node@10
       displayName: 'Install vim and node'
 
@@ -98,11 +102,13 @@ stages:
       displayName: 'Print vim version information'
 
     - bash: |
+        VERSION=66e8ed9af1812ca0bb6cfcc7023a35742e1bd323
+        BUILD=1092
         set -ex
         mkdir -p lldb-mi
         pushd lldb-mi
-          curl -LO https://github.com/puremourning/lldb-mi/releases/download/1041/lldb-mi-db65c20a3d8e09d9ff2f3748c01cf43ec035a4d8.tar.gz
-          tar zxvf lldb-mi-db65c20a3d8e09d9ff2f3748c01cf43ec035a4d8.tar.gz
+          curl -LO https://github.com/puremourning/lldb-mi/releases/download/${BUILD}/lldb-mi-${VERSION}.tar.gz
+          tar zxvf lldb-mi-${VERSION}.tar.gz
           cp usr/local/bin/lldb-mi /usr/local/bin
         popd
       displayName: 'Install lldb-mi'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ stages:
      - bash: pip3 install -r dev_requirements.txt
        displayName: "Install requirements"
 
-     - bash: $HOME/.local/bin/flake8 python3/
+     - bash: '$HOME/.local/bin/flake8 python3/ *.py'
        displayName: "Run flake8"
 
   - job: 'Vimscript'

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,4 @@
 flake8==3.7.7
 vim-vint==0.3.21
+flake8-comprehensions
+flake8-ycm>= 0.1.0

--- a/install_gadget.py
+++ b/install_gadget.py
@@ -529,7 +529,7 @@ def DownloadFileTo( url,
                     destination,
                     file_name = None,
                     checksum = None,
-                    sslcheck = True):
+                    sslcheck = True ):
   if not file_name:
     file_name = url.split( '/' )[ -1 ]
 
@@ -759,7 +759,7 @@ for name, gadget in GADGETS.items():
         destination,
         file_name = gadget[ 'download' ].get( 'target' ),
         checksum = v.get( 'checksum' ),
-        sslcheck = not verify_cert_off)
+        sslcheck = not verify_cert_off )
       root = os.path.join( destination, 'root' )
       ExtractZipTo( file_path,
                     root,

--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -217,6 +217,11 @@ class ProjectBreakpoints( object ):
       response_received()
 
 
+    # NOTE: Must do this _first_ otherwise we might send requests and get
+    # replies before we finished sending all the requests.
+    if self._exception_breakpoints is None:
+      self._SetUpExceptionBreakpoints( self._configured_breakpoints )
+
 
     # TODO: add the _configured_breakpoints to line_breakpoints
     # TODO: the line numbers might have changed since pressing the F9 key!
@@ -271,9 +276,6 @@ class ProjectBreakpoints( object ):
         },
         failure_handler = lambda *_: response_received()
       )
-
-    if self._exception_breakpoints is None:
-      self._SetUpExceptionBreakpoints( self._configured_breakpoints )
 
     if self._exception_breakpoints:
       awaiting = awaiting + 1

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -112,7 +112,7 @@ class DebugSession( object ):
     else:
       configuration_name = utils.SelectFromList(
         'Which launch configuration?',
-        sorted( list( configurations.keys() ) ) )
+        sorted( configurations.keys() ) )
 
     if not configuration_name or configuration_name not in configurations:
       return
@@ -259,13 +259,13 @@ class DebugSession( object ):
   def IfConnected( fct ):
     """Decorator, call fct if self._connected else echo warning"""
     @functools.wraps( fct )
-    def wrapper(self, *args, **kwargs):
+    def wrapper( self, *args, **kwargs ):
       if not self._connection:
         utils.UserMessage(
           'Vimspector not connected, start a debug session first',
           persist=True, error=True )
         return
-      return fct(self, *args, **kwargs)
+      return fct( self, *args, **kwargs )
     return wrapper
 
   def OnChannelData( self, data ):

--- a/python3/vimspector/output.py
+++ b/python3/vimspector/output.py
@@ -210,4 +210,4 @@ class OutputView( object ):
                    '*' if tab_buffer.flag else '' ) )
 
   def GetCategories( self ):
-    return [ category for category in self._buffers.keys() ]
+    return list( self._buffers.keys() )

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -232,7 +232,7 @@ def Escape( msg ):
   return msg.replace( "'", "''" )
 
 
-def UserMessage( msg, persist=False, error=False):
+def UserMessage( msg, persist=False, error=False ):
   if persist:
     _logger.warning( 'User Msg: ' + msg )
   else:
@@ -242,11 +242,11 @@ def UserMessage( msg, persist=False, error=False):
   vim.command( 'redraw' )
   try:
     if error:
-      vim.command("echohl WarningMsg")
+      vim.command( "echohl WarningMsg" )
     for line in msg.split( '\n' ):
       vim.command( "{0} '{1}'".format( cmd, Escape( line ) ) )
   finally:
-    vim.command('echohl None') if error else None
+    vim.command( 'echohl None' ) if error else None
   vim.command( 'redraw' )
 
 
@@ -324,7 +324,7 @@ def SetBufferContents( buf, lines, modified=False ):
     if not isinstance( lines, list ):
       lines = lines.splitlines()
 
-    buf[:] = lines
+    buf[ : ] = lines
   finally:
     buf.options[ 'modified' ] = modified
 
@@ -347,7 +347,7 @@ def ExpandReferencesInObject( obj, mapping, user_choices ):
   return obj
 
 
-def ExpandReferencesInString( orig_s, mapping, user_choices):
+def ExpandReferencesInString( orig_s, mapping, user_choices ):
   s = os.path.expanduser( orig_s )
   s = os.path.expandvars( s )
 

--- a/support/test/python/simple_python/.vimspector.json
+++ b/support/test/python/simple_python/.vimspector.json
@@ -1,19 +1,6 @@
 {
-  "adapters": {
-    "debugpy": {
-      "command": [
-        "python",
-        "-m",
-        "debugpy.adapter"
-      ],
-      "name": "debugpy",
-      "configuration": {
-        "python": "python"
-      }
-    }
-  },
   "configurations": {
-    "run": {
+    "run legacy vscode-python": {
       "adapter": "vscode-python",
       "configuration": {
         "request": "launch",
@@ -45,14 +32,14 @@
         }
       }
     },
-    "run - debugpy": {
+    "run": {
       "adapter": "debugpy",
       "configuration": {
         "request": "launch",
         "type": "python",
         "cwd": "${workspaceRoot}",
         "program": "${file}",
-        "stopOnEntry": true,
+        "stopOnEntry": false,
         "console": "integratedTerminal"
       },
       "breakpoints": {

--- a/tests/breakpoints.test.vim
+++ b/tests/breakpoints.test.vim
@@ -275,7 +275,7 @@ function! Test_Insert_Code_Above_Breakpoint()
 
   " CHeck that we break at the right point
   call setpos( '.', [ 0, 1, 1 ] )
-  call vimspector#LaunchWithSettings( { "configuration": "run" } )
+  call vimspector#LaunchWithSettings( { 'configuration': 'run' } )
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 26, 1 )
   call vimspector#Reset()
   call vimspector#test#setup#WaitForReset()

--- a/tests/language_python.test.vim
+++ b/tests/language_python.test.vim
@@ -28,7 +28,7 @@ function! Test_Python_Simple()
   call setpos( '.', [ 0, 1, 1 ] )
 
   " Here we go. Start Debugging
-  call vimspector#LaunchWithSettings( { "configuration": "run" } )
+  call vimspector#LaunchWithSettings( { 'configuration': 'run' } )
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 6, 1 )
 
   " Step

--- a/tests/lib/plugin/screendump.vim
+++ b/tests/lib/plugin/screendump.vim
@@ -28,7 +28,7 @@ endif
 func RunVimInTerminal(arguments, options)
   " If Vim doesn't exit a swap file remains, causing other tests to fail.
   " Remove it here.
-  call delete(".swp")
+  call delete('.swp')
 
   if exists('$COLORFGBG')
     " Clear $COLORFGBG to avoid 'background' being set to "dark", which will
@@ -61,7 +61,7 @@ func RunVimInTerminal(arguments, options)
 	\ 'term_rows': rows,
 	\ 'term_cols': cols,
 	\ })
-  if &termwinsize == ''
+  if &termwinsize ==# ''
     " in the GUI we may end up with a different size, try to set it.
     if term_getsize(buf) != [rows, cols]
       call term_setsize(buf, rows, cols)
@@ -80,7 +80,7 @@ func RunVimInTerminal(arguments, options)
     call WaitFor({-> len(term_getline(buf, rows)) >= cols - 1 || len(term_getline(buf, rows - statusoff)) >= cols - 1})
   catch /timed out after/
     let lines = map(range(1, rows), {key, val -> term_getline(buf, val)})
-    call assert_report('RunVimInTerminal() failed, screen contents: ' . join(lines, "<NL>"))
+    call assert_report('RunVimInTerminal() failed, screen contents: ' . join(lines, '<NL>'))
   endtry
 
   return buf
@@ -88,7 +88,7 @@ endfunc
 
 " Stop a Vim running in terminal buffer "buf".
 func StopVimInTerminal(buf)
-  call assert_equal("running", term_getstatus(a:buf))
+  call assert_equal('running', term_getstatus(a:buf))
 
   " CTRL-O : works both in Normal mode and Insert mode to start a command line.
   " In Command-line it's inserted, the CTRL-U removes it again.

--- a/tests/lib/plugin/shared.vim
+++ b/tests/lib/plugin/shared.vim
@@ -37,8 +37,8 @@ endfunc
 func RunCommand(cmd)
   let job = 0
   if has('job')
-    let job = job_start(a:cmd, {"stoponexit": "hup"})
-    call job_setoptions(job, {"stoponexit": "kill"})
+    let job = job_start(a:cmd, {'stoponexit': 'hup'})
+    call job_setoptions(job, {'stoponexit': 'kill'})
   elseif has('win32')
     exe 'silent !start cmd /c start "test_channel" ' . a:cmd
   else
@@ -53,7 +53,7 @@ func GetPort()
   " with 200 it sometimes failed
   for i in range(400)
     try
-      let l = readfile("Xportnr")
+      let l = readfile('Xportnr')
     catch
     endtry
     if len(l) >= 1
@@ -61,7 +61,7 @@ func GetPort()
     endif
     sleep 10m
   endfor
-  call delete("Xportnr")
+  call delete('Xportnr')
 
   if len(l) == 0
     " Can't make the connection, give up.
@@ -74,14 +74,14 @@ endfunc
 " Always kills the server before returning.
 func RunServer(cmd, testfunc, args)
   " The Python program writes the port number in Xportnr.
-  call delete("Xportnr")
+  call delete('Xportnr')
 
   if len(a:args) == 1
     let arg = ' ' . a:args[0]
   else
     let arg = ''
   endif
-  let pycmd = s:python . " " . a:cmd . arg
+  let pycmd = s:python . ' ' . a:cmd . arg
 
   try
     let g:currentJob = RunCommand(pycmd)
@@ -108,10 +108,10 @@ func s:kill_server(cmd)
       unlet g:currentJob
     endif
   elseif has('win32')
-    let cmd = substitute(a:cmd, ".py", '', '')
+    let cmd = substitute(a:cmd, '.py', '', '')
     call system('taskkill /IM ' . s:python . ' /T /F /FI "WINDOWTITLE eq ' . cmd . '"')
   else
-    call system("pkill -f " . a:cmd)
+    call system('pkill -f ' . a:cmd)
   endif
 endfunc
 
@@ -253,7 +253,7 @@ func GetVimCommand(...)
   " "vimcmd" file, including environment options.
   " Other Makefiles just write the executable in the first line, so fall back
   " to that if there is no second line or it is empty.
-  if len(lines) > 1 && lines[1] != ''
+  if len(lines) > 1 && lines[1] !=# ''
     let cmd = lines[1]
   else
     let cmd = lines[0]
@@ -267,7 +267,7 @@ func GetVimCommand(...)
   let cmd = substitute(cmd, 'VIMRUNTIME=.*VIMRUNTIME;', '', '')
 
   " If using valgrind, make sure every run uses a different log file.
-  if cmd =~ 'valgrind.*--log-file='
+  if cmd =~# 'valgrind.*--log-file='
     let cmd = substitute(cmd, '--log-file=\(^\s*\)', '--log-file=\1.' . g:valgrind_cnt, '')
     let g:valgrind_cnt += 1
   endif
@@ -308,7 +308,7 @@ func RunVimPiped(before, after, arguments, pipecmd)
     let args .= ' -S Xafter.vim'
   endif
 
-  exe "silent !" . a:pipecmd . cmd . args . ' ' . a:arguments
+  exe 'silent !' . a:pipecmd . cmd . args . ' ' . a:arguments
 
   if len(a:before) > 0
     call delete('Xbefore.vim')
@@ -320,7 +320,7 @@ func RunVimPiped(before, after, arguments, pipecmd)
 endfunc
 
 func CanRunGui()
-  return has('gui') && ($DISPLAY != "" || has('gui_running'))
+  return has('gui') && ($DISPLAY !=# '' || has('gui_running'))
 endfunc
 
 func WorkingClipboard()
@@ -328,7 +328,7 @@ func WorkingClipboard()
     return 0
   endif
   if has('x11')
-    return $DISPLAY != ""
+    return $DISPLAY !=# ''
   endif
   return 1
 endfunc

--- a/tests/tabpage.test.vim
+++ b/tests/tabpage.test.vim
@@ -28,7 +28,7 @@ function! Test_Step_With_Different_Tabpage()
   call assert_equal( 1, col( '.' ), 'Current column' )
 
   " Switch to the other tab
-  normal gt
+  normal! gt
 
   call assert_notequal( vimspector_tabnr, tabpagenr() )
 


### PR DESCRIPTION
Thanks to @int19h for all the help, we're now forcing migration to `debugpy`; the old adapter is still there (for now) but requires specifying `--force-enable-python.legacy` to `install.py`. Now `--enable-python` will locally build `debugpy` in the gadget directory (rather than relying on pip or any of that nonesense). 

Fixes #109 