### PR TITLE
Allow moving the gadget/configuration dirs to arbitrary location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,12 @@ There are 2 ways:
    follow the instructions for running tets directly.
 1. Directly: Run `./install_gadget.py --all` and then `./run_tests`. Note that
    this depends on your runtime environment and might not match CI. I recommend
-   running the tests in the docker container.
+   running the tests in the docker container. If you have your own custom
+   gadgets and/or custom configurations (in `vimspector/configurations` and/or
+   `vimspector/gadget`, then consider using `./run_tests --install --basedir
+   /tmp/vimspector_test` (then delete `/tmp/vimspector_test`). This will install
+   the gadgets to that dir and use it for the gadget dir/config dir so that your
+   custom configuration won't interfere with the tess.
 
 When tests fail, they dump a load of logs to a directory for each failed tests.
 Usually the most useful output is `messages`, which tells you what actually

--- a/install_gadget.py
+++ b/install_gadget.py
@@ -530,12 +530,10 @@ def InstallGagdet( name, gadget, failed, all_adapters ):
     print( "FAILED installing {}: {}".format( name, e ) )
 
 
-vimspector_base = os.path.dirname( __file__ )
-OS = install.GetOS()
-gadget_dir = install.GetGadgetDir( vimspector_base, OS )
+# ------------------------------------------------------------------------------
+# Entry point
+# ------------------------------------------------------------------------------
 
-print( 'OS = ' + OS )
-print( 'gadget_dir = ' + gadget_dir )
 
 parser = argparse.ArgumentParser(
   formatter_class = argparse.RawDescriptionHelpFormatter,
@@ -565,6 +563,14 @@ parser.add_argument( '--all',
 parser.add_argument( '--force-all',
                      action = 'store_true',
                      help = 'Enable all unsupported completers' )
+
+parser.add_argument( '--basedir',
+                     action = 'store',
+                     help = 'Advanced option. '
+                            'Base directory under which to keep gadgets, '
+                            'configurations, etc.. Default: vimspector '
+                            'installation dir. Useful for developers or '
+                            'multi-user installations' )
 
 parser.add_argument( '--no-gadget-config',
                      action = 'store_true',
@@ -623,6 +629,18 @@ args = parser.parse_args()
 
 installer.AbortIfSUperUser( args.sudo )
 
+vimspector_base = os.path.dirname( __file__ )
+if args.basedir:
+  vimspector_base = os.path.abspath( args.basedir )
+
+install.MakeInstallDirs( vimspector_base )
+
+OS = install.GetOS()
+gadget_dir = install.GetGadgetDir( vimspector_base, OS )
+
+print( 'OS = ' + OS )
+print( 'gadget_dir = ' + gadget_dir )
+
 if args.force_all and not args.all:
   args.all = True
 
@@ -675,3 +693,9 @@ else:
 if failed:
   raise RuntimeError( 'Failed to install gadgets: {}'.format(
     ','.join( failed ) ) )
+
+if args.basedir:
+  print( "" )
+  print( "***NOTE***: You set --basedir to " + args.basedir +
+         ". Therefore you _must_ ensure this is in your vimrc:\n"
+         "let g:vimspector_base_dir='" + vimspector_base + "'" )

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -32,9 +32,8 @@ from vimspector import ( breakpoints,
                          variables )
 from vimspector.vendor.json_minify import minify
 
-VIMSPECTOR_HOME = os.path.abspath( os.path.join( os.path.dirname( __file__ ),
-                                                 '..',
-                                                 '..' ) )
+# We cache this once, and don't allow it to change (FIXME?)
+VIMSPECTOR_HOME = utils.GetVimspectorBase()
 
 # cache of what the user entered for any option we ask them
 USER_CHOICES = {}
@@ -1007,7 +1006,7 @@ def PathsToAllGadgetConfigs( vimspector_base, current_file ):
 
 
 def PathsToAllConfigFiles( vimspector_base, current_file, filetypes ):
-  for ft in filetypes:
+  for ft in filetypes + [ '_all' ]:
     for p in sorted( glob.glob(
       os.path.join( install.GetConfigDirForFiletype( vimspector_base, ft ),
                     '*.json' ) ) ):

--- a/python3/vimspector/install.py
+++ b/python3/vimspector/install.py
@@ -26,6 +26,18 @@ def GetOS():
     return 'linux'
 
 
+def mkdirs( p ):
+  try:
+    os.makedirs( p )
+  except FileExistsError:
+    pass
+
+
+def MakeInstallDirs( vimspector_base ):
+  mkdirs( GetGadgetConfigDir( vimspector_base ) )
+  mkdirs( GetConfigDirForFiletype( vimspector_base, '_all' ) )
+
+
 def GetGadgetDir( vimspector_base, OS ):
   return os.path.join( os.path.abspath( vimspector_base ), 'gadgets', OS )
 

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -563,3 +563,12 @@ def HideSplash( api_prefix, splash ):
     Call( f'vimspector#internal#{api_prefix}popup#HideSplash', splash )
 
   return None
+
+
+def GetVimspectorBase():
+  try:
+    return vim.vars[ 'vimspector_base_dir' ].decode( 'utf-8' )
+  except KeyError:
+    return os.path.abspath( os.path.join( os.path.dirname( __file__ ),
+                                          '..',
+                                          '..' ) )

--- a/run_tests
+++ b/run_tests
@@ -1,16 +1,54 @@
 #!/usr/bin/env bash
 
 if [ "$1" == "--help" ]; then
-  echo "$(basename $0) <optional list of tests in form file:func>"
+  echo "$(basename $0) [--basedir <basedir>] [--install] <optional list of tests in form file:func>"
+  echo ""
+  echo " --basedir <basedir> path to runtime directory like the optino to install_gadget.py"
+  echo " --install           run install_gadget.py, useful with --basedir"
   echo "e.g.: "
   echo " - run all tests: $0"
   echo " - run specific tests script: $0 signature_help.test.vim"
   echo " - run specific tests fun: $0 signature_help.test.vim:Test_signatures_TopLine\(\)"
+  echo " - run all tests in a clean env: $0 --basedir \$(mktemp -d) --install"
   exit 0
 fi
 
-RUN_VIM="vim --clean --not-a-term"
+
+BASEDIR=$(dirname $0)
+INSTALL=0
+RUN_VIM="vim -N --clean --not-a-term"
 RUN_TEST="${RUN_VIM} -S lib/run_test.vim"
+BASEDIR_CMD='py3 pass'
+
+while [ -n "$1" ]; do
+  case "$1" in
+    "--basedir")
+      BASEDIR=$2
+      if [[ ! $BASEDIR = /* ]]; then
+        # Relative
+        BASEDIR=$(pwd)/${BASEDIR}
+      fi
+      BASEDIR_CMD="let g:vimspector_base_dir='${BASEDIR}'"
+      shift
+      shift
+      ;;
+    "--install")
+      INSTALL=1
+      shift
+      ;;
+    "--")
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ $INSTALL = 1 ]; then
+  python3 $(dirname $0)/install_gadget.py --basedir ${BASEDIR} --all
+fi
 
 if [ -z "$VIMSPECTOR_MIMODE" ]; then
   if which lldb >/dev/null 2>&1; then
@@ -25,6 +63,10 @@ fi
 
 echo "Testing with:"
 echo " * VIMSPECTOR_MIMODE=$VIMSPECTOR_MIMODE"
+echo " * RUN_VIM=$RUN_VIM"
+echo " * RUN_TEST=$RUN_TEST"
+echo " * BASEDIR_CMD=$BASEDIR_CMD"
+
 
 echo "%SETUP - Building test programs..."
 set -e
@@ -53,9 +95,10 @@ for t in ${TESTS}; do
   # split on : into fileName and testName
   IFS=: read -s t T <<< "$t"
 
-  TESTLOGDIR=$(pwd)/logs/$t
+  TESTLOGDIR=${BASEDIR}/tests/logs/$t
 
-  if ${RUN_TEST} --cmd 'au SwapExists * let v:swapchoice = "e"' $t $T \
+  if ${RUN_TEST} --cmd "${BASEDIR_CMD}" \
+                 --cmd 'au SwapExists * let v:swapchoice = "e"' $t $T \
      && [ -f $t.res ];  then
     echo "%PASS: $t PASSED"
   else

--- a/tests/tabpage.test.vim
+++ b/tests/tabpage.test.vim
@@ -44,10 +44,7 @@ function! Test_Step_With_Different_Tabpage()
   call assert_equal( 'simple.cpp', bufname( '%' ), 'Current buffer' )
   call assert_equal( 1, col( '.' ), 'Current column' )
 
-  call vimspector#Reset()
-  call vimspector#ClearBreakpoints()
-
-  call WaitForAssert( {-> assert_notequal( vimspector_tabnr, tabpagenr() ) } )
+  call vimspector#test#setup#Reset()
   lcd -
   %bwipeout!
 endfunction


### PR DESCRIPTION
This is handy for running the tests in a clean way (e.g. if you have a configurations directory or custom gadgets, etc.)

It could also be useful in multi-user environments and/or (unfortunately) for third-party packaging (which I _strongly_ discourage)