### PR TITLE
fix if variable is None; don't print (<unknown type>)

### DIFF
--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -257,14 +257,19 @@ class VariablesView( object ):
 
   def _DrawVariables( self, view,  variables, indent ):
     for variable in variables:
+      if variable is None:
+        continue
+      type_ = variable.get( 'type', '' )
+      if type_ != '':
+        type_ = '({})'.format(type_)
       line = utils.AppendToBuffer(
         view.win.buffer,
-        '{indent}{icon} {name} ({type_}): {value}'.format(
+        '{indent}{icon} {name}{type_}: {value}'.format(
           indent = ' ' * indent,
           icon = '+' if ( variable.get( 'variablesReference', 0 ) > 0 and
                           '_variables' not in variable ) else '-',
           name = variable[ 'name' ],
-          type_ = variable.get( 'type', '<unknown type>' ),
+          type_ = type_,
           value = variable.get( 'value', '<unknown value>' ) ).split( '\n' ) )
       view.lines[ line ] = variable
 

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -261,7 +261,7 @@ class VariablesView( object ):
         continue
       type_ = variable.get( 'type', '' )
       if type_ != '':
-        type_ = '({})'.format(type_)
+        type_ = '({})'.format( type_ )
       line = utils.AppendToBuffer(
         view.win.buffer,
         '{indent}{icon} {name}{type_}: {value}'.format(


### PR DESCRIPTION
go version go1.13.8 linux/amd64
```go
package main

func main() {
	a := 0
	b := 1
	c := 2
	d := map[string]int {
		"0": 0,
		"1": 1,
		"2": 2,
	}
	print(a, b, c, d)
}
```
```json
{
  "configurations": {
    "go": {
      "adapter": "vscode-go",
      "configuration": {
        "program": "$cwd",
        "request": "launch",
        "args": [],
        "environment": [],
        "cwd": "$cwd",
        "mode": "debug",
        "dlvToolPath": "$HOME/go/bin/dlv"
      }
    }
  }
}
```
Add a breakpoint at `print` and launch vimspector. Expand `d` in vimspector.variables and  vimspector throws `AttributeError: 'NoneType' object has no attribute 'get'` resulting in following status  
```go
- Scope: Local
  - a (<unknown type>): 0
  - b (<unknown type>): 1
  - c (<unknown type>): 2
  - d (<unknown type>): <map[string]int> (length: 3)
    - "0" (<unknown type>): 0
```
Type definitions are always <unknown type> when debug golang