### PR TITLE
Support for scala

### DIFF
--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -30,6 +30,10 @@ function! vimspector#LaunchWithSettings( settings ) abort
   py3 _vimspector_session.Start( launch_variables = vim.eval( 'a:settings' ) )
 endfunction
 
+function! vimspector#Connect( port, configuration ) abort
+  py3 _vimspector_session.Connect ( port = vim.eval( 'a:port' ), configuration = vim.eval( 'a:configuration' ) )
+endfunction
+
 function! vimspector#Reset() abort
   py3 _vimspector_session.Reset()
 endfunction

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -77,6 +77,7 @@ class DebugSession( object ):
                        launch_variables )
     self._configuration = None
     self._adapter = None
+    self._supportReconnect = True
 
     current_file = utils.GetBufferFilepath( vim.current.buffer )
 
@@ -246,12 +247,24 @@ class DebugSession( object ):
 
     start()
 
+  def Connect( self, port, configuration ):
+    self._logger.info( 'Connecting to %s using %s', port,
+                       json.dumps( configuration ) )
+    self._supportReconnect = False
+    self._StartWithConfiguration(
+      configuration,
+      { 'port': int( port ) }
+    )
+
   def Restart( self ):
     # TODO: There is a restart message but isn't always supported.
     # FIXME: For some reason this doesn't work when run from the WinBar. It just
     # beeps and doesn't display the config selector. One option is to just not
     # display the selector and restart with the same opitons.
-    if not self._configuration or not self._adapter:
+    if not self._supportReconnect:
+      utils.UserMessage( 'Restart is not supported in current mode.' )
+      return
+    elif not self._configuration or not self._adapter:
       return self.Start()
 
     self._StartWithConfiguration( self._configuration, self._adapter )


### PR DESCRIPTION
I would like to add couple functions to support debugging of scala applications. It will work a bit different than current workflow.

[Metals](https://scalameta.org/metals/) is language server for scala. But besides usual possibilities of language server, Metals can start Debug Adapter for any runnable application or test from project. So using CodeLens from Language Server Protocol, the user can launch application (or test) and start Debug Adapter. It means that gadgets and file `.vimspector.json` are not needed for scala developers. Metals can start Debug Adapter for free. Once debug server is launched Metals returns port where server is running. So vimspector just needs to connect to this port.

In my pull request I add new function `Connect` which will be called from [coc-metals](https://github.com/scalameta/coc-metals) extension. So user will be able to debug application using CodeLens from Language Server Protocol without gadget or file `.vimspector.json`. I already [talked](https://github.com/scalameta/coc-metals/issues/80) with author of coc-metals and he agreed to add this integration in coc-metals.