### PR TITLE
Don't leak buffers when creating output view

### DIFF
--- a/tests/tabpage.test.vim
+++ b/tests/tabpage.test.vim
@@ -49,3 +49,103 @@ function! Test_Step_With_Different_Tabpage()
   %bwipeout!
 endfunction
 
+function! Test_All_Buffers_Deleted_NoHidden()
+  set nohidden
+  lcd testdata/cpp/simple
+  edit simple.cpp
+
+  let opts = #{ buflisted: v:true }
+
+  let buffers_before = getbufinfo( opts )
+
+  call setpos( '.', [ 0, 15, 1 ] )
+  call vimspector#ToggleBreakpoint()
+  call vimspector#Launch()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 15, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer(
+        \ 'simple.cpp',
+        \ 15 )
+
+  call vimspector#Reset()
+  call vimspector#test#setup#WaitForReset()
+
+  let buffers_after = getbufinfo( opts )
+
+  call assert_equal( len( buffers_before ), len( buffers_after ) )
+
+  set hidden&
+  lcd -
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+function! Test_All_Buffers_Deleted_Hidden()
+  set hidden
+  lcd testdata/cpp/simple
+  edit simple.cpp
+
+  let opts = #{ buflisted: v:true }
+
+  let buffers_before = getbufinfo( opts )
+
+  call setpos( '.', [ 0, 15, 1 ] )
+  call vimspector#ToggleBreakpoint()
+  call vimspector#Launch()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 15, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer(
+        \ 'simple.cpp',
+        \ 15 )
+
+  call vimspector#Reset()
+  call vimspector#test#setup#WaitForReset()
+
+  let buffers_after = getbufinfo( opts )
+
+  call assert_equal( len( buffers_before ), len( buffers_after ) )
+
+  set hidden&
+  lcd -
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+function! Test_All_Buffers_Deleted_ToggleLog()
+  set hidden
+  let buffers_before = getbufinfo( #{ buflisted: 1 } )
+  VimspectorToggleLog
+  VimspectorToggleLog
+  let buffers_after = getbufinfo( #{ buflisted: 1 } )
+  call assert_equal( len( buffers_before ), len( buffers_after ) )
+
+  call vimspector#test#setup#Reset()
+  set hidden&
+  %bwipe!
+endfunction
+
+let g:vimspector_test_install_done = 0
+
+function! Test_All_Buffers_Deleted_Installer()
+  set hidden
+  let buffers_before = getbufinfo( #{ buflisted: 1 } )
+
+  augroup Test_All_Buffers_Deleted_Installer
+    au!
+    au User VimspectorInstallSuccess let g:vimspector_test_install_done = 1
+    au User VimspectorInstallFailed let g:vimspector_test_install_done = 1
+  augroup END
+
+  VimspectorUpdate
+
+  " The test timeout will take care of this taking too long
+  call WaitForAssert(
+        \ { -> assert_equal( 1, g:vimspector_test_install_done ) },
+        \ 120000 )
+
+  let buffers_after = getbufinfo( #{ buflisted: 1 } )
+  call assert_equal( len( buffers_before ), len( buffers_after ) )
+
+  call vimspector#test#setup#Reset()
+  set hidden&
+  au! Test_All_Buffers_Deleted_Installer
+  %bwipe!
+endfunction


### PR DESCRIPTION
We create a new window for the output view, then we use _CreateBuffer to create some buffers. This leaks the empty buffer that gets put in the output view.

This solution re-uses that empty buffer for the first output buffer created.

TODO:

* [x] Check that VimspectorToggleLog doesn't leak one too
* [x] Check that the installer doesn't leak one too.