### PR TITLE
Removed squared brackets in the README for conditional breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ See [the reference guide][vimspector-ref-config-selection] for details.
 
 ## Breakpoints
 
-* Use `vimspector#ToggleBreakpoint([ { 'condition': '<condition expr>' } ])`
+* Use `vimspector#ToggleBreakpoint( { 'condition': '<condition expr>' } )`
   to set/disable/delete a line breakpoint, with optional condition.
 * Use `vimspector#AddFunctionBreakpoint( '<name>' [, { 'condition': '<condition expr>' } ] )`
   to add a function breakpoint with optional condition.


### PR DESCRIPTION
I had the issue that my conditional breakpoints didn't work: https://github.com/puremourning/vimspector/issues/246
So I changed that in the README and removed the square brackets in the `BREAKPOINTS` section.