### PR TITLE
Display a different sign when there's a breakpoint on the PC line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1405,6 +1405,7 @@ define them in your `vimrc`.
 | `vimspectorBPCond`     | Conditional line breakpiont         | 9        |
 | `vimspectorBPDisabled` | Disabled breakpoint                 | 9        |
 | `vimspectorPC`         | Program counter (i.e. current line) | 200      |
+| `vimspectorPCBP`       | Program counter and breakpoint      | 200      |
 
 The default symbols are the equivalent of something like the following:
 
@@ -1413,6 +1414,7 @@ sign define vimspectorBP         text=\ ● texthl=WarningMsg
 sign define vimspectorBPCond     text=\ ◆ texthl=WarningMsg
 sign define vimspectorBPDisabled text=\ ● texthl=LineNr
 sign define vimspectorPC         text=\ ▶ texthl=MatchParen linehl=CursorLine
+sign define vimspectorPCBP       text=●▶  texthl=MatchParen linehl=CursorLine
 ```
 
 If the signs don't display properly, your font probably doesn't contain these
@@ -1420,10 +1422,11 @@ glyphs. You can easily change them by deifining the sign in your vimrc. For
 example, you could put this in your `vimrc` to use some simple ASCII symbols:
 
 ```viml
-sign define vimspectorBP text==>         texthl=WarningMsg
-sign define vimspectorBPCond text=?>     texthl=WarningMsg
-sign define vimspectorBPDisabled text=!> texthl=LineNr
-sign define vimspectorPC text=->         texthl=MatchParen
+sign define vimspectorBP text=o          texthl=WarningMsg
+sign define vimspectorBPCond text=o?     texthl=WarningMsg
+sign define vimspectorBPDisabled text=o! texthl=LineNr
+sign define vimspectorPC text=\ >        texthl=MatchParen
+sign define vimspectorPCBP text=o>       texthl=MatchParen
 ```
 
 ## Sign priority

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -29,6 +29,7 @@ DEFAULTS = {
   # Signs
   'sign_priority': {
     'vimspectorPC':         200,
+    'vimspectorPCBP':       200,
     'vimspectorBP':         9,
     'vimspectorBPCond':     9,
     'vimspectorBPDisabled': 9,

--- a/tests/breakpoints.test.vim
+++ b/tests/breakpoints.test.vim
@@ -551,6 +551,7 @@ endfunction
 function! Test_Custom_Breakpoint_Priority()
   let g:vimspector_sign_priority = {
         \ 'vimspectorPC': 1,
+        \ 'vimspectorPCBP': 1,
         \ 'vimspectorBP': 2,
         \ 'vimspectorBPCond': 3,
         \ 'vimspectorBPDisabled': 4
@@ -597,7 +598,7 @@ function! Test_Custom_Breakpoint_Priority()
   call vimspector#test#signs#AssertSignAtLine(
         \ 'VimspectorCode',
         \ 15,
-        \ 'vimspectorPC',
+        \ 'vimspectorPCBP',
         \ 1 )
   call vimspector#test#signs#AssertSignGroupSingletonAtLine( 'VimspectorCode',
                                                            \ 17,
@@ -626,7 +627,7 @@ function! Test_Custom_Breakpoint_Priority()
   call vimspector#test#signs#AssertSignAtLine(
         \ 'VimspectorCode',
         \ 17,
-        \ 'vimspectorPC',
+        \ 'vimspectorPCBP',
         \ 1 )
 
 
@@ -684,7 +685,7 @@ function! Test_Custom_Breakpoint_Priority_Partial()
   call vimspector#test#signs#AssertSignAtLine(
         \ 'VimspectorCode',
         \ 15,
-        \ 'vimspectorPC',
+        \ 'vimspectorPCBP',
         \ 200 )
   call vimspector#test#signs#AssertSignGroupSingletonAtLine( 'VimspectorCode',
                                                            \ 17,
@@ -713,7 +714,7 @@ function! Test_Custom_Breakpoint_Priority_Partial()
   call vimspector#test#signs#AssertSignAtLine(
         \ 'VimspectorCode',
         \ 17,
-        \ 'vimspectorPC',
+        \ 'vimspectorPCBP',
         \ 200 )
 
 

--- a/tests/lib/autoload/vimspector/test/signs.vim
+++ b/tests/lib/autoload/vimspector/test/signs.vim
@@ -32,7 +32,7 @@ function! vimspector#test#signs#AssertPCIsAtLineInBuffer( buffer, line ) abort
   let index = 0
   while index < len( signs[ 0 ].signs )
     let s = signs[ 0 ].signs[ index ]
-    if s.name ==# 'vimspectorPC'
+    if s.name ==# 'vimspectorPC' || s.name ==# 'vimspectorPCBP'
       if assert_false( pc_index >= 0, 'Too many PC signs' )
         return 1
       endif


### PR DESCRIPTION
Vim only renders a single sign-per-line. If we have the PC _and_ a
breakpoint, we should make that clear. Do this using a vimspectorPCBP
sign which combines both vimspectorPC and vimspectorBP (sort of).

We can't (unfortuantely) render the breakpoint blob in a different
colour, but it's at least obvious when we toggle on the PC line.

Fixes #257 