### PR TITLE
Add basic support for conditional breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ features to set your own mappings. To that end, Vimspector defines the following
 * `<Plug>VimspectorRestart`
 * `<Plug>VimspectorPause`
 * `<Plug>VimspectorToggleBreakpoint`
+* `<Plug>VimspectorToggleConditionalBreakpoint`
 * `<Plug>VimspectorAddFunctionBreakpoint`
 * `<Plug>VimspectorStepOver`
 * `<Plug>VimspectorStepInto`
@@ -513,17 +514,18 @@ loading vimspector**:
 let g:vimspector_enable_mappings = 'HUMAN'
 ```
 
-| Key   | Function                                                  | API |
-| ---   | ---                                                       | --- |
-| `F5`  | When debugging, continue. Otherwise start debugging.      | `vimspector#Continue()` |
-| `F3`  | Stop debugging.                                           | `vimspector#Stop()` |
-| `F4`  | Restart debugging with the same configuration.            | `vimspector#Restart()` |
-| `F6`  | Pause debugee.                                            | `vimspector#Pause()` |
-| `F9`  | Toggle line breakpoint on the current line.               | `vimspector#ToggleBreakpoint()` |
-| `F8`  | Add a function breakpoint for the expression under cursor | `vimspector#AddFunctionBreakpoint( '<cexpr>' )` |
-| `F10` | Step Over                                                 | `vimspector#StepOver()` |
-| `F11` | Step Into                                                 | `vimspector#StepInto()` |
-| `F12` | Step out of current function scope                        | `vimspector#StepOut()` |
+| Key          | Function                                                  | API                                                          |
+| ---          | ---                                                       | ---                                                          |
+| `F5`         | When debugging, continue. Otherwise start debugging.      | `vimspector#Continue()`                                      |
+| `F3`         | Stop debugging.                                           | `vimspector#Stop()`                                          |
+| `F4`         | Restart debugging with the same configuration.            | `vimspector#Restart()`                                       |
+| `F6`         | Pause debugee.                                            | `vimspector#Pause()`                                         |
+| `F9`         | Toggle line breakpoint on the current line.               | `vimspector#ToggleBreakpoint()`                              |
+| `<leader>F9` | Toggle conditional line breakpoint on the current line.   | `vimspector#ToggleBreakpoint( {condition, hit condition } )` |
+| `F8`         | Add a function breakpoint for the expression under cursor | `vimspector#AddFunctionBreakpoint( '<cexpr>' )`              |
+| `F10`        | Step Over                                                 | `vimspector#StepOver()`                                      |
+| `F11`        | Step Into                                                 | `vimspector#StepInto()`                                      |
+| `F12`        | Step out of current function scope                        | `vimspector#StepOut()`                                       |
 
 # Usage
 
