### PR TITLE
Disable subprocess debugging by default in debugpy

### DIFF
--- a/install_gadget.py
+++ b/install_gadget.py
@@ -125,7 +125,11 @@ GADGETS = {
         ],
         "name": "debugpy",
         "configuration": {
-          "python": sys.executable
+          "python": sys.executable,
+          # Don't debug into subprocesses, as this leads to problems (vimspector
+          # doesn't support the custom messages)
+          # https://github.com/puremourning/vimspector/issues/141
+          "subProcess": False,
         }
       }
     },


### PR DESCRIPTION
As mentioned here: https://github.com/puremourning/vimspector/issues/141#issuecomment-605289072