### PR TITLE
Fix breakpoint event

### DIFF
--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -183,7 +183,7 @@ function! vimspector#Evaluate( expr ) abort
     return
   endif
   py3 _vimspector_session.ShowOutput( 'Console' )
-  py3 _vimspector_session.EvaluateConsole( vim.eval( 'a:expr' ) )
+  py3 _vimspector_session.EvaluateConsole( vim.eval( 'a:expr' ), True )
 endfunction
 
 function! vimspector#EvaluateConsole( expr ) abort
@@ -192,7 +192,7 @@ function! vimspector#EvaluateConsole( expr ) abort
   endif
   stopinsert
   setlocal nomodified
-  py3 _vimspector_session.EvaluateConsole( vim.eval( 'a:expr' ) )
+  py3 _vimspector_session.EvaluateConsole( vim.eval( 'a:expr' ), False )
 endfunction
 
 function! vimspector#ShowOutput( ... ) abort

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -467,9 +467,10 @@ class DebugSession( object ):
                                   expression )
 
   @IfConnected()
-  def EvaluateConsole( self, expression ):
+  def EvaluateConsole( self, expression, verbose ):
     self._outputView.Evaluate( self._stackTraceView.GetCurrentFrame(),
-                               expression )
+                               expression,
+                               verbose )
 
   @IfConnected()
   def DeleteWatch( self ):

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -1050,7 +1050,9 @@ class DebugSession( object ):
     if reason == 'changed':
       self._codeView.UpdateBreakpoint( bp )
     elif reason == 'new':
-      self._codeView.AddBreakpoints( None, bp )
+      self._codeView.AddBreakpoint( bp )
+    elif reason == 'removed':
+      self._codeView.RemoveBreakpoint( bp )
     else:
       utils.UserMessage(
         'Unrecognised breakpoint event (undocumented): {0}'.format( reason ),

--- a/python3/vimspector/output.py
+++ b/python3/vimspector/output.py
@@ -260,14 +260,18 @@ class DAPOutputView( OutputView ):
     # Don't clear because output is probably still useful
     self._connection = None
 
-  def Evaluate( self, frame, expression ):
-    self._Print( 'Console', [ 'Evaluating: ' + expression ] )
+  def Evaluate( self, frame, expression, verbose ):
+    if verbose:
+      self._Print( 'Console', f"Evaluating: { expression }" )
 
     def print_result( message ):
       result = message[ 'body' ][ 'result' ]
       if result is None:
         result = '<no result>'
-      self._Print( 'Console', f'  Result: { result }' )
+      self._Print( 'Console', result.splitlines() )
+
+    def print_failure( reason, msg ):
+      self._Print( 'Console', reason.splitlines() )
 
     request = {
       'command': 'evaluate',
@@ -280,4 +284,6 @@ class DAPOutputView( OutputView ):
     if frame:
       request[ 'arguments' ][ 'frameId' ] = frame[ 'id' ]
 
-    self._connection.DoRequest( print_result, request )
+    self._connection.DoRequest( print_result,
+                                request,
+                                print_failure )

--- a/tests/testdata/cpp/simple/.vimspector.json
+++ b/tests/testdata/cpp/simple/.vimspector.json
@@ -68,6 +68,45 @@
           "CALCULATED_STR", "${CALCULATED_STR}"
         ]
       }
+    },
+    "lldb-vscode": {
+      "adapter": "lldb-vscode",
+      "configuration": {
+        "request": "launch",
+        "program": "${workspaceRoot}/${fileBasenameNoExtension}",
+        "cwd": "${workspaceRoot}",
+        "externalConsole": false,
+        "MIMode": "lldb"
+      }
+    },
+    "CodeLLDB": {
+      "adapter": "CodeLLDB",
+      "configuration": {
+        "request": "launch",
+        "program": "${workspaceRoot}/${fileBasenameNoExtension}",
+        "cwd": "${workspaceRoot}",
+        "expressions": "native"
+      }
+    }
+  },
+  "adapters": {
+    "lldb-vscode": {
+      "variables": {
+        "LLVM": {
+          "shell": "brew --prefix llvm"
+        }
+      },
+      "attach": {
+        "pidProperty": "pid",
+        "pidSelect": "ask"
+      },
+      "command": [
+        "${LLVM}/bin/lldb-vscode"
+      ],
+      "env": {
+        "LLDB_LAUNCH_FLAG_LAUNCH_IN_TTY": "YES"
+      },
+      "name": "lldb"
     }
   }
 }

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -499,7 +499,7 @@ function Test_EvaluateConsole()
   call WaitForAssert( {->
         \   assert_equal(
         \     [
-        \       '  Result: 1'
+        \       '1'
         \     ],
         \     getbufline( bufnr( 'vimspector.Console' ), '$', '$' )
         \   )
@@ -511,9 +511,55 @@ function Test_EvaluateConsole()
         \   assert_equal(
         \     [
         \       'Evaluating: t.i',
-        \       '  Result: 1'
+        \       '1'
         \     ],
         \     getbufline( bufnr( 'vimspector.Console' ), len-1, '$' )
+        \   )
+        \ } )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer(
+        \ 'vimspector.Console', len, v:null )
+
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+
+function Test_EvaluatePromptConsole()
+  let fn =  'testdata/cpp/simple/struct.cpp'
+  call s:StartDebugging( #{ fn: fn, line: 24, col: 1, launch: #{
+        \   configuration: 'run-to-breakpoint'
+        \ } } )
+
+  " Make sure the Test t is initialised
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 26, 1 )
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 27, 1 )
+
+  VimspectorShowOutput
+  call assert_equal( bufnr( 'vimspector.Console' ),
+                   \ winbufnr( g:vimspector_session_windows.output ) )
+
+  call feedkeys( "it.i\<CR>", 'xt' )
+  call WaitForAssert( {->
+        \   assert_equal(
+        \     [
+        \       '1'
+        \     ],
+        \     getbufline( bufnr( 'vimspector.Console' ), '$', '$' )
+        \   )
+        \ } )
+
+  let len = getbufinfo( 'vimspector.Console' )[ 0 ].linecount
+
+  call WaitForAssert( {->
+        \   assert_equal(
+        \     [
+        \       '> t.i',
+        \       '',
+        \       '1'
+        \     ],
+        \     getbufline( bufnr( 'vimspector.Console' ), len-2, '$' )
         \   )
         \ } )
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer(


### PR DESCRIPTION
Few problems:
 - we were passing a dict instead of a list of breakpoints
 - if the breakpoint had a source which was {} we crashed (even though this is clearly a break of the spec)
 - we didn't support the 'removed' event


Fixes #278 