### PR TITLE
Don't create a new buffer when opening the vimspector tab

### DIFF
--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -22,7 +22,7 @@ from vimspector import utils
 
 
 class CodeView( object ):
-  def __init__( self, window, original_window, api_prefix ):
+  def __init__( self, window, api_prefix ):
     self._window = window
     self._api_prefix = api_prefix
 
@@ -42,7 +42,6 @@ class CodeView( object ):
 
 
     with utils.LetCurrentWindow( self._window ):
-      vim.current.buffer = original_window.buffer
       vim.command( 'nnoremenu WinBar.Continue :call vimspector#Continue()<CR>' )
       vim.command( 'nnoremenu WinBar.Next :call vimspector#StepOver()<CR>' )
       vim.command( 'nnoremenu WinBar.Step :call vimspector#StepInto()<CR>' )

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -150,10 +150,6 @@ class DebugSession( object ):
 
       adapter = adapter_dict
 
-    # TODO: Do we want some form of persistence ? e.g. self._staticVariables,
-    # set from an api call like SetLaunchParam( 'var', 'value' ), perhaps also a
-    # way to load .vimspector.local.json which just sets variables
-    #
     # Additional vars as defined by VSCode:
     #
     # ${workspaceFolder} - the path of the folder opened in VS Code
@@ -457,14 +453,11 @@ class DebugSession( object ):
 
 
   def _SetUpUI( self ):
-    original_window = vim.current.window
-
-    vim.command( 'tabnew' )
+    vim.command( 'tabedit %' )
     self._uiTab = vim.current.tabpage
 
     # Code window
     self._codeView = code.CodeView( vim.current.window,
-                                    original_window,
                                     self._api_prefix )
 
     # Call stack


### PR DESCRIPTION
`:tabnew` creates a new buffer. Use `tabedit %`

Fixes #138 

@ckipp01 can you try it ?