### PR TITLE
Fix neovim (again) - incompatible exception behaviour

### DIFF
--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -348,14 +348,11 @@ class ProjectBreakpoints( object ):
                 f"Invalid value for exception breakpoint filter '{f}': "
                 f"'{result}'. Must be boolean, 'Y', 'N' or '' (default)" )
           else:
-            try:
-              result = utils.AskForInput(
-                "{}: Break on {} (Y/N/default: {})? ".format( f[ 'filter' ],
-                                                              f[ 'label' ],
-                                                              default_value ),
-                default_value )
-            except KeyboardInterrupt:
-              result = ''
+            result = utils.AskForInput(
+              "{}: Break on {} (Y/N/default: {})? ".format( f[ 'filter' ],
+                                                            f[ 'label' ],
+                                                            default_value ),
+              default_value )
 
           if result == 'Y':
             exception_filters.append( f[ 'filter' ] )

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -339,7 +339,7 @@ def SelectFromList( prompt, options ):
       if selection < 0 or selection >= len( options ):
         return None
       return options[ selection ]
-    except KeyboardInterrupt:
+    except ( KeyboardInterrupt, vim.error ):
       return None
 
 
@@ -353,7 +353,7 @@ def AskForInput( prompt, default_value = None ):
     try:
       return vim.eval( "input( '{}' {} )".format( Escape( prompt ),
                                                   default_option ) )
-    except KeyboardInterrupt:
+    except ( KeyboardInterrupt, vim.error ):
       return None
 
 
@@ -732,7 +732,7 @@ def GetVimValue( vim_dict, name, default=None ):
   # FIXME: use 'encoding' ?
   try:
     value = vim_dict[ name ]
-  except KeyError:
+  except ( KeyError, vim.error ):
     return default
 
   if isinstance( value, bytes ):
@@ -743,7 +743,7 @@ def GetVimValue( vim_dict, name, default=None ):
 def GetVimList( vim_dict, name, default=None ):
   try:
     value = vim_dict[ name ]
-  except KeyError:
+  except ( KeyError, vim.error ):
     return default
 
   if not isinstance( value, collections.abc.Iterable ):


### PR DESCRIPTION
Neovim does not raise:

* KeyError when accessing a vim dict
* KeyboardInterrupt when ctrl-c at a prompt

Instead it raises some internal subclass of vim.errro which cannot
easily be identified, so we just catch any vim.error.

Fixes #236