### PR TITLE
Fix balloon display

### DIFF
--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -624,9 +624,9 @@ def ParseVariables( variables_list,
 def DisplayBaloon( is_term, display ):
   if not is_term:
     display = '\n'.join( display )
-
-  # Remove balloon
-  vim.eval( "balloon_show( '' )" )
+    # To enable the Windows GUI to display the balloon correctly
+    # Refer https://github.com/vim/vim/issues/1512#issuecomment-492070685
+    vim.eval( "balloon_show( '' )" )
 
   vim.eval( "balloon_show( {0} )".format(
     json.dumps( display ) ) )

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -625,6 +625,9 @@ def DisplayBaloon( is_term, display ):
   if not is_term:
     display = '\n'.join( display )
 
+  # Remove balloon
+  vim.eval( "balloon_show( '' )")
+
   vim.eval( "balloon_show( {0} )".format(
     json.dumps( display ) ) )
 

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -626,7 +626,7 @@ def DisplayBaloon( is_term, display ):
     display = '\n'.join( display )
 
   # Remove balloon
-  vim.eval( "balloon_show( '' )")
+  vim.eval( "balloon_show( '' )" )
 
   vim.eval( "balloon_show( {0} )".format(
     json.dumps( display ) ) )


### PR DESCRIPTION
Fixed an issue where `...` kept showing up in the balloon.

Before:
![vimspector_before](https://user-images.githubusercontent.com/16581287/91630279-ec1b3500-ea0a-11ea-81d0-2de3ece98c97.gif)

After:
![vimspector_after](https://user-images.githubusercontent.com/16581287/91630281-ef162580-ea0a-11ea-8bd9-3c739db3bef8.gif)

### Describe the bug

No information was displayed in the balloon view.

It kept showing `...` was displayed.

Solution: call `balloon_show("")` once and remove the `...` balloon.


### Minimal reproduciton

1. Run `gvim.exe -Nu mini_vimrc main.py` (`/support/test/python/simple_python/main.py`)

```
" min_vimrc
set encoding=utf-8
scriptencoding utf-8

syntax enable
filetype plugin indent on

set nocompatible

set ambiwidth=double

set runtimepath^=~\ghq\github.com\puremourning\vimspector

nmap <F5> <Plug>VimspectorContinue
nmap <C-m> <Plug>VimspectorToggleBreakpoint

colorscheme murphy

language messages en
```

1. Put the breakpoint on line 15.
2. Press `<F5>`. (Start)
3. Place the cursor on the variable B. (Balloon Display)
4. `...` is displayed and continues.

Use the following Vimspector config file:

```
{
  "configurations": {
    "run - $current.py": {
      "adapter": "debugpy",
      "configuration": {
        "request": "launch",
        "type": "python",
        "cwd": "${cwd}",
        "program": "${file}",
        "stopOnEntry": false,
        "console": "integratedTerminal"
      },
      "breakpoints": {
        "exception": {
          "raised": "N",
          "uncaught": "",
          "userUnhandled": ""
        }
      }
    }
  }
}
```


### Expected behaviour

I want it to appear as follows.

```
Type: int
Value: 0
```


### Actual behaviour

`...` is displayed and continues.

#### Vimspector log (~/.vimspector.log)

```
2020-08-29 15:01:21,592 - INFO - **** INITIALISING NEW VIMSPECTOR SESSION ****
2020-08-29 15:01:21,592 - INFO - API is: 
2020-08-29 15:01:21,592 - INFO - VIMSPECTOR_HOME = C:\Users\tamago324\ghq\github.com\puremourning\vimspector
2020-08-29 15:01:21,592 - INFO - gadgetDir = C:\Users\tamago324\ghq\github.com\puremourning\vimspector\gadgets\windows
2020-08-29 15:01:21,593 - DEBUG - Toggle found bp at C:\Users\tamago324\ghq\github.com\puremourning\vimspector\support\test\python\simple_python\main.py:15 ? False (New)
2020-08-29 15:01:22,963 - INFO - User requested start debug session with {}
2020-08-29 15:01:22,963 - DEBUG - Reading gadget config: C:\Users\tamago324\ghq\github.com\puremourning\vimspector\gadgets\windows\.gadgets.json
2020-08-29 15:01:22,965 - DEBUG - Reading gadget config: None
2020-08-29 15:01:22,967 - DEBUG - Reading configurations from: None
2020-08-29 15:01:22,967 - DEBUG - Reading configurations from: C:\Users\tamago324\ghq\github.com\puremourning\vimspector\support\test\python\simple_python\.vimspector.json
2020-08-29 15:01:25,581 - INFO - Configuration: {"adapter": "debugpy", "configuration": {"request": "launch", "type": "python", "cwd": "C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python", "program": "C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py", "stopOnEntry": false, "console": "integratedTerminal"}, "breakpoints": {"exception": {"raised": "N", "uncaught": "", "userUnhandled": ""}}}
2020-08-29 15:01:25,581 - INFO - Adapter: {"command": ["C:\\Users\\tamago324\\.pyenv\\pyenv-win\\versions\\3.8.1\\python.exe", "C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\gadgets\\windows/debugpy/build/lib/debugpy/adapter"], "configuration": {"python": "C:\\Users\\tamago324\\.pyenv\\pyenv-win\\versions\\3.8.1\\python.exe", "subProcess": false}, "name": "debugpy"}
2020-08-29 15:01:25,601 - INFO - Starting debug adapter with: {"command": ["C:\\Users\\tamago324\\.pyenv\\pyenv-win\\versions\\3.8.1\\python.exe", "C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\gadgets\\windows/debugpy/build/lib/debugpy/adapter"], "configuration": {"python": "C:\\Users\\tamago324\\.pyenv\\pyenv-win\\versions\\3.8.1\\python.exe", "subProcess": false}, "name": "debugpy"}
2020-08-29 15:01:25,627 - INFO - Debug Adapter Started
2020-08-29 15:01:25,627 - DEBUG - Sending Message: {"command": "initialize", "arguments": {"adapterID": "debugpy", "clientID": "vimspector", "clientName": "vimspector", "linesStartAt1": true, "columnsStartAt1": true, "locale": "en_GB", "pathFormat": "path", "supportsVariableType": true, "supportsVariablePaging": false, "supportsRunInTerminalRequest": true}, "seq": 0, "type": "request"}
2020-08-29 15:01:25,804 - DEBUG - Message received: {'seq': 1, 'type': 'event', 'event': 'output', 'body': {'category': 'telemetry', 'output': 'ptvsd', 'data': {'packageVersion': '0+untagged.754.ge900938'}}}
2020-08-29 15:01:25,806 - DEBUG - Message received: {'seq': 2, 'type': 'event', 'event': 'output', 'body': {'category': 'telemetry', 'output': 'debugpy', 'data': {'packageVersion': '0+untagged.754.ge900938'}}}
2020-08-29 15:01:25,806 - DEBUG - Message received: {'seq': 3, 'type': 'response', 'request_seq': 0, 'success': True, 'command': 'initialize', 'body': {'supportsCompletionsRequest': True, 'supportsConditionalBreakpoints': True, 'supportsConfigurationDoneRequest': True, 'supportsDebuggerProperties': True, 'supportsDelayedStackTraceLoading': True, 'supportsEvaluateForHovers': True, 'supportsExceptionInfoRequest': True, 'supportsExceptionOptions': True, 'supportsHitConditionalBreakpoints': True, 'supportsLogPoints': True, 'supportsModulesRequest': True, 'supportsSetExpression': True, 'supportsSetVariable': True, 'supportsValueFormattingOptions': True, 'supportsTerminateDebuggee': True, 'supportsGotoTargetsRequest': True, 'exceptionBreakpointFilters': [{'filter': 'raised', 'label': 'Raised Exceptions', 'default': False}, {'filter': 'uncaught', 'label': 'Uncaught Exceptions', 'default': True}]}}
2020-08-29 15:01:25,806 - DEBUG - LAUNCH!
2020-08-29 15:01:25,806 - DEBUG - Sending Message: {"command": "launch", "arguments": {"python": "C:\\Users\\tamago324\\.pyenv\\pyenv-win\\versions\\3.8.1\\python.exe", "subProcess": false, "request": "launch", "type": "python", "cwd": "C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python", "program": "C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py", "stopOnEntry": false, "console": "integratedTerminal", "name": "test"}, "seq": 1, "type": "request"}
2020-08-29 15:01:25,808 - DEBUG - Message received: {'seq': 4, 'type': 'request', 'command': 'runInTerminal', 'arguments': {'kind': 'integrated', 'title': 'Python Debug Console', 'args': ['C:\\Users\\tamago324\\.pyenv\\pyenv-win\\versions\\3.8.1\\python.exe', 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\gadgets\\windows\\debugpy\\build\\lib\\debugpy\\launcher', '53073', '--', 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py'], 'env': {}, 'cwd': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python'}}
2020-08-29 15:01:25,892 - DEBUG - Sending Message: {"seq": 2, "type": "response", "request_seq": 4, "command": "runInTerminal", "body": {"processId": 10484}, "success": true}
2020-08-29 15:01:26,833 - DEBUG - Message received: {'seq': 5, 'type': 'event', 'event': 'initialized'}
2020-08-29 15:01:26,833 - DEBUG - Sending Message: {"command": "setBreakpoints", "arguments": {"source": {"name": "main.py", "path": "C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py"}, "breakpoints": [{"line": 15}]}, "sourceModified": false, "seq": 3, "type": "request"}
2020-08-29 15:01:26,834 - DEBUG - Sending Message: {"command": "setExceptionBreakpoints", "arguments": {"filters": ["uncaught"], "exceptionOptions": []}, "seq": 4, "type": "request"}
2020-08-29 15:01:26,839 - DEBUG - Message received: {'seq': 6, 'type': 'response', 'request_seq': 3, 'success': True, 'command': 'setBreakpoints', 'body': {'breakpoints': [{'verified': True, 'id': 0, 'source': {'name': 'main.py', 'path': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py'}, 'line': 15}]}}
2020-08-29 15:01:26,840 - DEBUG - Breakpoints at this point: {
  "C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py": [
    {
      "verified": true,
      "id": 0,
      "source": {
        "name": "main.py",
        "path": "C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py"
      },
      "line": 15
    }
  ]
}
2020-08-29 15:01:26,840 - DEBUG - Message received: {'seq': 7, 'type': 'response', 'request_seq': 4, 'success': True, 'command': 'setExceptionBreakpoints'}
2020-08-29 15:01:26,840 - DEBUG - Sending Message: {"command": "configurationDone", "seq": 5, "type": "request"}
2020-08-29 15:01:26,844 - DEBUG - Message received: {'seq': 8, 'type': 'response', 'request_seq': 5, 'success': True, 'command': 'configurationDone'}
2020-08-29 15:01:26,844 - DEBUG - Message received: {'seq': 9, 'type': 'response', 'request_seq': 1, 'success': True, 'command': 'launch'}
2020-08-29 15:01:26,844 - DEBUG - Sending Message: {"command": "threads", "seq": 6, "type": "request"}
2020-08-29 15:01:26,844 - DEBUG - Message received: {'seq': 10, 'type': 'event', 'event': 'process', 'body': {'startMethod': 'launch', 'isLocalProcess': True, 'systemProcessId': 15600, 'name': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py', 'pointerSize': 32}}
2020-08-29 15:01:26,845 - INFO - User Msg: The debugee was started: C:\Users\tamago324\ghq\github.com\puremourning\vimspector\support\test\python\simple_python\main.py
2020-08-29 15:01:26,851 - DEBUG - Message received: {'seq': 11, 'type': 'event', 'event': 'thread', 'body': {'reason': 'started', 'threadId': 1}}
2020-08-29 15:01:26,852 - DEBUG - Message received: {'seq': 12, 'type': 'response', 'request_seq': 6, 'success': True, 'command': 'threads', 'body': {'threads': [{'id': 1, 'name': 'MainThread'}]}}
2020-08-29 15:01:26,852 - DEBUG - Sending Message: {"command": "stackTrace", "arguments": {"threadId": 1}, "seq": 7, "type": "request"}
2020-08-29 15:01:26,953 - DEBUG - Message received: {'seq': 13, 'type': 'response', 'request_seq': 7, 'success': True, 'command': 'stackTrace', 'body': {'stackFrames': [{'id': 2, 'name': 'DoSomething', 'line': 15, 'column': 1, 'source': {'path': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py', 'sourceReference': 0}}, {'id': 3, 'name': '__init__', 'line': 8, 'column': 1, 'source': {'path': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py', 'sourceReference': 0}}, {'id': 4, 'name': 'Main', 'line': 23, 'column': 1, 'source': {'path': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py', 'sourceReference': 0}}, {'id': 5, 'name': '<module>', 'line': 29, 'column': 1, 'source': {'path': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py', 'sourceReference': 0}}], 'totalFrames': 4}}
2020-08-29 15:01:26,959 - DEBUG - Sending Message: {"command": "scopes", "arguments": {"frameId": 2}, "seq": 8, "type": "request"}
2020-08-29 15:01:26,959 - DEBUG - Message received: {'seq': 14, 'type': 'event', 'event': 'stopped', 'body': {'reason': 'breakpoint', 'threadId': 1, 'preserveFocusHint': False, 'allThreadsStopped': True}}
2020-08-29 15:01:26,959 - WARNING - User Msg: Paused in thread 1 due to breakpoint
2020-08-29 15:01:26,968 - DEBUG - Sending Message: {"command": "stackTrace", "arguments": {"threadId": 1}, "seq": 9, "type": "request"}
2020-08-29 15:01:26,968 - DEBUG - Message received: {'seq': 15, 'type': 'event', 'event': 'module', 'body': {'reason': 'new', 'module': {'id': 0, 'name': '__main__', 'path': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py'}}}
2020-08-29 15:01:26,968 - DEBUG - Message received: {'seq': 16, 'type': 'event', 'event': 'module', 'body': {'reason': 'new', 'module': {'id': 1, 'name': 'runpy', 'path': 'C:\\Users\\tamago324\\.pyenv\\pyenv-win\\versions\\3.8.1\\Lib\\runpy.py'}}}
2020-08-29 15:01:26,970 - DEBUG - Message received: {'seq': 17, 'type': 'response', 'request_seq': 8, 'success': True, 'command': 'scopes', 'body': {'scopes': [{'name': 'Locals', 'variablesReference': 6, 'expensive': False, 'presentationHint': 'locals', 'source': {}}, {'name': 'Globals', 'variablesReference': 7, 'expensive': False, 'source': {}}]}}
2020-08-29 15:01:26,970 - DEBUG - Sending Message: {"command": "variables", "arguments": {"variablesReference": 6}, "seq": 10, "type": "request"}
2020-08-29 15:01:26,970 - DEBUG - Message received: {'seq': 18, 'type': 'response', 'request_seq': 9, 'success': True, 'command': 'stackTrace', 'body': {'stackFrames': [{'id': 2, 'name': 'DoSomething', 'line': 15, 'column': 1, 'source': {'path': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py', 'sourceReference': 0}}, {'id': 3, 'name': '__init__', 'line': 8, 'column': 1, 'source': {'path': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py', 'sourceReference': 0}}, {'id': 4, 'name': 'Main', 'line': 23, 'column': 1, 'source': {'path': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py', 'sourceReference': 0}}, {'id': 5, 'name': '<module>', 'line': 29, 'column': 1, 'source': {'path': 'C:\\Users\\tamago324\\ghq\\github.com\\puremourning\\vimspector\\support\\test\\python\\simple_python\\main.py', 'sourceReference': 0}}], 'totalFrames': 4}}
2020-08-29 15:01:26,971 - DEBUG - Sending Message: {"command": "scopes", "arguments": {"frameId": 2}, "seq": 11, "type": "request"}
2020-08-29 15:01:27,018 - DEBUG - Message received: {'seq': 19, 'type': 'response', 'request_seq': 10, 'success': True, 'command': 'variables', 'body': {'variables': [{'name': 'i', 'value': '0', 'type': 'int', 'evaluateName': 'i', 'variablesReference': 0}, {'name': 'self', 'value': '<__main__.TestClass object at 0x048F2808>', 'type': 'TestClass', 'evaluateName': 'self', 'variablesReference': 8}]}}
2020-08-29 15:01:27,018 - DEBUG - Message received: {'seq': 20, 'type': 'response', 'request_seq': 11, 'success': True, 'command': 'scopes', 'body': {'scopes': [{'name': 'Locals', 'variablesReference': 6, 'expensive': False, 'presentationHint': 'locals', 'source': {}}, {'name': 'Globals', 'variablesReference': 7, 'expensive': False, 'source': {}}]}}
2020-08-29 15:01:27,018 - DEBUG - Sending Message: {"command": "variables", "arguments": {"variablesReference": 6}, "seq": 12, "type": "request"}
2020-08-29 15:01:27,066 - DEBUG - Message received: {'seq': 21, 'type': 'response', 'request_seq': 12, 'success': True, 'command': 'variables', 'body': {'variables': [{'name': 'i', 'value': '0', 'type': 'int', 'evaluateName': 'i', 'variablesReference': 0}, {'name': 'self', 'value': '<__main__.TestClass object at 0x048F2808>', 'type': 'TestClass', 'evaluateName': 'self', 'variablesReference': 8}]}}
2020-08-29 15:01:29,964 - DEBUG - Sending Message: {"command": "evaluate", "arguments": {"expression": "i", "frameId": 2, "context": "hover"}, "seq": 13, "type": "request"}
2020-08-29 15:01:29,973 - DEBUG - Message received: {'seq': 22, 'type': 'response', 'request_seq': 13, 'success': True, 'command': 'evaluate', 'body': {'result': '0', 'variablesReference': 0, 'type': 'int', 'presentationHint': {}}}
2020-08-29 15:01:41,036 - DEBUG - Sending Message: {"command": "evaluate", "arguments": {"expression": "i", "frameId": 2, "context": "hover"}, "seq": 14, "type": "request"}
2020-08-29 15:01:41,053 - DEBUG - Message received: {'seq': 23, 'type': 'response', 'request_seq': 14, 'success': True, 'command': 'evaluate', 'body': {'result': '0', 'variablesReference': 0, 'type': 'int', 'presentationHint': {}}}
```


### Environemnt

* Version of Vimspector: 7a8bdef08874151acf4d06cfd249b4a917125d8c

* Output of `vim --version` or `nvim --version`

```
VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Apr 13 2020 22:13:23)
MS-Windows 32-bit GUI version with OLE support
Included patches: 1-577
Compiled by appveyor@APPVYR-WIN
Huge version with GUI.  Features included (+) or not (-):
+acl                +cmdline_compl      -ebcdic             +insert_expand      +mksession          +popupwin           +spell              -tgetent            +wildmenu
+arabic             +cmdline_hist       +emacs_tags         -ipv6               +modify_fname       -postscript         +startuptime        +timers             +windows
+autocmd            +cmdline_info       +eval               +job                +mouse              +printer            +statusline         +title              +writebackup
+autochdir          +comments           +ex_extra           +jumplist           +mouseshape         +profile            -sun_workshop       +toolbar            -xfontset
+autoservername     +conceal            +extra_search       +keymap             +multi_byte_ime/dyn +python/dyn         +syntax             +user_commands      -xim
+balloon_eval       +cryptv             -farsi              +lambda             +multi_lang         +python3/dyn        +tag_binary         +vartabs            +xpm_w32
-balloon_eval_term  +cscope             +file_in_path       +langmap            +mzscheme/dyn       +quickfix           -tag_old_static     +vertsplit          -xterm_save
+browse             +cursorbind         +find_in_path       +libcall            +netbeans_intg      +reltime            -tag_any_white      +virtualedit        
++builtin_terms     +cursorshape        +float              +linebreak          +num64              +rightleft          +tcl/dyn            +visual             
+byte_offset        +dialog_con_gui     +folding            +lispindent         +ole                +ruby/dyn           -termguicolors      +visualextra        
+channel            +diff               -footer             +listcmds           +packages           +scrollbind         +terminal           +viminfo            
+cindent            +digraphs           +gettext/dyn        +localmap           +path_extra         +signs              -termresponse       +vreplace           
+clientserver       +directx            -hangul_input       +lua/dyn            +perl/dyn           +smartindent        +textobjects        -vtp                
+clipboard          -dnd                +iconv/dyn          +menu               +persistent_undo    +sound              +textprop           +wildignore         
   system vimrc file: "$VIM\vimrc"
     user vimrc file: "$HOME\_vimrc"
 2nd user vimrc file: "$HOME\vimfiles\vimrc"
 3rd user vimrc file: "$VIM\_vimrc"
      user exrc file: "$HOME\_exrc"
  2nd user exrc file: "$VIM\_exrc"
  system gvimrc file: "$VIM\gvimrc"
    user gvimrc file: "$HOME\_gvimrc"
2nd user gvimrc file: "$HOME\vimfiles\gvimrc"
3rd user gvimrc file: "$VIM\_gvimrc"
       defaults file: "$VIMRUNTIME\defaults.vim"
    system menu file: "$VIMRUNTIME\menu.vim"
Compilation: cl -c /W3 /nologo  -I. -Iproto -DHAVE_PATHDEF -DWIN32  -DFEAT_CSCOPE -DFEAT_TERMINAL -DFEAT_SOUND -DFEAT_NETBEANS_INTG -DFEAT_JOB_CHANNEL   -DFEAT_XPM_W32   -DWINVER=0x0501 -D_WIN32_WINNT=0x0501 /source-charset:utf-8 /MP -DHAVE_STDINT_H /Ox /GL -DNDEBUG /arch:IA32 /Zl /MT /D_CRT_SECURE_NO_DEPRECATE /D_CRT_NONSTDC_NO_DEPRECATE -DFEAT_OLE -DFEAT_MBYTE_IME -DDYNAMIC_IME -DFEAT_GUI_MSWIN -DFEAT_DIRECTX -DDYNAMIC_DIRECTX -DFEAT_DIRECTX_COLOR_EMOJI -DDYNAMIC_ICONV -DDYNAMIC_GETTEXT -DFEAT_TCL -DDYNAMIC_TCL -DDYNAMIC_TCL_DLL=\"tcl86t.dll\" -DDYNAMIC_TCL_VER=\"8.6\" -DFEAT_LUA -DDYNAMIC_LUA -DDYNAMIC_LUA_DLL=\"lua53.dll\" -DFEAT_PYTHON -DDYNAMIC_PYTHON -DDYNAMIC_PYTHON_DLL=\"python27.dll\" -DFEAT_PYTHON3 -DDYNAMIC_PYTHON3 -DDYNAMIC_PYTHON3_DLL=\"python38.dll\" -DFEAT_MZSCHEME -I "C:\Program Files (x86)\Racket\include" -DMZ_PRECISE_GC -DDYNAMIC_MZSCHEME -DDYNAMIC_MZSCH_DLL=\"libracket3m_a36fs8.dll\" -DDYNAMIC_MZGC_DLL=\"libracket3m_a36fs8.dll\" -DFEAT_PERL -DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -DDYNAMIC_PERL -DDYNAMIC_PERL_DLL=\"perl528.dll\" -DFEAT_RUBY -DDYNAMIC_RUBY -DDYNAMIC_RUBY_DLL=\"msvcrt-ruby240.dll\" -DRUBY_VERSION=24 -DFEAT_HUGE /Fd.\ObjGXOULYHTRZi386/ /Zi
Linking: link  /nologo /opt:ref /LTCG:STATUS oldnames.lib kernel32.lib advapi32.lib shell32.lib gdi32.lib  comdlg32.lib ole32.lib netapi32.lib uuid.lib /machine:i386 gdi32.lib version.lib   winspool.lib comctl32.lib advapi32.lib shell32.lib netapi32.lib  /machine:i386  libcmt.lib oleaut32.lib user32.lib  /nodefaultlib:lua53.lib  /STACK:8388608  /nodefaultlib:python27.lib /nodefaultlib:python38.lib   "C:\Tcl\lib\tclstub86.lib" winmm.lib WSock32.lib Ws2_32.lib xpm\x86\lib-vc14\libXpm.lib /PDB:gvim.pdb -debug
```

* Output of `which vim` or `which nvim`:

```sh
> where vim
C:\Vim\vim82\vim.exe
```

* Output of `:py3 print( __import__( 'sys' ).version )`:

```
3.8.1 (tags/v3.8.1:1b293b6, Dec 18 2019, 22:39:24) [MSC v.1916 32 bit (Intel)]
```

* Output of `:py3 import vim`:

```
no output
```

* Output of `:py3 import vimspector`:

```
no output
```


* Operating system: Windows 10 64bit
  
### Declaration

* I have read and understood [CONTRIBUTING.md](https://github.com/puremourning/vimspector/blob/master/CONTRIBUTING.md) \[Yes/No] Yes

Thanks!
