### PR TITLE
ExpandVariable for the buffer of vimspector.variables rather than the window

### DIFF
--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -222,7 +222,7 @@ class VariablesView( object ):
     self._DrawWatches()
 
   def ExpandVariable( self ):
-    if vim.current.window == self._vars.win:
+    if vim.current.buffer == self._vars.win.buffer:
       view = self._vars
     elif vim.current.window == self._watch.win:
       view = self._watch


### PR DESCRIPTION
Launch vimspcetor and focus on vimspector.variables window, type `:split<cr>`, pressing enter at any line starting with `+` has no effect in the spawned window