### PR TITLE
Ability to coerce types in the vimspector config

### DIFF
--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -544,6 +544,7 @@ def ExpandReferencesInString( orig_s,
 def CoerceType( mapping: typing.Dict[ str, typing.Any ], key: str ):
   DICT_TYPES = {
     'json': json.loads,
+    's': str
   }
 
   parts = key.split( '#' )

--- a/support/test/python/simple_python/.vimspector.json
+++ b/support/test/python/simple_python/.vimspector.json
@@ -60,7 +60,8 @@
         "stopOnEntry#json": "${StopOnEntry:true}",
         "console": "integratedTerminal",
         "args#json": "${args:[]}",
-        "env#json": "${env:{\\}}"
+        "env#json": "${env:{\\}}",
+        "igored#json#s": "string not json"
       },
       "breakpoints": {
         "exception": {

--- a/support/test/python/simple_python/.vimspector.json
+++ b/support/test/python/simple_python/.vimspector.json
@@ -57,8 +57,10 @@
         "type": "python",
         "cwd": "${workspaceRoot}",
         "program": "${program:${file\\}}",
-        "stopOnEntry": false,
-        "console": "integratedTerminal"
+        "stopOnEntry#json": "${StopOnEntry:true}",
+        "console": "integratedTerminal",
+        "args#json": "${args:[]}",
+        "env#json": "${env:{\\}}"
       },
       "breakpoints": {
         "exception": {


### PR DESCRIPTION
Initially I considered using #i, #s, etc. to coerce to specific types,
but then it wasn't clear of the semantics (particularly for bool, where
JSON bool true/false, Python bool True/False).

But it turns out that we can just coerce any key from a JSON string.
Users can _probably_ type JSON strings for most things, or use variables
to run scripts to generate them, this allows essentially complete
flexibility to define the data types needed to populate the launch spec.

The purpose of this is to allow some level of automated setup by
requesting data from the user and then (subsequently) saving the
flattneed config to the vimspector config file.

TODO:

- [ ] Update the docs
- [ ] add some tests (maybe pytest for these things)

This is stage 1 in providing better support for initial setups and guided or automated setup.