### PR TITLE
Highlight the current line using linehl=CursorLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1370,7 +1370,7 @@ define them in your `vimrc`.
 | `vimspectorBP`         | Line breakpoint                     | 9        |
 | `vimspectorBPCond`     | Conditional line breakpiont         | 9        |
 | `vimspectorBPDisabled` | Disabled breakpoint                 | 9        |
-| `vimspectorPC`         | Program counter (i.e. current line) | 20       |
+| `vimspectorPC`         | Program counter (i.e. current line) | 200      |
 
 The default symbols are the equivalent of something like the following:
 
@@ -1378,7 +1378,7 @@ The default symbols are the equivalent of something like the following:
 sign define vimspectorBP         text=\ ● texthl=WarningMsg
 sign define vimspectorBPCond     text=\ ◆ texthl=WarningMsg
 sign define vimspectorBPDisabled text=\ ● texthl=LineNr
-sign define vimspectorPC         text=\ ▶ texthl=MatchParen
+sign define vimspectorPC         text=\ ▶ texthl=MatchParen linehl=CursorLine
 ```
 
 If the signs don't display properly, your font probably doesn't contain these

--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -383,7 +383,6 @@ class ProjectBreakpoints( object ):
         signs.PlaceSign( bp[ 'sign_id' ],
                          'VimspectorBP',
                          sign,
-                         9,
                          file_name,
                          bp[ 'line' ] )
 

--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -78,7 +78,6 @@ class CodeView( object ):
       signs.PlaceSign( self._signs[ 'vimspectorPC' ],
                        'VimspectorCode',
                        'vimspectorPC',
-                       20,
                        frame[ 'source' ][ 'path' ],
                        frame[ 'line' ] )
     except vim.error as e:
@@ -184,7 +183,6 @@ class CodeView( object ):
                          'VimspectorCode',
                          'vimspectorBP' if breakpoint[ 'verified' ]
                                         else 'vimspectorBPDisabled',
-                         9,
                          file_name,
                          breakpoint[ 'line' ] )
 
@@ -248,9 +246,9 @@ class CodeView( object ):
       if term_options[ 'vertical' ] and not term_options.get( 'curwin', 0 ):
         term_options[ 'term_cols' ] = max(
           min ( int( vim.eval( 'winwidth( 0 )' ) )
-                     - settings.Int( 'code_minwidth', 82 ),
-                settings.Int( 'terminal_maxwidth', 80 ) ),
-          settings.Int( 'terminal_minwidth' , 10 )
+                     - settings.Int( 'code_minwidth' ),
+                settings.Int( 'terminal_maxwidth' ) ),
+          settings.Int( 'terminal_minwidth' )
         )
 
       buffer_number = int(

--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -53,7 +53,8 @@ class CodeView( object ):
       if not signs.SignDefined( 'vimspectorPC' ):
         signs.DefineSign( 'vimspectorPC',
                           text = '▶',
-                          texthl = 'MatchParen' )
+                          texthl = 'MatchParen',
+                          linehl = 'CursorLine' )
 
 
   def SetCurrentFrame( self, frame ):

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -510,7 +510,7 @@ class DebugSession( object ):
 
     # TODO: The UI code is too scattered. Re-organise into a UI class that
     # just deals with these thigns like window layout and custmisattion.
-    vim.command( f'botright { settings.Int( "bottombar_height", 10 ) }new' )
+    vim.command( f'botright { settings.Int( "bottombar_height" ) }new' )
     win = vim.current.window
     self._logView = output.OutputView( win, self._api_prefix )
     self._logView.AddLogFileView()
@@ -525,7 +525,7 @@ class DebugSession( object ):
       # and poking into each View class to check its window is valid also feels
       # wrong.
       with utils.LetCurrentTabpage( self._uiTab ):
-        vim.command( f'botright { settings.Int( "bottombar_height", 10 ) }new' )
+        vim.command( f'botright { settings.Int( "bottombar_height" ) }new' )
         self._outputView.UseWindow( vim.current.window )
         vim.vars[ 'vimspector_session_windows' ][ 'output' ] = utils.WindowID(
           vim.current.window,
@@ -568,7 +568,7 @@ class DebugSession( object ):
 
     # Call stack
     vim.command(
-      f'topleft vertical { settings.Int( "sidebar_width", 50 ) }new' )
+      f'topleft vertical { settings.Int( "sidebar_width" ) }new' )
     stack_trace_window = vim.current.window
     one_third = int( vim.eval( 'winheight( 0 )' ) ) / 3
     self._stackTraceView = stack_trace.StackTraceView( self,
@@ -594,7 +594,7 @@ class DebugSession( object ):
 
     # Output/logging
     vim.current.window = code_window
-    vim.command( f'rightbelow { settings.Int( "bottombar_height", 10 ) }new' )
+    vim.command( f'rightbelow { settings.Int( "bottombar_height" ) }new' )
     output_window = vim.current.window
     self._outputView = output.DAPOutputView( output_window,
                                              self._api_prefix )

--- a/python3/vimspector/installer.py
+++ b/python3/vimspector/installer.py
@@ -114,7 +114,7 @@ def RunInstaller( api_prefix, leave_open, *args, **kwargs ):
   _ResetInstaller()
 
   with utils.RestoreCurrentWindow():
-    vim.command( f'botright { settings.Int( "bottombar_height", 10 ) }new' )
+    vim.command( f'botright { settings.Int( "bottombar_height" ) }new' )
     win = vim.current.window
     OUTPUT_VIEW = output.OutputView( win, api_prefix )
 

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -28,7 +28,7 @@ DEFAULTS = {
 
   # Signs
   'sign_priority': {
-    'vimspectorPC':         20,
+    'vimspectorPC':         200,
     'vimspectorBP':         9,
     'vimspectorBPCond':     9,
     'vimspectorBPDisabled': 9,

--- a/python3/vimspector/signs.py
+++ b/python3/vimspector/signs.py
@@ -22,8 +22,8 @@ def DefineSign( name, text, texthl, col = 'right' ):
   vim.command( f'sign define { name } text={ text } texthl={ texthl }' )
 
 
-def PlaceSign( sign_id, group, name, priority, file, line ):
-  priority = settings.Dict( 'sign_priority' ).get( name, priority )
+def PlaceSign( sign_id, group, name, file, line ):
+  priority = settings.Dict( 'sign_priority' )[ name ]
 
   cmd = ( f'sign place { sign_id } '
           f'group={ group } '

--- a/python3/vimspector/signs.py
+++ b/python3/vimspector/signs.py
@@ -12,14 +12,18 @@ def SignDefined( name ):
   return False
 
 
-def DefineSign( name, text, texthl, col = 'right' ):
+def DefineSign( name, text, texthl, col = 'right', **kwargs ):
   if col == 'right':
     if int( utils.Call( 'strdisplaywidth', text ) ) < 2:
       text = ' ' + text
 
   text = text.replace( ' ', r'\ ' )
 
-  vim.command( f'sign define { name } text={ text } texthl={ texthl }' )
+  cmd = f'sign define { name } text={ text } texthl={ texthl }'
+  for key, value in kwargs.items():
+    cmd += f' { key }={ value }'
+
+  vim.command( cmd )
 
 
 def PlaceSign( sign_id, group, name, file, line ):

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -749,7 +749,6 @@ def GetVimList( vim_dict, name, default=None ):
   return [ i.decode( 'utf-8' ) if isinstance( i, bytes ) else i for i in value ]
 
 
-
 def GetVimspectorBase():
   return GetVimValue( vim.vars,
                      'vimspector_base_dir',

--- a/tests/breakpoints.test.vim
+++ b/tests/breakpoints.test.vim
@@ -631,6 +631,7 @@ function! Test_Custom_Breakpoint_Priority()
   call vimspector#test#setup#Reset()
   lcd -
   %bwipeout!
+  unlet! g:vimspector_sign_priority
 endfunction
 
 function! Test_Custom_Breakpoint_Priority_Partial()
@@ -717,8 +718,5 @@ function! Test_Custom_Breakpoint_Priority_Partial()
   call vimspector#test#setup#Reset()
   lcd -
   %bwipeout!
-endfunction
-
-function! TearDown_Test_Custom_Breakpoint_Priority()
   unlet! g:vimspector_sign_priority
 endfunction

--- a/tests/tabpage.test.vim
+++ b/tests/tabpage.test.vim
@@ -71,7 +71,12 @@ function! Test_All_Buffers_Deleted_NoHidden()
 
   let buffers_after = getbufinfo( opts )
 
-  call assert_equal( len( buffers_before ), len( buffers_after ) )
+  if assert_equal( len( buffers_before ), len( buffers_after ) )
+    call assert_report( 'Expected '
+                      \ . string( buffers_before )
+                      \ . ' but found '
+                      \ . string( buffers_after ) )
+  endif
 
   set hidden&
   lcd -
@@ -101,7 +106,12 @@ function! Test_All_Buffers_Deleted_Hidden()
 
   let buffers_after = getbufinfo( opts )
 
-  call assert_equal( len( buffers_before ), len( buffers_after ) )
+  if assert_equal( len( buffers_before ), len( buffers_after ) )
+    call assert_report( 'Expected '
+                      \ . string( buffers_before )
+                      \ . ' but found '
+                      \ . string( buffers_after ) )
+  endif
 
   set hidden&
   lcd -
@@ -115,7 +125,13 @@ function! Test_All_Buffers_Deleted_ToggleLog()
   VimspectorToggleLog
   VimspectorToggleLog
   let buffers_after = getbufinfo( #{ buflisted: 1 } )
-  call assert_equal( len( buffers_before ), len( buffers_after ) )
+
+  if assert_equal( len( buffers_before ), len( buffers_after ) )
+    call assert_report( 'Expected '
+                      \ . string( buffers_before )
+                      \ . ' but found '
+                      \ . string( buffers_after ) )
+  endif
 
   call vimspector#test#setup#Reset()
   set hidden&
@@ -142,7 +158,12 @@ function! Test_All_Buffers_Deleted_Installer()
         \ 120000 )
 
   let buffers_after = getbufinfo( #{ buflisted: 1 } )
-  call assert_equal( len( buffers_before ), len( buffers_after ) )
+  if assert_equal( len( buffers_before ), len( buffers_after ) )
+    call assert_report( 'Expected '
+                      \ . string( buffers_before )
+                      \ . ' but found '
+                      \ . string( buffers_after ) )
+  endif
 
   call vimspector#test#setup#Reset()
   set hidden&


### PR DESCRIPTION
Also, set the priority to > 100 as required in https://github.com/vim/vim/commit/39f7aa3c3124065b50f182b1d2f7ac92a0918656

This shows just a subtle highlight by default, but you can customise to use e.g. `debugPC` if you like.

Also centralise all the settings because they were getting out off hand.