### PR TITLE
Support completion for console and watches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ For a tutorial and usage overview, take a look at the
     * [Stepping](#stepping)
     * [Variables and scopes](#variables-and-scopes)
     * [Watches](#watches)
+       * [Watch autocompletion](#watch-autocompletion)
     * [Stack Traces](#stack-traces)
     * [Program Output](#program-output)
        * [Console](#console)
+       * [Console autocompletion](#console-autocompletion)
        * [Log View](#log-view)
     * [Closing debugger](#closing-debugger)
  * [Debug adapter configuration](#debug-adapter-configuration)
@@ -77,7 +79,7 @@ For a tutorial and usage overview, take a look at the
  * [License](#license)
  * [Sponsorship](#sponsorship)
 
-<!-- Added by: ben, at: Tue  1 Sep 2020 13:42:32 BST -->
+<!-- Added by: ben, at: Fri  4 Sep 2020 00:48:17 BST -->
 
 <!--te-->
 
@@ -109,10 +111,10 @@ And a couple of brief demos:
 - launch and attach
 - remote launch, remote attach
 - locals and globals display
-- watch expressions
+- watch expressions with autocompletion
 - call stack display and navigation
 - variable value display hover
-- interactive debug console
+- interactive debug console with autocompletion
 - launch debugee within Vim's embedded terminal
 - logging/stdout display
 - simple stable API for custom tooling (e.g. integrate with language server)
@@ -742,6 +744,22 @@ to add a new watch expression.
 
 The watches are represented by the buffer `vimspector.StackTrace`.
 
+### Watch autocompletion
+
+The watch prompt buffer  has its `omnifunc` set to a function that will
+calcualte completion for the current expression. This is trivailly used with
+`<Ctrl-x><Ctrl-o>` (see `:help ins-completion`), or integrated with your
+favourite completion system. The filetype in the buffer is set to
+`VimspectorPrompt`.
+
+For YouCompleteMe, the following config works well:
+
+```viml
+let g:ycm_semantic_triggers =  {
+  \   'VimspectorPrompt': [ '.', '->', ':', '<' ]
+}
+```
+
 ## Stack Traces
 
 * In the threads window, use `<CR>` to expand/collapse.
@@ -781,6 +799,22 @@ NOTE: See also [Watches](#watches) above.
 
 If the output window is closed, a new one can be opened with
 `:VimspectorShowOutput Console`.
+
+### Console autocompletion
+
+The console prompt buffer has its `omnifunc` set to a function that will
+calcualte completion for the current command/expression. This is trivailly used
+with `<Ctrl-x><Ctrl-o>` (see `:help ins-completion`), or integrated with your
+favourite completion system. The filetype in the buffer is set to
+`VimspectorPrompt`.
+
+For YouCompleteMe, the following config works well:
+
+```viml
+let g:ycm_semantic_triggers =  {
+  \   'VimspectorPrompt': [ '.', '->', ':', '<' ]
+}
+```
 
 ### Log View
 

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -266,14 +266,17 @@ let s:latest_completion_request = {}
 
 function! vimspector#CompleteFuncSync( prompt, find_start, query ) abort
   if py3eval( 'not _vimspector_session' )
-    return []
+    if a:find_start
+      return -3
+    endif
+    return v:none
   endif
 
   if a:find_start
 
     " We're busy
     if !empty( s:latest_completion_request )
-      return -1
+      return -3
     endif
 
     let line = getline( line( '.' ) )[ len( a:prompt ) : ]

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -324,13 +324,13 @@ function! vimspector#CompleteFuncSync( prompt, find_start, query ) abort
     let s:latest_completion_request.start_pos = start_pos
     let s:latest_completion_request.prompt = a:prompt
 
-    call s:Debug( 'FindStart: %s', {
-          \ 'line': line,
-          \ 'col': col,
-          \ 'prompt': len( a:prompt ),
-          \ 'start_pos': start_pos,
-          \ 'returning': ( start_pos + len( a:prompt ) ) - 1,
-          \ } )
+    " call s:Debug( 'FindStart: %s', {
+    "       \ 'line': line,
+    "       \ 'col': col,
+    "       \ 'prompt': len( a:prompt ),
+    "       \ 'start_pos': start_pos,
+    "       \ 'returning': ( start_pos + len( a:prompt ) ) - 1,
+    "       \ } )
 
     " start_pos is 1-based and the return of findstart is 0-based
     return ( start_pos + len( a:prompt ) ) - 1
@@ -349,9 +349,9 @@ function! vimspector#CompleteFuncSync( prompt, find_start, query ) abort
       endif
 
       if item.length > len( a:query )
-        call s:Debug( 'Rejecting %s, length is greater than %s',
-              \ item,
-              \ len( a:query ) )
+        " call s:Debug( 'Rejecting %s, length is greater than %s',
+        "       \ item,
+        "       \ len( a:query ) )
         continue
       endif
 
@@ -363,7 +363,7 @@ function! vimspector#CompleteFuncSync( prompt, find_start, query ) abort
     endfor
     let s:latest_completion_request = {}
 
-    call s:Debug( 'Items: %s', items )
+    " call s:Debug( 'Items: %s', items )
     return { 'words': items, 'refresh': 'always' }
   endif
 endfunction

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -19,7 +19,7 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 " }}}
 
-function! s:Debug( ... )
+function! s:Debug( ... ) abort
   py3 <<EOF
 if _vimspector_session is not None:
   _vimspector_session._logger.debug( *vim.eval( 'a:000' ) )

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -554,8 +554,7 @@ class DebugSession( object ):
     # TODO:
     #  - start / length
     #  - sortText
-    return [ i.get( 'text' ) or i[ 'label' ]
-             for i in response[ 'body' ][ 'targets' ] ]
+    return response[ 'body' ][ 'targets' ]
 
 
   def _SetUpUI( self ):

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -940,13 +940,26 @@ class DebugSession( object ):
     if 'name' not in launch_config:
       launch_config[ 'name' ] = 'test'
 
+    def failure_handler( reason, msg ):
+      text = [
+        'Launch Failed',
+        '',
+        reason,
+        '',
+        'Use :VimspectorReset to close'
+      ]
+      self._splash_screen = utils.DisplaySplash( self._api_prefix,
+                                                 self._splash_screen,
+                                                 text )
+
+
     self._connection.DoRequest(
       lambda msg: self._OnLaunchComplete(),
       {
         'command': launch_config[ 'request' ],
         'arguments': launch_config
-      }
-    )
+      },
+      failure_handler )
 
 
   def _OnLaunchComplete( self ):

--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -407,14 +407,14 @@ GADGETS = {
       'url': 'https://marketplace.visualstudio.com/_apis/public/gallery/'
              'publishers/msjsdiag/vsextensions/'
              'debugger-for-chrome/${version}/vspackage',
-      'target': 'msjsdiag.debugger-for-chrome-4.12.0.vsix.gz',
+      'target': 'msjsdiag.debugger-for-chrome-4.12.10.vsix.gz',
       'format': 'zip.gz',
     },
     'all': {
-      'version': '4.12.0',
-      'file_name': 'msjsdiag.debugger-for-chrome-4.12.0.vsix',
+      'version': '4.12.10',
+      'file_name': 'msjsdiag.debugger-for-chrome-4.12.10.vsix',
       'checksum':
-        '0df2fe96d059a002ebb0936b0003e6569e5a5c35260dc3791e1657d27d82ccf5'
+        ''
     },
     'adapters': {
       'chrome': {

--- a/python3/vimspector/output.py
+++ b/python3/vimspector/output.py
@@ -192,7 +192,8 @@ class OutputView( object ):
         utils.SetUpPromptBuffer( tab_buffer.buf,
                                  name,
                                  '> ',
-                                 'vimspector#EvaluateConsole' )
+                                 'vimspector#EvaluateConsole',
+                                 'vimspector#OmniFuncConsole' )
       else:
         utils.SetUpHiddenBuffer( tab_buffer.buf, name )
 

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -135,7 +135,7 @@ def SetUpHiddenBuffer( buf, name ):
   buf.name = name
 
 
-def SetUpPromptBuffer( buf, name, prompt, callback ):
+def SetUpPromptBuffer( buf, name, prompt, callback, omnifunc ):
   # This feature is _super_ new, so only enable when available
   if not Exists( '*prompt_setprompt' ):
     return SetUpHiddenBuffer( buf, name )
@@ -148,6 +148,7 @@ def SetUpPromptBuffer( buf, name, prompt, callback ):
   buf.options[ 'buflisted' ] = False
   buf.options[ 'bufhidden' ] = 'hide'
   buf.options[ 'textwidth' ] = 0
+  buf.options[ 'omnifunc' ] = omnifunc
   buf.name = name
 
   vim.eval( "prompt_setprompt( {0}, '{1}' )".format( buf.number,
@@ -155,6 +156,12 @@ def SetUpPromptBuffer( buf, name, prompt, callback ):
   vim.eval( "prompt_setcallback( {0}, function( '{1}' ) )".format(
     buf.number,
     Escape( callback ) ) )
+
+  # This serves a few purposes, mainly to ensure that completion systems have
+  # something to work with. In particular it makes YCM use its identifier engine
+  # and you can config ycm to trigger semantic (annoyingly, synchronously) using
+  # some let g:ycm_auto_trggier
+  Call( 'setbufvar', buf.number, '&filetype', 'VimspectorPrompt' )
 
 
 def SetUpUIWindow( win ):

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -147,7 +147,8 @@ class VariablesView( object ):
     utils.SetUpPromptBuffer( self._watch.buf,
                              'vimspector.Watches',
                              'Expression: ',
-                             'vimspector#AddWatchPrompt' )
+                             'vimspector#AddWatchPrompt',
+                             'vimspector#OmniFuncWatch' )
     with utils.LetCurrentWindow( watches_win ):
       vim.command(
         'nnoremap <buffer> <CR> :call vimspector#ExpandVariable()<CR>' )

--- a/support/test/bash/test_script
+++ b/support/test/bash/test_script
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+function Test() {
+  echo $1
+}
+
+for i in "$@"; do
+  Test $i
+done

--- a/support/test/chrome/run_server
+++ b/support/test/chrome/run_server
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+php -S localhost:1234 -t www

--- a/support/test/chrome/www/js/test.js
+++ b/support/test/chrome/www/js/test.js
@@ -6,5 +6,12 @@ $( document ).ready( function() {
     return msg;
   };
 
-  alert( 'test: ' + getMessage() );
+  var obj = {
+    test: getMessage(),
+    toast: function() { return 'egg'; },
+    spam: 'ham'
+  };
+
+  alert( 'test: ' + obj.test );
+  alert( 'toast: ' + obj.toast() );
 } );

--- a/support/test/node/simple/simple.js
+++ b/support/test/node/simple/simple.js
@@ -1,3 +1,10 @@
 var msg = 'Hello, world!'
 
-console.log( "OK stuff happened" )
+var obj = {
+  test: 'testing',
+  toast: function() {
+    return 'toasty' . this.test;
+  }
+}
+
+console.log( "OK stuff happened " + obj.toast() )

--- a/tests/tabpage.test.vim
+++ b/tests/tabpage.test.vim
@@ -71,12 +71,8 @@ function! Test_All_Buffers_Deleted_NoHidden()
 
   let buffers_after = getbufinfo( opts )
 
-  if assert_equal( len( buffers_before ), len( buffers_after ) )
-    call assert_report( 'Expected '
-                      \ . string( buffers_before )
-                      \ . ' but found '
-                      \ . string( buffers_after ) )
-  endif
+  call WaitForAssert( {->
+        \ assert_equal( len( buffers_before ), len( buffers_after ) ) } )
 
   set hidden&
   lcd -
@@ -106,12 +102,8 @@ function! Test_All_Buffers_Deleted_Hidden()
 
   let buffers_after = getbufinfo( opts )
 
-  if assert_equal( len( buffers_before ), len( buffers_after ) )
-    call assert_report( 'Expected '
-                      \ . string( buffers_before )
-                      \ . ' but found '
-                      \ . string( buffers_after ) )
-  endif
+  call WaitForAssert( {->
+        \ assert_equal( len( buffers_before ), len( buffers_after ) ) } )
 
   set hidden&
   lcd -
@@ -126,12 +118,8 @@ function! Test_All_Buffers_Deleted_ToggleLog()
   VimspectorToggleLog
   let buffers_after = getbufinfo( #{ buflisted: 1 } )
 
-  if assert_equal( len( buffers_before ), len( buffers_after ) )
-    call assert_report( 'Expected '
-                      \ . string( buffers_before )
-                      \ . ' but found '
-                      \ . string( buffers_after ) )
-  endif
+  call WaitForAssert( {->
+        \ assert_equal( len( buffers_before ), len( buffers_after ) ) } )
 
   call vimspector#test#setup#Reset()
   set hidden&
@@ -158,12 +146,8 @@ function! Test_All_Buffers_Deleted_Installer()
         \ 120000 )
 
   let buffers_after = getbufinfo( #{ buflisted: 1 } )
-  if assert_equal( len( buffers_before ), len( buffers_after ) )
-    call assert_report( 'Expected '
-                      \ . string( buffers_before )
-                      \ . ' but found '
-                      \ . string( buffers_after ) )
-  endif
+  call WaitForAssert( {->
+        \ assert_equal( len( buffers_before ), len( buffers_after ) ) } )
 
   call vimspector#test#setup#Reset()
   set hidden&


### PR DESCRIPTION
Add omnifunc for prompt buffers

This synchronous completion can be used with any completion system
including built-in CTRL-X CTRL-O.

The filetype of the prompt buffers is set to VimspectorPrompt so that it
can be identified by completion systems. For example, this works well
with YCM:

let g:ycm_semantic_triggers =  {
  \   'VimspectorPrompt': [ '.', '->', ':', '<' ]
  \ }

closes #245 

TODO:

* [x] docs and examples
* [ ] lots of tests
* [x] fix command line completion as this is behaving erratically
* [x] test with many other servers to validate assumptions about offsets
* [ ] add an asynchronous version for use with _other_ completion systems ?