### PR TITLE
Bump version of vscode-cpptools from 0.26.3 to 0.27.0

### DIFF
--- a/install_gadget.py
+++ b/install_gadget.py
@@ -47,17 +47,17 @@ GADGETS = {
     },
     'do': lambda name, root, gadget: InstallCppTools( name, root, gadget ),
     'all': {
-      'version': '0.26.3',
+      'version': '0.27.0',
     },
     'linux': {
       'file_name': 'cpptools-linux.vsix',
       'checksum':
-        'd660367fbedd6acaffcc233c1d41ef280ff79aeba81846b86bf9bd97b4887379'
+        '3695202e1e75a03de18049323b66d868165123f26151f8c974a480eaf0205435'
     },
     'macos': {
       'file_name': 'cpptools-osx.vsix',
       'checksum':
-        'ca0793dd1dfd70757491da80cf04b2b15631048b572de2ebe3864f9eed96dff9',
+        'cb061e3acd7559a539e5586f8d3f535101c4ec4e8a48195856d1d39380b5cf3c',
     },
     'windows': {
       'file_name': 'cpptools-win32.vsix',


### PR DESCRIPTION
vscode-cpptools upstream recently had a fix which makes the workarounds described in the README unnecessary (debugging now works again in Catalina without the need for CodeLLDB).

This pull request changes `install_gadget.py` to have it fetch the newest version `0.27.0` to bring these changes into the debug adapter vimspector uses.

The checksums were generated by downloading the latest version and running `shasum -a 256 <filename`. I can confirm that this works on macOS Catalina 10.15.3, and resolves #146.