### PR TITLE
fix some exceptions not handled

### DIFF
--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -171,8 +171,11 @@ def RestoreCurrentWindow():
   try:
     yield
   finally:
-    vim.current.tabpage = old_tabpage
-    vim.current.window = old_window
+    try:
+      vim.current.tabpage = old_tabpage
+      vim.current.window = old_window
+    except:
+      pass
 
 
 @contextlib.contextmanager

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -165,17 +165,18 @@ def RestoreCursorPosition():
 
 @contextlib.contextmanager
 def RestoreCurrentWindow():
-  # TODO: Don't trigger autocommands when shifting windows
-  old_tabpage = vim.current.tabpage
-  old_window = vim.current.window
   try:
-    yield
-  finally:
+    saved_eventignore = vim.options['eventignore']
+    vim.options['eventignore'] = 'BufWinEnter,BufWinLeave,BufEnter,BufLeave,TabEnter,TabLeave'
+    old_tabpage = vim.current.tabpage
+    old_window = vim.current.window
     try:
+      yield
+    finally:
       vim.current.tabpage = old_tabpage
       vim.current.window = old_window
-    except Exception as e:
-      print(e)
+  finally:
+    vim.options['eventignore'] = saved_eventignore
 
 
 @contextlib.contextmanager

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -174,8 +174,8 @@ def RestoreCurrentWindow():
     try:
       vim.current.tabpage = old_tabpage
       vim.current.window = old_window
-    except:
-      pass
+    except Exception as e:
+      print(e)
 
 
 @contextlib.contextmanager

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -257,14 +257,19 @@ class VariablesView( object ):
 
   def _DrawVariables( self, view,  variables, indent ):
     for variable in variables:
+      if variable is None:
+        continue
+      type_ = variable.get( 'type', '' )
+      if type_ != '':
+        type_ = '({})'.format(type_)
       line = utils.AppendToBuffer(
         view.win.buffer,
-        '{indent}{icon} {name} ({type_}): {value}'.format(
+        '{indent}{icon} {name}{type_}: {value}'.format(
           indent = ' ' * indent,
           icon = '+' if ( variable.get( 'variablesReference', 0 ) > 0 and
                           '_variables' not in variable ) else '-',
           name = variable[ 'name' ],
-          type_ = variable.get( 'type', '<unknown type>' ),
+          type_ = type_,
           value = variable.get( 'value', '<unknown value>' ) ).split( '\n' ) )
       view.lines[ line ] = variable
 

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -222,7 +222,7 @@ class VariablesView( object ):
     self._DrawWatches()
 
   def ExpandVariable( self ):
-    if vim.current.window == self._vars.win:
+    if vim.current.buffer == self._vars.win.buffer:
       view = self._vars
     elif vim.current.window == self._watch.win:
       view = self._watch


### PR DESCRIPTION
I duplicate vimspector.Variables in a new window/tab which cannot be expanded