### PR TITLE
Tweaks

### DIFF
--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -591,7 +591,8 @@ class DebugSession( object ):
 
     arguments = {}
     if self._server_capabilities.get( 'supportTerminateDebuggee' ):
-      arguments[ 'terminateDebugee' ] = True
+      # If we attached, we should _not_ terminate the debuggee
+      arguments[ 'terminateDebuggee' ] = False
 
     self._connection.DoRequest( handler, {
       'command': 'disconnect',

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -120,7 +120,8 @@ class DebugSession( object ):
 
     if 'configuration' in launch_variables:
       configuration_name = launch_variables.pop( 'configuration' )
-    elif len( configurations ) == 1:
+    elif ( len( configurations ) == 1 and
+           next( iter( configurations.values() ) ).get( "autoselect", True ) ):
       configuration_name = next( iter( configurations.keys() ) )
     else:
       configuration_name = utils.SelectFromList(

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -844,6 +844,10 @@ class DebugSession( object ):
       self._stackTraceView.LoadThreads( True )
 
 
+  def OnEvent_loadedSource( self, msg ):
+    pass
+
+
   def OnEvent_capabilities( self, msg ):
     self._server_capabilities.update(
       ( msg.get( 'body' ) or {} ).get( 'capabilities' ) or {} )


### PR DESCRIPTION
* Add `autoselect` option to debug configs. Setting it to `false` means that this option won't be automatically picked when hitting `<F5>`. Useful for configs in the shared `configurations` directory.
* Ignore the `loadedSource` event. it's not clear what it's for, but some adapters spam it out and it's noisy to see the errors
* Don't terminate the deubgee when detaching. vscode-cpptools does this irrespective and it's really annoying.  