### PR TITLE
Allow users to close UI windows

### DIFF
--- a/autoload/vimspector/internal/channel.vim
+++ b/autoload/vimspector/internal/channel.vim
@@ -20,12 +20,20 @@ set cpoptions&vim
 " }}}
 
 function! s:_OnServerData( channel, data ) abort
+  if !exists( 's:ch' ) || s:ch isnot a:channel
+    return
+  endif
+
   py3 << EOF
 _vimspector_session.OnChannelData( vim.eval( 'a:data' ) )
 EOF
 endfunction
 
 function! s:_OnClose( channel ) abort
+  if !exists( 's:ch' ) || s:ch isnot a:channel
+    return
+  endif
+
   echom 'Channel closed'
   redraw
   unlet s:ch

--- a/autoload/vimspector/internal/neochannel.vim
+++ b/autoload/vimspector/internal/neochannel.vim
@@ -22,6 +22,14 @@ set cpoptions&vim
 
 
 function! s:_OnEvent( chan_id, data, event ) abort
+  if v:exiting isnot# v:null
+    return
+  endif
+
+  if !exists( 's:ch' ) || a:chan_id != s:ch
+    return
+  endif
+
   if a:data == ['']
     echom 'Channel closed'
     redraw

--- a/autoload/vimspector/internal/neojob.vim
+++ b/autoload/vimspector/internal/neojob.vim
@@ -39,8 +39,6 @@ function! s:_OnEvent( chan_id, data, event ) abort
     echom 'Channel exit with status ' . a:data
     redraw
     unlet s:job
-    " This causes terminal spam in neovim due to
-    " https://github.com/neovim/neovim/issues/11725
     py3 _vimspector_session.OnServerExit( vim.eval( 'a:data' ) )
   endif
 endfunction

--- a/autoload/vimspector/internal/neoterm.vim
+++ b/autoload/vimspector/internal/neoterm.vim
@@ -46,12 +46,17 @@ function! vimspector#internal#neoterm#ResetEnvironment( env, old_env ) abort
 endfunction
 
 function! vimspector#internal#neoterm#Start( cmd, opts ) abort
+  " Prepare current buffer to be turned into a term if curwin is not set
   if ! get( a:opts, 'curwin', 0 )
+    let mods = ''
     if get( a:opts, 'vertical', 0 )
-      vnew
+      let mods .= 'vertical '
+      let mods .= get( a:opts, 'term_cols', '' )
     else
-      new
+      let mods .= get( a:opts, 'term_rows', '' )
     endif
+
+    execute mods . 'new'
   endif
 
   " HACK: Neovim's termopen doesn't support env

--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -56,6 +56,10 @@ class CodeView( object ):
 
 
   def SetCurrentFrame( self, frame ):
+    """Returns True if the code window was updated with the frame, False
+    otherwise. False means either the frame is junk, we couldn't find the file
+    (or don't have the data) or the code window no longer exits."""
+
     if self._signs[ 'vimspectorPC' ]:
       vim.command( 'sign unplace {} group=VimspectorCode'.format(
         self._signs[ 'vimspectorPC' ] ) )
@@ -67,8 +71,25 @@ class CodeView( object ):
     if 'path' not in frame[ 'source' ]:
       return False
 
-    utils.JumpToWindow( self._window )
+    self._signs[ 'vimspectorPC' ] = self._next_sign_id
+    self._next_sign_id += 1
 
+    try:
+      vim.command( 'sign place {0} group=VimspectorCode priority=20 '
+                                   'line={1} name=vimspectorPC '
+                                   'file={2}'.format(
+                                     self._signs[ 'vimspectorPC' ],
+                                     frame[ 'line' ],
+                                     frame[ 'source' ][ 'path' ] ) )
+    except vim.error as e:
+      # Ignore 'invalid buffer name'
+      if 'E158' in str( e ):
+        pass
+
+    if not self._window.valid:
+      return False
+
+    utils.JumpToWindow( self._window )
     try:
       utils.OpenFileInCurrentWindow( frame[ 'source' ][ 'path' ] )
     except vim.error:
