### PR TITLE
[#178]Set GO111MODULE to off and the sample project won't fail in go 1.12+

### DIFF
--- a/support/test/go/hello_world/.vimspector.json
+++ b/support/test/go/hello_world/.vimspector.json
@@ -7,7 +7,8 @@
         "program": "${workspaceRoot}/hello-world.go",
         "mode": "debug",
         "dlvToolPath": "$HOME/go/bin/dlv",
-        "trace": true
+        "trace": true,
+        "env": { "GO111MODULE": "off" }
       }
     }
   }


### PR DESCRIPTION
Refer to https://github.com/puremourning/vimspector/issues/178 for more info. Tested with Go 1.12 and Go 1.14