### PR TITLE
Hide splash screen when debugger is stopped

### DIFF
--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -613,6 +613,10 @@ class DebugSession( object ):
       'arguments': arguments,
     }, failure_handler = handler, timeout = 5000 )
 
+    self._splash_screen = utils.HideSplash(
+      self._api_prefix,
+      self._splash_screen )
+
     # TODO: Use the 'tarminate' request if supportsTerminateRequest set
 
 


### PR DESCRIPTION
I ran into an issue where the splash screen "Shutting down debug adapter..." would stay on the screen when the debugger was stopped and the screen wasn't reset.

I wasn't able to find a better spot to hide the splash screen and I couldn't see a place where the splash screen would have been hidden elsewhere without utilizing the Reset method