### PR TITLE
Upgrade gadgets when they change

### DIFF
--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -234,8 +234,7 @@ GADGETS = {
     },
     'macos': {
       'file_name': 'netcoredbg-osx-master.tar.gz',
-      'checksum':
-        'c1dc6ed58c3f5b0473cfb4985a96552999360ceb9795e42d9c9be64af054f821',
+      'checksum': '',
     },
     'linux': {
       'file_name': 'netcoredbg-linux-master.tar.gz',
@@ -385,7 +384,7 @@ GADGETS = {
     'enabled': False,
     'repo': {
       'url': 'https://github.com/microsoft/vscode-node-debug2',
-      'ref': 'v1.42.0',
+      'ref': 'v1.42.5'
     },
     'do': lambda name, root, gadget: installer.InstallNodeDebug( name,
                                                                  root,

--- a/python3/vimspector/install.py
+++ b/python3/vimspector/install.py
@@ -42,6 +42,11 @@ def GetGadgetDir( vimspector_base ):
   return os.path.join( os.path.abspath( vimspector_base ), 'gadgets', GetOS() )
 
 
+def GetManifestFile( vimspector_base ):
+  return os.path.join( GetGadgetDir( vimspector_base ),
+                       '.gadgets.manifest.json' )
+
+
 def GetGadgetConfigFile( vimspector_base ):
   return os.path.join( GetGadgetDir( vimspector_base ), '.gadgets.json' )
 

--- a/syntax/vimspector-installer.vim
+++ b/syntax/vimspector-installer.vim
@@ -4,10 +4,18 @@ endif
 
 let b:current_syntax = 'vimspector-installer'
 
+syn match VimspectorGadget /[^ ]*\ze@/
+syn match VimspectorGadgetVersion /@\@<=[^ ]*\ze\.\.\./
+
+
 syn keyword VimspectorInstalling Installing
 syn keyword VimspectorDone  Done
+syn keyword VimspectorSkip  Skip
 syn keyword VimspectorError Failed FAILED
 
 hi default link VimspectorInstalling Constant
 hi default link VimspectorDone  DiffAdd
+hi default link VimspectorSkip  DiffAdd
 hi default link VimspectorError WarningMsg
+hi default link VimspectorGadget String
+hi default link VimspectorGadgetVersion Identifier


### PR DESCRIPTION
This adds a --upgrade option to install_gadget.py and makes
VimspectorUpdate only update things which have changed.

To do this, we record the gadget spec in a manfiest file and compare it
with the current spec when in upgrade mode.

'Changed' in this case means that the gadget spec has changed from the
last time the installer was run. It does _not_ actually check the
presence of the gadget.

--

Also update the node debugger to the latest version and remove the node 10 check :) 

Fixes #176 
Fixes #217 