### PR TITLE
Windows support for cpptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,31 +729,29 @@ Current tested with the following debug adapters.
 Example `.vimspector.json` (works with both `vscode-cpptools` and `lldb-vscode`.
 For `lldb-vscode` replace the name of the adapter with `lldb-vscode`:
 
+* vscode-cpptools Linux/MacOS:
+
 ```
 {
   "configurations": {
-    "<name>: Launch": {
+    "Launch": {
       "adapter": "vscode-cpptools",
       "configuration": {
-        "name": "<name>",
-        "type": "cppdbg",
         "request": "launch",
         "program": "<path to binary>",
         "args": [ ... ],
         "cwd": "<working directory>",
         "environment": [ ... ],
         "externalConsole": true,
-        "MIMode": "lldb"
+        "MIMode": "<lldb or gdb>"
       }
     },
-    "<name>: Attach": {
+    "Attach": {
       "adapter": "vscode-cpptools",
       "configuration": {
-        "name": "<name>: Attach",
-        "type": "cppdbg",
         "request": "attach",
         "program": "<path to binary>",
-        "MIMode": "lldb"
+        "MIMode": "<lldb or gdb>"
       }
     }
     ...
@@ -761,14 +759,36 @@ For `lldb-vscode` replace the name of the adapter with `lldb-vscode`:
 }
 ```
 
+* vscode-cpptools Windows
+
+***NOTE FOR WINDOWS USERS:*** You need to install `gdb.exe`. I recommend using
+`scoop install gdb`. Vimspector cannot use the visual studio debugger due to
+licensing.
+
+```
+{
+  "configurations": {
+    "Launch": {
+      "adapter": "vscode-cpptools",
+      "configuration": {
+        "request": "launch",
+        "program": "<path to binary>",
+        "stopAtEntry": true
+      }
+    }
+  }
+}
+```
+
+* lldb-vscode (MacOS)
+
 An alternative is to to use `lldb-vscode`, which comes with llvm.  Here's how:
 
-* Install llvm with HomeBrew: `brew install llvm`
+* Install llvm (e.g. with HomeBrew: `brew install llvm`)
 * Create a file named
   `/path/to/vimspector/gadgets/macos/.gadgets.d/lldb-vscode.json`:
 
 ```json
-
 {
   "adapters": {
     "lldb-vscode": {

--- a/install_gadget.py
+++ b/install_gadget.py
@@ -48,11 +48,29 @@ GADGETS = {
     'do': lambda name, root, gadget: InstallCppTools( name, root, gadget ),
     'all': {
       'version': '0.27.0',
+      "adapters": {
+        "vscode-cpptools": {
+          "name": "cppdbg",
+          "command": [
+            "${gadgetDir}/vscode-cpptools/debugAdapters/OpenDebugAD7"
+          ],
+          "attach": {
+            "pidProperty": "processId",
+            "pidSelect": "ask"
+          },
+          "configuration": {
+            "type": "cppdbg",
+            "args": [],
+            "cwd": "${workspaceRoot}",
+            "environment": [],
+          }
+        },
+      },
     },
     'linux': {
       'file_name': 'cpptools-linux.vsix',
       'checksum':
-        '3695202e1e75a03de18049323b66d868165123f26151f8c974a480eaf0205435'
+        '3695202e1e75a03de18049323b66d868165123f26151f8c974a480eaf0205435',
     },
     'macos': {
       'file_name': 'cpptools-osx.vsix',
@@ -61,24 +79,27 @@ GADGETS = {
     },
     'windows': {
       'file_name': 'cpptools-win32.vsix',
-      'checksum': None,
-    },
-    "adapters": {
-      "vscode-cpptools": {
-        "name": "cppdbg",
-        "command": [
-          "${gadgetDir}/vscode-cpptools/debugAdapters/OpenDebugAD7"
-        ],
-        "attach": {
-          "pidProperty": "processId",
-          "pidSelect": "ask"
+      'checksum':
+        'aa294368ed16d48c59e49c8000e146eae5a19ad07b654efed5db8ec93b24229e',
+      "adapters": {
+        "vscode-cpptools": {
+          "name": "cppdbg",
+          "command": [
+            "${gadgetDir}/vscode-cpptools/debugAdapters/bin/OpenDebugAD7.exe"
+          ],
+          "attach": {
+            "pidProperty": "processId",
+            "pidSelect": "ask"
+          },
+          "configuration": {
+            "type": "cppdbg",
+            "args": [],
+            "cwd": "${workspaceRoot}",
+            "environment": [],
+            "MIMode": "gdb",
+            "MIDebuggerPath": "gdb.exe"
+          }
         },
-        "configuration": {
-          "type": "cppdbg",
-          "args": [],
-          "cwd": "${workspaceRoot}",
-          "environment": [],
-        }
       },
     },
   },
@@ -531,6 +552,9 @@ def InstallGagdet( name, gadget, failed, all_adapters ):
     else:
       installer.MakeExtensionSymlink( vimspector_base, name, root )
 
+    # Allow per-OS adapter overrides. v already did that for us...
+    all_adapters.update( v.get( 'adapters', {} ) )
+    # Add any other "all" adapters
     all_adapters.update( gadget.get( 'adapters', {} ) )
 
     print( "Done installing {}".format( name ) )

--- a/support/test/cpp/simple_c_program/.vimspector.json
+++ b/support/test/cpp/simple_c_program/.vimspector.json
@@ -1,37 +1,11 @@
 {
-  "adapters": {
-      "cppdbg": {
-        "name": "cppdbg",
-        "command": [ "$HOME/.vscode/extensions/ms-vscode.cpptools-0.20.1/debugAdapters/OpenDebugAD7" ],
-        "attach": {
-          "pidProperty": "processId",
-          "pidSelect": "ask"
-        }
-      }
-  },
   "configurations": {
     "simple_c_program - Launch": {
-      "adapter": "cppdbg",
+      "adapter": "vscode-cpptools",
       "configuration": {
-        "name": "ms Launch",
-        "type": "cppdbg",
         "request": "launch",
         "program": "${workspaceRoot}/test",
-        "args": [],
-        "cwd": "${workspaceRoot}",
-        "environment": [],
-        "MIMode": "lldb",
         "stopAtEntry": true
-      }
-    },
-    "simple_c_program - Attach": {
-      "adapter": "cppdbg",
-      "configuration": {
-        "name": "(lldb) Attach",
-        "type": "cppdbg",
-        "request": "attach",
-        "program": "${workspaceRoot}/test",
-        "MIMode": "lldb"
       }
     }
   }


### PR DESCRIPTION
cc @MintSoup

add a way for the installer to set up different adapters by OS.

Add some guidance to the readme.

Rationalise the "demo" cpp app

Fixes #129 