### PR TITLE
No longer throws a KeyError when checking for non expensive scope

### DIFF
--- a/install_gadget.py
+++ b/install_gadget.py
@@ -254,6 +254,10 @@ GADGETS = {
       'file_name': 'netcoredbg-linux-master.tar.gz',
       'checksum': '',
     },
+    'windows': {
+      'file_name': 'netcoredbg-win64-master.zip',
+      'checksum': '',
+    },
     'do': lambda name, root, gadget: installer.MakeSymlink(
       gadget_dir,
       name,

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -221,7 +221,7 @@ class VariablesView( object ):
 
         new_scopes.append( scope )
 
-        if not scope.scope.get('expensive', '') and not scope.IsCollapsedByUser():
+        if not scope.scope.get( 'expensive' ) and not scope.IsCollapsedByUser():
           # Expand any non-expensive scope which is not manually collapsed
           scope.expanded = True
 

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -221,7 +221,7 @@ class VariablesView( object ):
 
         new_scopes.append( scope )
 
-        if not scope.scope[ 'expensive' ] and not scope.IsCollapsedByUser():
+        if not scope.scope.get('expensive', '') and not scope.IsCollapsedByUser():
           # Expand any non-expensive scope which is not manually collapsed
           scope.expanded = True
 


### PR DESCRIPTION
I was running into an issue when debugging on Windows where any each step there would be a KeyError when trying to find any non-expensive scope. I was able to fix it with a quick change. I have only tested this with C# on Windows