@@ -88,16 +109,6 @@ class CodeView( object ):
                               frame[ 'column' ],
                               frame[ 'source' ][ 'path' ] )
       return False
-
-    self._signs[ 'vimspectorPC' ] = self._next_sign_id
-    self._next_sign_id += 1
-
-    vim.command( 'sign place {0} group=VimspectorCode priority=20 '
-                                 'line={1} name=vimspectorPC '
-                                 'file={2}'.format(
-                                   self._signs[ 'vimspectorPC' ],
-                                   frame[ 'line' ],
-                                   frame[ 'source' ][ 'path' ] ) )
 
     self.current_syntax = utils.ToUnicode(
       vim.current.buffer.options[ 'syntax' ] )
@@ -215,8 +226,13 @@ class CodeView( object ):
       'env': env,
     }
 
-    window_for_start = self._window
-    if self._terminal_window is not None:
+    if self._window.valid:
+      window_for_start = self._window
+    else:
+      # TOOD: Where?
+      window_for_start = vim.current.window
+
+    if self._terminal_window is not None and self._terminal_window.valid:
       assert self._terminal_buffer_number
       if ( self._terminal_window.buffer.number == self._terminal_buffer_number
            and int( utils.Call( 'vimspector#internal#{}term#IsFinished'.format(

--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -40,7 +40,6 @@ class CodeView( object ):
       'breakpoints': []
     }
 
-
     with utils.LetCurrentWindow( self._window ):
       vim.command( 'nnoremenu WinBar.Continue :call vimspector#Continue()<CR>' )
       vim.command( 'nnoremenu WinBar.Next :call vimspector#StepOver()<CR>' )
@@ -221,6 +220,7 @@ class CodeView( object ):
 
     options = {
       'vertical': 1,
+      'term_cols': 80,
       'norestore': 1,
       'cwd': cwd,
       'env': env,

--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -82,8 +82,8 @@ class CodeView( object ):
                                      frame[ 'source' ][ 'path' ] ) )
     except vim.error as e:
       # Ignore 'invalid buffer name'
-      if 'E158' in str( e ):
-        pass
+      if 'E158' not in str( e ):
+        raise
 
     if not self._window.valid:
       return False

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -518,6 +518,10 @@ class DebugSession( object ):
     self.SetCurrentFrame( None )
 
   def SetCurrentFrame( self, frame ):
+    if not frame:
+      self._stackTraceView.Clear()
+      self._variablesView.Clear()
+
     if not self._codeView.SetCurrentFrame( frame ):
       return False
 
@@ -526,9 +530,6 @@ class DebugSession( object ):
       self._stackTraceView.SetSyntax( self._codeView.current_syntax )
       self._variablesView.LoadScopes( frame )
       self._variablesView.EvaluateWatches()
-    else:
-      self._stackTraceView.Clear()
-      self._variablesView.Clear()
 
     return True
 

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -36,7 +36,7 @@ class StackTraceView( object ):
     self._threads = []
     self._sources = {}
 
-    utils.SetUpScratchBuffer( self._buf, 'vimspector.StackTrace' )
+    utils.SetUpHiddenBuffer( self._buf, 'vimspector.StackTrace' )
 
     vim.current.buffer = self._buf
     utils.SetUpUIWindow( vim.current.window )

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -81,7 +81,7 @@ class StackTraceView( object ):
 
   def Reset( self ):
     self.Clear()
-    # TODO: delete the buffer ?
+    utils.CleanUpHiddenBuffer( self._buf )
 
   def LoadThreads( self, infer_current_frame ):
     pending_request = False

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -39,10 +39,7 @@ class StackTraceView( object ):
     utils.SetUpScratchBuffer( self._buf, 'vimspector.StackTrace' )
 
     vim.current.buffer = self._buf
-    # FIXME: Remove all usage of "Windown" and just use buffers to prevent all
-    # the bugs around the window being closed.
-    self._win = vim.current.window
-    utils.SetUpUIWindow( self._win )
+    utils.SetUpUIWindow( vim.current.window )
 
     vim.command( 'nnoremap <buffer> <CR> :call vimspector#GoToFrame()<CR>' )
 
@@ -311,4 +308,4 @@ class StackTraceView( object ):
   def SetSyntax( self, syntax ):
     self._current_syntax = utils.SetSyntax( self._current_syntax,
                                             syntax,
-                                            self._win )
+                                            self._buf )

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -97,6 +97,7 @@ def CleanUpHiddenBuffer( buf ):
 
 def SetUpScratchBuffer( buf, name ):
   SetUpHiddenBuffer( buf, name )
+  buf.options[ 'bufhidden' ] = 'wipe'
 
 
 def SetUpHiddenBuffer( buf, name ):

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -194,6 +194,14 @@ def LetCurrentWindow( window ):
     yield
 
 
+@contextlib.contextmanager
+def LetCurrentBuffer( buf ):
+  with RestoreCursorPosition():
+    with RestoreCurrentBuffer( vim.current.window ):
+      vim.current.buffer = buf
+      yield
+
+
 def JumpToWindow( window ):
   vim.current.tabpage = window.tabpage
   vim.current.window = window
@@ -555,8 +563,11 @@ def SetSyntax( current_syntax, syntax, *args ):
   if current_syntax == syntax:
     return
 
-  for win in args:
-    with LetCurrentWindow( win ):
+  for buf in args:
+    with LetCurrentBuffer( buf ):
+      # We use set syn= because just setting vim.Buffer.options[ 'syntax' ]
+      # doesn't actually trigger the Syntax autocommand, and i'm not sure that
+      # 'doautocmd Syntax' is the right solution or not
       vim.command( 'set syntax={}'.format( Escape( syntax ) ) )
 
   return syntax

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -16,14 +16,10 @@
 import abc
 import vim
 import logging
-from collections import namedtuple
 from functools import partial
 import typing
 
 from vimspector import utils
-
-View = namedtuple( 'View', [ 'win', 'lines', 'draw' ] )
-
 
 
 class Expandable:
@@ -104,7 +100,6 @@ class Variable( Expandable ):
     self.variable = variable
 
 
-
 class Watch:
   """Holds a user watch expression (DAP request) and the result (WatchResult)"""
   def __init__( self, expression: dict ):
@@ -114,29 +109,44 @@ class Watch:
     self.result = None
 
 
+class View:
+  lines: typing.Dict[ int, Expandable ]
+  draw: typing.Callable
+  buf: vim.Buffer
+
+  def __init__( self, win: vim.Window, lines, draw ):
+    self.lines = lines
+    self.draw = draw
+    self.buf = win.buffer
+
+    utils.SetUpUIWindow( win )
+
+
 class VariablesView( object ):
   def __init__( self, connection, variables_win, watches_win ):
     self._logger = logging.getLogger( __name__ )
     utils.SetUpLogging( self._logger )
 
-    self._vars = View( variables_win, {}, self._DrawScopes )
-    self._watch = View( watches_win, {}, self._DrawWatches )
     self._connection = connection
     self._current_syntax = ''
 
-    # Allows us to hit <CR> to expand/collapse variables
-    with utils.LetCurrentWindow( self._vars.win ):
+    # Set up the "Variables" buffer in the variables_win
+    self._scopes: typing.List[ Scope ] = []
+    self._vars = View( variables_win, {}, self._DrawScopes )
+    utils.SetUpScratchBuffer( self._vars.buf, 'vimspector.Variables' )
+    with utils.LetCurrentWindow( variables_win ):
       vim.command(
         'nnoremap <buffer> <CR> :call vimspector#ExpandVariable()<CR>' )
 
-    # List of current scopes of type Scope
-    self._scopes: typing.List[ 'Scope' ] = []
-
-    # List of current Watches of type Watch
-    self._watches: typing.List[ 'Watch' ] = []
-
-    # Allows us to hit <CR> to expand/collapse variables
-    with utils.LetCurrentWindow( self._watch.win ):
+    # Set up the "Watches" buffer in the watches_win (and create a WinBar in
+    # there)
+    self._watches: typing.List[ Watch ] = []
+    self._watch = View( watches_win, {}, self._DrawWatches )
+    utils.SetUpPromptBuffer( self._watch.buf,
+                             'vimspector.Watches',
+                             'Expression: ',
+                             'vimspector#AddWatchPrompt' )
+    with utils.LetCurrentWindow( watches_win ):
       vim.command(
         'nnoremap <buffer> <CR> :call vimspector#ExpandVariable()<CR>' )
       vim.command(
@@ -149,15 +159,7 @@ class VariablesView( object ):
       vim.command( 'nnoremenu 1.3 WinBar.Delete '
                    ':call vimspector#DeleteWatch()<CR>' )
 
-    utils.SetUpScratchBuffer( self._vars.win.buffer, 'vimspector.Variables' )
-    utils.SetUpPromptBuffer( self._watch.win.buffer,
-                             'vimspector.Watches',
-                             'Expression: ',
-                             'vimspector#AddWatchPrompt' )
-
-    utils.SetUpUIWindow( self._vars.win )
-    utils.SetUpUIWindow( self._watch.win )
-
+    # Set the (global!) balloon expr if supported
     has_balloon      = int( vim.eval( "has( 'balloon_eval' )" ) )
     has_balloon_term = int( vim.eval( "has( 'balloon_eval_term' )" ) )
 
@@ -181,10 +183,10 @@ class VariablesView( object ):
     self._is_term = not bool( int( vim.eval( "has( 'gui_running' )" ) ) )
 
   def Clear( self ):
-    with utils.ModifiableScratchBuffer( self._vars.win.buffer ):
-      utils.ClearBuffer( self._vars.win.buffer )
-    with utils.ModifiableScratchBuffer( self._watch.win.buffer ):
-      utils.ClearBuffer( self._watch.win.buffer )
+    with utils.ModifiableScratchBuffer( self._vars.buf ):
+      utils.ClearBuffer( self._vars.buf )
+    with utils.ModifiableScratchBuffer( self._watch.buf ):
+      utils.ClearBuffer( self._watch.buf )
     self._current_syntax = ''
 
   def ConnectionUp( self, connection ):
@@ -198,8 +200,8 @@ class VariablesView( object ):
     for k, v in self._oldoptions.items():
       vim.options[ k ] = v
 
-    vim.command( 'bdelete! ' + str( self._watch.win.buffer.number ) )
-    vim.command( 'bdelete! ' + str( self._vars.win.buffer.number ) )
+    vim.command( 'bdelete! ' + str( self._watch.buf.number ) )
+    vim.command( 'bdelete! ' + str( self._vars.buf.number ) )
 
   def LoadScopes( self, frame ):
     def scopes_consumer( message ):
@@ -256,8 +258,8 @@ class VariablesView( object ):
     self.EvaluateWatches()
 
   def DeleteWatch( self ):
-    if vim.current.window != self._watch.win:
-      utils.UserMessage( 'Not a watch window' )
+    if vim.current.buffer != self._watch.buf:
+      utils.UserMessage( 'Not a watch buffer' )
       return
 
     current_line = vim.current.window.cursor[ 0 ]
@@ -305,9 +307,9 @@ class VariablesView( object ):
     self._DrawWatches()
 
   def ExpandVariable( self ):
-    if vim.current.window == self._vars.win:
+    if vim.current.buffer == self._vars.buf:
       view = self._vars
-    elif vim.current.window == self._watch.win:
+    elif vim.current.buffer == self._watch.buf:
       view = self._watch
     else:
       return
@@ -341,7 +343,7 @@ class VariablesView( object ):
     assert indent > 0
     for variable in variables:
       line = utils.AppendToBuffer(
-        view.win.buffer,
+        view.buf,
         '{indent}{marker}{icon} {name} ({type_}): {value}'.format(
           # We borrow 1 space of indent to draw the change marker
           indent = ' ' * ( indent - 1 ),
@@ -363,8 +365,8 @@ class VariablesView( object ):
     # However it is pretty inefficient.
     self._vars.lines.clear()
     with utils.RestoreCursorPosition():
-      with utils.ModifiableScratchBuffer( self._vars.win.buffer ):
-        utils.ClearBuffer( self._vars.win.buffer )
+      with utils.ModifiableScratchBuffer( self._vars.buf ):
+        utils.ClearBuffer( self._vars.buf )
         for scope in self._scopes:
           self._DrawScope( 0, scope )
 
@@ -374,11 +376,11 @@ class VariablesView( object ):
     # However it is pretty inefficient.
     self._watch.lines.clear()
     with utils.RestoreCursorPosition():
-      with utils.ModifiableScratchBuffer( self._watch.win.buffer ):
-        utils.ClearBuffer( self._watch.win.buffer )
-        utils.AppendToBuffer( self._watch.win.buffer, 'Watches: ----' )
+      with utils.ModifiableScratchBuffer( self._watch.buf ):
+        utils.ClearBuffer( self._watch.buf )
+        utils.AppendToBuffer( self._watch.buf, 'Watches: ----' )
         for watch in self._watches:
-          line = utils.AppendToBuffer( self._watch.win.buffer,
+          line = utils.AppendToBuffer( self._watch.buf,
                                        'Expression: '
                                        + watch.expression[ 'expression' ] )
           watch.line = line
@@ -387,7 +389,7 @@ class VariablesView( object ):
   def _DrawScope( self, indent, scope ):
     icon = '+' if scope.IsExpandable() and not scope.IsExpandedByUser() else '-'
 
-    line = utils.AppendToBuffer( self._vars.win.buffer,
+    line = utils.AppendToBuffer( self._vars.buf,
                                  '{0}{1} Scope: {2}'.format(
                                    ' ' * indent,
                                    icon,
@@ -413,7 +415,7 @@ class VariablesView( object ):
       icon = icon,
       result = watch.result.result.get( 'result', '<unknown>' ) )
 
-    line = utils.AppendToBuffer( self._watch.win.buffer, line.split( '\n' ) )
+    line = utils.AppendToBuffer( self._watch.buf, line.split( '\n' ) )
     self._watch.lines[ line ] = watch.result
 
     if watch.result.ShouldDrawDrillDown():
@@ -495,7 +497,7 @@ class VariablesView( object ):
   def SetSyntax( self, syntax ):
     self._current_syntax = utils.SetSyntax( self._current_syntax,
                                             syntax,
-                                            self._vars.win,
-                                            self._watch.win )
+                                            self._vars.buf,
+                                            self._watch.buf )
 
 # vim: sw=2

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -112,9 +112,8 @@ class Watch:
 class View:
   lines: typing.Dict[ int, Expandable ]
   draw: typing.Callable
-  buf: vim.Buffer
 
-  def __init__( self, win: vim.Window, lines, draw ):
+  def __init__( self, win, lines, draw ):
     self.lines = lines
     self.draw = draw
     self.buf = win.buffer

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -133,7 +133,7 @@ class VariablesView( object ):
     # Set up the "Variables" buffer in the variables_win
     self._scopes: typing.List[ Scope ] = []
     self._vars = View( variables_win, {}, self._DrawScopes )
-    utils.SetUpScratchBuffer( self._vars.buf, 'vimspector.Variables' )
+    utils.SetUpHiddenBuffer( self._vars.buf, 'vimspector.Variables' )
     with utils.LetCurrentWindow( variables_win ):
       vim.command(
         'nnoremap <buffer> <CR> :call vimspector#ExpandVariable()<CR>' )

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -200,8 +200,8 @@ class VariablesView( object ):
     for k, v in self._oldoptions.items():
       vim.options[ k ] = v
 
-    vim.command( 'bdelete! ' + str( self._watch.buf.number ) )
-    vim.command( 'bdelete! ' + str( self._vars.buf.number ) )
+    utils.CleanUpHiddenBuffer( self._vars.buf )
+    utils.CleanUpHiddenBuffer( self._watch.buf )
 
   def LoadScopes( self, frame ):
     def scopes_consumer( message ):

--- a/support/test/java/test_project/.vimspector.json
+++ b/support/test/java/test_project/.vimspector.json
@@ -9,7 +9,10 @@
         "classPaths": [ "${workspaceRoot}/target/classes" ],
         "args": "hello world!",
         "stopOnEntry": true,
-        "console": "integratedTerminal"
+        "console": "integratedTerminal",
+        "stepFilters": {
+          "skipClasses": [ "$$JDK" ]
+        }
       }
     },
     "Java Attach": {
@@ -19,7 +22,10 @@
         "sourcePaths": [ "${workspaceRoot}/src/main/java" ],
         "stopOnEntry": true,
         "hostName": "localhost",
-        "port": "${JVMDebugPort}"
+        "port": "${JVMDebugPort}",
+        "stepFilters": {
+          "skipClasses": [ "$$JDK" ]
+        }
       }
     },
     "Attach with vscode-javac": {

--- a/support/test/java/test_project/java.vim
+++ b/support/test/java/test_project/java.vim
@@ -1,0 +1,24 @@
+let g:ycm_java_jdtls_extension_path = [
+      \ expand( '<sfile>:p:h:h:h:h:h' ) . '/gadgets/macos'
+      \ ]
+
+let s:jdt_ls_debugger_port = 0
+function! s:StartDebugging()
+  if s:jdt_ls_debugger_port <= 0
+    " Get the DAP port
+    let s:jdt_ls_debugger_port = youcompleteme#GetCommandResponse(
+      \ 'ExecuteCommand',
+      \ 'vscode.java.startDebugSession' )
+
+    if s:jdt_ls_debugger_port == ''
+       echom "Unable to get DAP port - is YCM initialized?"
+       let s:jdt_ls_debugger_port = 0
+       return
+     endif
+  endif
+
+  " Start debugging with the DAP port
+  call vimspector#LaunchWithSettings( { 'DAPPort': s:jdt_ls_debugger_port } )
+endfunction
+
+nnoremap <silent> <buffer> <Leader><F5> :call <SID>StartDebugging()<CR>

--- a/support/test/java/test_project/pom.xml
+++ b/support/test/java/test_project/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>TestApplication</artifactId>
   <version>1</version>
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
   </properties>
 </project>

--- a/support/test/java/test_project/src/main/java/com/vimspector/test/Base.java
+++ b/support/test/java/test_project/src/main/java/com/vimspector/test/Base.java
@@ -1,0 +1,8 @@
+package com.vimspector.test;
+
+class Base {
+  public String DoSomething()
+  {
+    return "";
+  }
+}

--- a/support/test/java/test_project/src/main/java/com/vimspector/test/TestApplication.java
+++ b/support/test/java/test_project/src/main/java/com/vimspector/test/TestApplication.java
@@ -24,6 +24,16 @@ public class TestApplication {
     }
   }
 
+  private static class TestGeneric<T extends Base > {
+    T t;
+    public TestGeneric( T t ) {
+      this.t = t;
+    }
+    public void DoSomethingUseful() {
+      System.out.println( t.DoSomething() );
+    }
+  }
+
   private static <T extends Base> void DoGeneric( T b ) {
     TestGeneric<T> foo = new TestGeneric<>( b );
     foo.DoSomethingUseful();


### PR DESCRIPTION
There are a few things that we have to do:

* Try to stop using `vim.Window` objects as much as possible. We can do this completely for variables and stack trace. You can even re-open them by `:bu vimspector.Watches`
* For the output window, it's tricker as this is a 'quasi-tab-window'. If it's closed `vim.Window.valid` goes `False` so just check that in all the places we need it
* Tidy more shutdown races - we can receive data for a _new_ connection after an Exit callback, so check taht the channel we got is associated with the _current_ job.
* Fix the terminal spam on exit - never try to use python in a callback if `v:exiting isnot# null` per https://github.com/neovim/neovim/issues/11725
* Fix a regression introduced by a fix. We now correctly try and shut down jobs in the output views in neovim, but that triggered code which never worked ( arguments to `jobstart` and `jobwait` need to be numbers, and `jobwait` takes a list for some reason)

this is stage 1 in "UI customisation" and fixes #159 