@@ -564,9 +566,10 @@ debugger](#java---partially-supported)
 
 ## Breakpoints
 
-* Use `vimspector#ToggleBreakpoint()` to set/disable/delete a line breakpoint.
-* Use `vimspector#AddFunctionBreakpoint( '<name>' )` to add a function
-breakpoint.
+* Use `vimspector#ToggleBreakpoint([ { 'condition': '<condition>' } ])`
+  to set/disable/delete a line breakpoint, with optional condition.
+* Use `vimspector#AddFunctionBreakpoint( '<name>' [, { 'condition': '<condition>' } ] )`
+  to add a function breakpoint with optional condition.
 
 ## Stepping
 

--- a/README.md
+++ b/README.md
@@ -74,17 +74,20 @@ But for now, here's a (rather old) screenshot of Vimsepctor debugging Vim:
 
 ## Supported debugging features
 
+- flexible configuration syntax that can be checked in to source control
 - breakpoints (function, line and exception breakpoints)
+- conditional breakpoints (function, line)
 - step in/out/over/up, stop, restart
 - launch and attach
 - remote launch, remote attach
 - locals and globals display
 - watch expressions
-- call stack and navigation
+- call stack display and navigation
 - variable value display hover
 - interactive debug console
 - launch debugee within Vim's embedded terminal
 - logging/stdout display
+- simple stable API for custom tooling (e.g. integrate with language server)
 
 ## Supported languages:
 
@@ -427,14 +430,6 @@ than welcome.
 
 The backlog can be [viewed on Trello](https://trello.com/b/yvAKK0rD/vimspector).
 
-In order to use it you have to currently:
-
-- Write a mostly undocumented configuration file that contains essentially
-  undocumented parameters.
-- Accept that it isn't complete yet
-- Work around some frustrating bugs in Vim
-- Ignore probably many bugs in vimspector!
-
 ### Experimental
 
 The plugin is currently _experimental_. That means that any part of it
@@ -443,8 +438,9 @@ can (and probably will) change, including things like:
 - breaking changes to the configuration
 - keys, layout, functionatlity of the UI
 
-If a large number of people start using it then I will do my best to
-minimise this, or at least announce on Gitter.
+However, I commit to only doing this in the most extreme cases and to annouce
+such changes on Gitter well in advance. There's nothing more annoying than stuff
+just breaking on you. I get that.
 
 # Mappings
 
@@ -464,7 +460,7 @@ features to set your own mappings. To that end, Vimspector defines the following
 * `<Plug>VimspectorStepInto`
 * `<Plug>VimspectorStepOut`
 
-These map 1-1 with the API functions below.
+These map roughly 1-1 with the API functions below.
 
 For example, if you want `<F5>` to start/continue debugging, add this to some
 appropriate place, such as your `vimrc` (hint: run `:e $MYVIMRC`).

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -42,12 +42,13 @@ function! vimspector#ClearBreakpoints() abort
   py3 _vimspector_session.ClearBreakpoints()
 endfunction
 
-function! vimspector#ToggleBreakpoint() abort
-  py3 _vimspector_session.ToggleBreakpoint()
+function! vimspector#ToggleBreakpoint( options = {} ) abort
+  py3 _vimspector_session.ToggleBreakpoint( vim.eval( 'a:options' ) )
 endfunction
 
-function! vimspector#AddFunctionBreakpoint( function ) abort
-  py3 _vimspector_session.AddFunctionBreakpoint( vim.eval( 'a:function' ) )
+function! vimspector#AddFunctionBreakpoint( function, options = {} ) abort
+  py3 _vimspector_session.AddFunctionBreakpoint( vim.eval( 'a:function' ),
+                                               \ vim.eval( 'a:options' ) )
 endfunction
 
 function! vimspector#StepOver() abort

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -42,13 +42,23 @@ function! vimspector#ClearBreakpoints() abort
   py3 _vimspector_session.ClearBreakpoints()
 endfunction
 
-function! vimspector#ToggleBreakpoint( options = {} ) abort
-  py3 _vimspector_session.ToggleBreakpoint( vim.eval( 'a:options' ) )
+function! vimspector#ToggleBreakpoint( ... ) abort
+  if a:0 == 0
+    let options = {}
+  else
+    let options = a:1
+  endif
+  py3 _vimspector_session.ToggleBreakpoint( vim.eval( 'options' ) )
 endfunction
 
-function! vimspector#AddFunctionBreakpoint( function, options = {} ) abort
+function! vimspector#AddFunctionBreakpoint( function, ... ) abort
+  if a:0 == 0
+    let options = {}
+  else
+    let options = a:1
+  endif
   py3 _vimspector_session.AddFunctionBreakpoint( vim.eval( 'a:function' ),
-                                               \ vim.eval( 'a:options' ) )
+                                               \ vim.eval( 'options' ) )
 endfunction
 
 function! vimspector#StepOver() abort

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -43,6 +43,11 @@ nnoremap <Plug>VimspectorRestart        :<c-u>call vimspector#Restart()<CR>
 nnoremap <Plug>VimspectorPause          :<c-u>call vimspector#Pause()<CR>
 nnoremap <Plug>VimspectorToggleBreakpoint
       \ :<c-u>call vimspector#ToggleBreakpoint()<CR>
+nnoremap <Plug>VimspectorToggleConditionalBreakpoint
+      \ :<c-u>call vimspector#ToggleBreakpoint(
+                    \ { 'condition': input( 'Enter condition: ' ),
+                    \   'hitCondition': input( 'Enter hit condition: ' ) }
+                    \ )<CR>
 nnoremap <Plug>VimspectorAddFunctionBreakpoint
       \ :<c-u>call vimspector#AddFunctionBreakpoint( expand( '<cexpr>' ) )<CR>
 nnoremap <Plug>VimspectorStepOver       :<c-u>call vimspector#StepOver()<CR>
@@ -65,6 +70,7 @@ elseif s:mappings ==# 'HUMAN'
   nmap <F4>         <Plug>VimspectorRestart
   nmap <F6>         <Plug>VimspectorPause
   nmap <F9>         <Plug>VimspectorToggleBreakpoint
+  nmap <leader><F9> <Plug>VimspectorToggleConditionalBreakpoint
   nmap <F8>         <Plug>VimspectorAddFunctionBreakpoint
   nmap <F10>        <Plug>VimspectorStepOver
   nmap <F11>        <Plug>VimspectorStepInto

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -982,8 +982,8 @@ class DebugSession( object ):
   def ListBreakpoints( self ):
     return self._breakpoints.ListBreakpoints()
 
-  def ToggleBreakpoint( self ):
-    return self._breakpoints.ToggleBreakpoint()
+  def ToggleBreakpoint( self, options ):
+    return self._breakpoints.ToggleBreakpoint( options )
 
   def ClearBreakpoints( self ):
     if self._connection:
@@ -991,8 +991,8 @@ class DebugSession( object ):
 
     return self._breakpoints.ClearBreakpoints()
 
-  def AddFunctionBreakpoint( self, function ):
-    return self._breakpoints.AddFunctionBreakpoint( function )
+  def AddFunctionBreakpoint( self, function, options ):
+    return self._breakpoints.AddFunctionBreakpoint( function, options )
 
 
 def PathsToAllGadgetConfigs( vimspector_base, current_file ):


### PR DESCRIPTION
This is the minimal required for a user to use conditional breakpoint -
we add an options dict to each breakpoint (line and function) and allow
the condition to be supplied. We add a plug mapping and a default
shortcut (<leader><F9>) to add one where we ask the user to enter the
condition and hit expression. This isn't great but it works.

We don't check the capabilities, so they would just be ignored if used
on a server that doesn't support them. We also ask for a hit expression
which most users won't understand so this isn't ideal either.

No tests, and no documentation yet.

Added a new sign type too, so you can see where a breakpoint is conditional.

I actually use this:

```
" vimspector
let g:vimspector_enable_mappings = 'HUMAN'

sign define vimspectorBP text=🔴         texthl=Normal
sign define vimspectorBPCond text=⭕     texthl=Normal
sign define vimspectorBPDisabled text=🔵 texthl=Normal
sign define vimspectorPC text=🔶         texthl=Normal
```

Fixes #152 