### PR TITLE
Run to cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ And a couple of brief demos:
 - breakpoints (function, line and exception breakpoints)
 - conditional breakpoints (function, line)
 - step in/out/over/up, stop, restart
+- run to cursor
 - launch and attach
 - remote launch, remote attach
 - locals and globals display
@@ -552,6 +553,7 @@ features to set your own mappings. To that end, Vimspector defines the following
 * `<Plug>VimspectorStepOver`
 * `<Plug>VimspectorStepInto`
 * `<Plug>VimspectorStepOut`
+* `<Plug>VimspectorRunToCursor`
 
 These map roughly 1-1 with the API functions below.
 
@@ -612,6 +614,7 @@ let g:vimspector_enable_mappings = 'HUMAN'
 | `F9`         | Toggle line breakpoint on the current line.               | `vimspector#ToggleBreakpoint()`                              |
 | `<leader>F9` | Toggle conditional line breakpoint on the current line.   | `vimspector#ToggleBreakpoint( { trigger expr, hit count expr } )` |
 | `F8`         | Add a function breakpoint for the expression under cursor | `vimspector#AddFunctionBreakpoint( '<cexpr>' )`              |
+| `<leader>F8` | Run to Cursor                                             | `vimspector#RunToCursor()`                                   |
 | `F10`        | Step Over                                                 | `vimspector#StepOver()`                                      |
 | `F11`        | Step Into                                                 | `vimspector#StepInto()`                                      |
 | `F12`        | Step out of current function scope                        | `vimspector#StepOut()`                                       |
@@ -709,6 +712,12 @@ You can configure your choices in the `.vimspector.json`. See
 
 * Use `vimspector#ClearBreakpoints()`
   to clear all breakpoints including the memory of exception breakpoint choices.
+
+### Run to Cursor
+
+* Use `vimspector#RunToCursor` or `<leader><F8>`: this creates a temporary
+  breakpoint on the current line, then continues execution, clearing the
+  breakpiont when it is hit.
 
 ## Stepping
 

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -27,45 +27,57 @@ EOF
 endfunction
 
 
-let s:enabled = vimspector#internal#state#Reset()
+let s:enabled = v:null
+
+function! s:Initialised() abort
+  return s:enabled != v:null
+endfunction
+
+function! s:Enabled() abort
+  if !s:Initialised()
+    let s:enabled = vimspector#internal#state#Reset()
+  endif
+
+  return s:enabled
+endfunction
 
 function! vimspector#Launch() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.Start()
 endfunction
 
 function! vimspector#LaunchWithSettings( settings ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.Start( launch_variables = vim.eval( 'a:settings' ) )
 endfunction
 
 function! vimspector#Reset() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.Reset()
 endfunction
 
 function! vimspector#Restart() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.Restart()
 endfunction
 
 function! vimspector#ClearBreakpoints() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.ClearBreakpoints()
 endfunction
 
 function! vimspector#ToggleBreakpoint( ... ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   if a:0 == 0
@@ -77,7 +89,7 @@ function! vimspector#ToggleBreakpoint( ... ) abort
 endfunction
 
 function! vimspector#SetLineBreakpoint( file_name, line_num, ... ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   if a:0 == 0
@@ -92,7 +104,7 @@ function! vimspector#SetLineBreakpoint( file_name, line_num, ... ) abort
 endfunction
 
 function! vimspector#ClearLineBreakpoint( file_name, line_num ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.ClearLineBreakpoint(
@@ -101,8 +113,18 @@ function! vimspector#ClearLineBreakpoint( file_name, line_num ) abort
 endfunction
 
 
+function! vimspector#RunToCursor() abort
+  if !s:Enabled()
+    return
+  endif
+  py3 _vimspector_session.RunTo(
+        \ vim.eval( "expand( '%' )" ),
+        \ int( vim.eval( "line( '.' )" ) ) )
+endfunction
+
+
 function! vimspector#AddFunctionBreakpoint( function, ... ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   if a:0 == 0
@@ -115,70 +137,70 @@ function! vimspector#AddFunctionBreakpoint( function, ... ) abort
 endfunction
 
 function! vimspector#StepOver() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.StepOver()
 endfunction
 
 function! vimspector#StepInto() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.StepInto()
 endfunction
 
 function! vimspector#StepOut() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.StepOut()
 endfunction
 
 function! vimspector#Continue() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.Continue()
 endfunction
 
 function! vimspector#Pause() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.Pause()
 endfunction
 
 function! vimspector#Stop() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.Stop()
 endfunction
 
 function! vimspector#ExpandVariable() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.ExpandVariable()
 endfunction
 
 function! vimspector#DeleteWatch() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.DeleteWatch()
 endfunction
 
 function! vimspector#GoToFrame() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.ExpandFrameOrThread()
 endfunction
 
 function! vimspector#AddWatch( ... ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   if a:0 == 0
@@ -195,7 +217,7 @@ function! vimspector#AddWatch( ... ) abort
 endfunction
 
 function! vimspector#AddWatchPrompt( expr ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   stopinsert
@@ -204,7 +226,7 @@ function! vimspector#AddWatchPrompt( expr ) abort
 endfunction
 
 function! vimspector#Evaluate( expr ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.ShowOutput( 'Console' )
@@ -212,7 +234,7 @@ function! vimspector#Evaluate( expr ) abort
 endfunction
 
 function! vimspector#EvaluateConsole( expr ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   stopinsert
@@ -221,7 +243,7 @@ function! vimspector#EvaluateConsole( expr ) abort
 endfunction
 
 function! vimspector#ShowOutput( ... ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   if a:0 == 1
@@ -232,7 +254,7 @@ function! vimspector#ShowOutput( ... ) abort
 endfunction
 
 function! vimspector#ShowOutputInWindow( win_id, category ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 __import__( 'vimspector',
@@ -242,21 +264,21 @@ function! vimspector#ShowOutputInWindow( win_id, category ) abort
 endfunction
 
 function! vimspector#ToggleLog() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.ToggleLog()
 endfunction
 
 function! vimspector#ListBreakpoints() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   py3 _vimspector_session.ListBreakpoints()
 endfunction
 
 function! vimspector#CompleteOutput( ArgLead, CmdLine, CursorPos ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   let buffers = py3eval( '_vimspector_session.GetOutputBuffers() '
@@ -287,7 +309,7 @@ def _vimspector_GetExprCompletions( ArgLead, prev_non_keyword_char ):
 EOF
 
 function! vimspector#CompleteExpr( ArgLead, CmdLine, CursorPos ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
 
@@ -415,7 +437,7 @@ function! vimspector#OmniFuncConsole( find_start, query ) abort
 endfunction
 
 function! vimspector#Install( bang, ... ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   let prefix = vimspector#internal#state#GetAPIPrefix()
@@ -427,7 +449,7 @@ function! vimspector#Install( bang, ... ) abort
 endfunction
 
 function! vimspector#CompleteInstall( ArgLead, CmdLine, CursorPos ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
   return py3eval( '"\n".join('
@@ -437,7 +459,7 @@ function! vimspector#CompleteInstall( ArgLead, CmdLine, CursorPos ) abort
 endfunction
 
 function! vimspector#Update( bang, ... ) abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
 
@@ -450,12 +472,31 @@ function! vimspector#Update( bang, ... ) abort
 endfunction
 
 function! vimspector#AbortInstall() abort
-  if !s:enabled
+  if !s:Enabled()
     return
   endif
 
   let prefix = vimspector#internal#state#GetAPIPrefix()
   py3 __import__( 'vimspector', fromlist = [ 'installer' ] ).installer.Abort()
+endfunction
+
+
+function! vimspector#OnBufferCreated( file_name ) abort
+  if len( a:file_name ) == 0
+    return
+  endif
+
+  " Don't actually load up vimsepctor python in autocommands that trigger
+  " regularly. We'll only create the session obkect in s:Enabled()
+  if !s:Initialised()
+    return
+  endif
+
+  if !s:Enabled()
+    return
+  endif
+
+  py3 _vimspector_session.RefreshSigns( vim.eval( 'a:file_name' ) )
 endfunction
 
 

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -76,6 +76,31 @@ function! vimspector#ToggleBreakpoint( ... ) abort
   py3 _vimspector_session.ToggleBreakpoint( vim.eval( 'options' ) )
 endfunction
 
+function! vimspector#SetLineBreakpoint( file_name, line_num, ... ) abort
+  if !s:enabled
+    return
+  endif
+  if a:0 == 0
+    let options = {}
+  else
+    let options = a:1
+  endif
+  py3 _vimspector_session.SetLineBreakpoint(
+        \ vim.eval( 'a:file_name' ),
+        \ int( vim.eval( 'a:line_num' ) ),
+        \ vim.eval( 'options' ) )
+endfunction
+
+function! vimspector#ClearLineBreakpoint( file_name, line_num ) abort
+  if !s:enabled
+    return
+  endif
+  py3 _vimspector_session.ClearLineBreakpoint(
+        \ vim.eval( 'a:file_name' ),
+        \ int( vim.eval( 'a:line_num' ) ) )
+endfunction
+
+
 function! vimspector#AddFunctionBreakpoint( function, ... ) abort
   if !s:enabled
     return

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -62,6 +62,9 @@ nnoremap <silent> <Plug>VimspectorStepInto
 nnoremap <silent> <Plug>VimspectorStepOut
       \ :<c-u>call vimspector#StepOut()<CR>
 
+nnoremap <silent> <Plug>VimspectorRunToCursor
+      \ :<c-u>call vimspector#RunToCursor()<CR>
+
 if s:mappings ==# 'VISUAL_STUDIO'
   nmap <F5>         <Plug>VimspectorContinue
   nmap <S-F5>       <Plug>VimspectorStop
@@ -80,6 +83,7 @@ elseif s:mappings ==# 'HUMAN'
   nmap <F9>         <Plug>VimspectorToggleBreakpoint
   nmap <leader><F9> <Plug>VimspectorToggleConditionalBreakpoint
   nmap <F8>         <Plug>VimspectorAddFunctionBreakpoint
+  nmap <leader><F8> <Plug>VimspectorRunToCursor
   nmap <F10>        <Plug>VimspectorStepOver
   nmap <F11>        <Plug>VimspectorStepInto
   nmap <F12>        <Plug>VimspectorStepOut
@@ -116,9 +120,14 @@ command! -bar -nargs=0
 
 " Dummy autocommands so that we can call this whenever
 augroup VimspectorUserAutoCmds
-  au!
-  au User VimspectorUICreated      silent
-  au User VimspectorTerminalOpened silent
+  autocmd!
+  autocmd User VimspectorUICreated      silent
+  autocmd User VimspectorTerminalOpened silent
+augroup END
+
+augroup Vimspector
+  autocmd!
+  autocmd BufNew * call vimspector#OnBufferCreated( expand( '<afile>' ) )
 augroup END
 
 " boilerplate {{{

--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -93,16 +93,12 @@ class CodeView( object ):
         sign = 'vimspectorPCBP'
         break
 
-    try:
+    if utils.BufferExists( frame[ 'source' ][ 'path' ] ):
       signs.PlaceSign( self._signs[ 'vimspectorPC' ],
                        'VimspectorCode',
                        sign,
                        frame[ 'source' ][ 'path' ],
                        frame[ 'line' ] )
-    except vim.error as e:
-      # Ignore 'invalid buffer name'
-      if 'E158' not in str( e ):
-        raise
 
 
   def SetCurrentFrame( self, frame ):
@@ -215,6 +211,11 @@ class CodeView( object ):
         return
 
 
+  def Refresh( self, file_name ):
+    # TODO: jsut the file ?
+    self.ShowBreakpoints()
+
+
   def _UndisplaySigns( self ):
     for sign_id in self._signs[ 'breakpoints' ]:
       signs.UnplaceSign( sign_id, 'VimspectorCode' )
@@ -236,12 +237,13 @@ class CodeView( object ):
         sign_id = self._next_sign_id
         self._next_sign_id += 1
         self._signs[ 'breakpoints' ].append( sign_id )
-        signs.PlaceSign( sign_id,
-                         'VimspectorCode',
-                         'vimspectorBP' if breakpoint[ 'verified' ]
-                                        else 'vimspectorBPDisabled',
-                         file_name,
-                         breakpoint[ 'line' ] )
+        if utils.BufferExists( file_name ):
+          signs.PlaceSign( sign_id,
+                           'VimspectorCode',
+                           'vimspectorBP' if breakpoint[ 'verified' ]
+                                          else 'vimspectorBPDisabled',
+                           file_name,
+                           breakpoint[ 'line' ] )
 
     # We need to also check if there's a breakpoint on this PC line and chnge
     # the PC

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -1165,6 +1165,12 @@ class DebugSession( object ):
   def ToggleBreakpoint( self, options ):
     return self._breakpoints.ToggleBreakpoint( options )
 
+  def SetLineBreakpoint( self, file_name, line_num, options ):
+    return self._breakpoints.SetLineBreakpoint( file_name, line_num, options )
+
+  def ClearLineBreakpoint( self, file_name, line_num ):
+    return self._breakpoints.ClearLineBreakpoint( file_name, line_num )
+
   def ClearBreakpoints( self ):
     if self._connection:
       self._codeView.ClearBreakpoints()

--- a/python3/vimspector/signs.py
+++ b/python3/vimspector/signs.py
@@ -29,7 +29,7 @@ def DefineSign( name, text, double_text, texthl, col = 'right', **kwargs ):
   vim.command( cmd )
 
 
-def PlaceSign( sign_id, group, name, file, line ):
+def PlaceSign( sign_id, group, name, file_name, line ):
   priority = settings.Dict( 'sign_priority' )[ name ]
 
   cmd = ( f'sign place { sign_id } '
@@ -37,7 +37,7 @@ def PlaceSign( sign_id, group, name, file, line ):
           f'name={ name } '
           f'priority={ priority } '
           f'line={ line } '
-          f'file={ file }' )
+          f'file={ file_name }' )
 
   vim.command( cmd )
 

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -149,12 +149,15 @@ class StackTraceView( object ):
 
         self._DrawStackTrace( thread )
 
-  def _LoadStackTrace( self, thread, infer_current_frame ):
+  def _LoadStackTrace( self,
+                       thread,
+                       infer_current_frame,
+                       reason = '' ):
     def consume_stacktrace( message ):
       thread[ '_frames' ] = message[ 'body' ][ 'stackFrames' ]
       if infer_current_frame:
         for frame in thread[ '_frames' ]:
-          if self._JumpToFrame( frame ):
+          if self._JumpToFrame( frame, reason ):
             break
 
       self._DrawThreads()
@@ -183,11 +186,11 @@ class StackTraceView( object ):
       else:
         self._LoadStackTrace( thread, False )
 
-  def _JumpToFrame( self, frame ):
+  def _JumpToFrame( self, frame, reason = '' ):
     def do_jump():
       if 'line' in frame and frame[ 'line' ] > 0:
         self._current_frame = frame
-        return self._session.SetCurrentFrame( self._current_frame )
+        return self._session.SetCurrentFrame( self._current_frame, reason )
       return False
 
     source = frame.get( 'source' ) or {}
@@ -211,7 +214,7 @@ class StackTraceView( object ):
     if self._current_thread is not None:
       for thread in self._threads:
         if thread[ 'id' ] == self._current_thread:
-          self._LoadStackTrace( thread, True )
+          self._LoadStackTrace( thread, True, 'stopped' )
           return
 
     self.LoadThreads( True )

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -45,8 +45,10 @@ _logger = logging.getLogger( __name__ )
 SetUpLogging( _logger )
 
 
-def BufferNumberForFile( file_name ):
-  return int( vim.eval( "bufnr( '{0}', 1 )".format( Escape( file_name ) ) ) )
+def BufferNumberForFile( file_name, create = True ):
+  return int( vim.eval( "bufnr( '{0}', {1} )".format(
+    Escape( file_name ),
+    int( create ) ) ) )
 
 
 def BufferForFile( file_name ):

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -55,6 +55,10 @@ def BufferForFile( file_name ):
   return vim.buffers[ BufferNumberForFile( file_name ) ]
 
 
+def BufferExists( file_name ):
+  return bool( int ( vim.eval( f"bufexists( '{ Escape( file_name ) }' )" ) ) )
+
+
 def NewEmptyBuffer():
   bufnr = int( vim.eval( 'bufadd("")' ) )
   Call( 'bufload', bufnr )

--- a/support/test/python/simple_python/.vimspector.json
+++ b/support/test/python/simple_python/.vimspector.json
@@ -52,6 +52,11 @@
     },
     "run - default": {
       "adapter": "debugpy",
+      "variables": {
+        "MAKE_ENV_OUTPUT": {
+          "shell": "${workspaceRoot}/make_env.sh"
+        }
+      },
       "configuration": {
         "request": "launch",
         "type": "python",
@@ -60,8 +65,8 @@
         "stopOnEntry#json": "${StopOnEntry:true}",
         "console": "integratedTerminal",
         "args#json": "${args:[]}",
-        "env#json": "${env:{\\}}",
-        "igored#json#s": "string not json"
+        "igored#json#s": "string not json",
+        "env#json": "${MAKE_ENV_OUTPUT}"
       },
       "breakpoints": {
         "exception": {

--- a/support/test/python/simple_python/make_env.sh
+++ b/support/test/python/simple_python/make_env.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cat <<"EOF"
+{
+  "Something": "Value1",
+  "SomethingElse": "Value2"
+}
+EOF
+

--- a/support/test/python/simple_python/print_env.py
+++ b/support/test/python/simple_python/print_env.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+import os
+
+
+def Main():
+  print( os.environ.get( 'Something', 'ERROR' ) )
+  print( os.environ.get( 'SomethingElse', 'ERROR' ) )
+
+  for k, v in os.environ:
+    print( f'{ k } = "{ v }"' )
+
+
+Main()
+

--- a/tests/breakpoints.test.vim
+++ b/tests/breakpoints.test.vim
@@ -6,38 +6,6 @@ function! ClearDown()
   call vimspector#test#setup#ClearDown()
 endfunction
 
-function! SetUp_Test_Mappings_Are_Added_HUMAN()
-  let g:vimspector_enable_mappings = 'HUMAN'
-endfunction
-
-function! Test_Mappings_Are_Added_HUMAN()
-  call assert_true( hasmapto( 'vimspector#Continue()' ) )
-  call assert_false( hasmapto( 'vimspector#Launch()' ) )
-  call assert_true( hasmapto( 'vimspector#Stop()' ) )
-  call assert_true( hasmapto( 'vimspector#Restart()' ) )
-  call assert_true( hasmapto( 'vimspector#ToggleBreakpoint()' ) )
-  call assert_true( hasmapto( 'vimspector#AddFunctionBreakpoint' ) )
-  call assert_true( hasmapto( 'vimspector#StepOver()' ) )
-  call assert_true( hasmapto( 'vimspector#StepInto()' ) )
-  call assert_true( hasmapto( 'vimspector#StepOut()' ) )
-endfunction
-
-function! SetUp_Test_Mappings_Are_Added_VISUAL_STUDIO()
-  let g:vimspector_enable_mappings = 'VISUAL_STUDIO'
-endfunction
-
-function! Test_Mappings_Are_Added_VISUAL_STUDIO()
-  call assert_true( hasmapto( 'vimspector#Continue()' ) )
-  call assert_false( hasmapto( 'vimspector#Launch()' ) )
-  call assert_true( hasmapto( 'vimspector#Stop()' ) )
-  call assert_true( hasmapto( 'vimspector#Restart()' ) )
-  call assert_true( hasmapto( 'vimspector#ToggleBreakpoint()' ) )
-  call assert_true( hasmapto( 'vimspector#AddFunctionBreakpoint' ) )
-  call assert_true( hasmapto( 'vimspector#StepOver()' ) )
-  call assert_true( hasmapto( 'vimspector#StepInto()' ) )
-  call assert_true( hasmapto( 'vimspector#StepOut()' ) )
-endfunction
-
 function! SetUp_Test_Signs_Placed_Using_API_Are_Shown()
   let g:vimspector_enable_mappings = 'VISUAL_STUDIO'
 endfunction
@@ -75,68 +43,6 @@ function! Test_Signs_Placed_Using_API_Are_Shown()
   call vimspector#test#signs#AssertSignGroupEmpty( 'VimspectorCode' )
 
   call vimspector#test#setup#Reset()
-  %bwipeout!
-endfunction
-
-function! SetUp_Test_Use_Mappings_HUMAN()
-  let g:vimspector_enable_mappings = 'HUMAN'
-endfunction
-
-function! Test_Use_Mappings_HUMAN()
-  lcd testdata/cpp/simple
-  edit simple.cpp
-  call setpos( '.', [ 0, 15, 1 ] )
-
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 15, 1 )
-  call vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorBP', 15 )
-
-  " Add the breakpoint
-  call feedkeys( "\<F9>", 'xt' )
-  call vimspector#test#signs#AssertSignGroupSingletonAtLine( 'VimspectorBP',
-                                                           \ 15,
-                                                           \ 'vimspectorBP',
-                                                           \ 9 )
-
-  " Disable the breakpoint
-  call feedkeys( "\<F9>", 'xt' )
-  call vimspector#test#signs#AssertSignGroupSingletonAtLine(
-        \ 'VimspectorBP',
-        \ 15,
-        \ 'vimspectorBPDisabled',
-        \ 9 )
-
-  " Delete the breakpoint
-  call feedkeys( "\<F9>", 'xt' )
-  call vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorBP', 15 )
-
-  " Add it again
-  call feedkeys( "\<F9>", 'xt' )
-  call vimspector#test#signs#AssertSignGroupSingletonAtLine(
-        \ 'VimspectorBP',
-        \ 15,
-        \ 'vimspectorBP',
-        \ 9 )
-
-  " Here we go. Start Debugging
-  call feedkeys( "\<F5>", 'xt' )
-
-  call assert_equal( 2, len( gettabinfo() ) )
-  let cur_tabnr = tabpagenr()
-  call assert_equal( 5, len( gettabinfo( cur_tabnr )[ 0 ].windows ) )
-
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 15, 1 )
-
-  " Step
-  call feedkeys( "\<F10>", 'xt' )
-
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 16, 1 )
-  call WaitForAssert( {->
-        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'simple.cp', 16 )
-        \ } )
-
-  call vimspector#test#setup#Reset()
-
-  lcd -
   %bwipeout!
 endfunction
 
@@ -200,8 +106,8 @@ function Test_DisableBreakpointWhileDebugging()
                                                           \ 16 )
         \ } )
 
-  " Add the breakpoint
-  call feedkeys( "\<F9>", 'xt' )
+  call setpos( '.', [ 0, 1, 1 ] )
+  call vimspector#SetLineBreakpoint( 'simple.cpp', 16 )
   call WaitForAssert( {->
         \ vimspector#test#signs#AssertSignGroupSingletonAtLine(
            \ 'VimspectorCode',
@@ -211,7 +117,6 @@ function Test_DisableBreakpointWhileDebugging()
         \ } )
 
   " Run to breakpoint
-  call setpos( '.', [ 0, 15, 1 ] )
   call feedkeys( "\<F5>", 'xt' )
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 16, 1 )
   call WaitForAssert( {->
@@ -255,6 +160,58 @@ function Test_DisableBreakpointWhileDebugging()
 
   lcd -
   call vimspector#test#setup#Reset()
+  %bwipeout!
+endfunction
+
+function! Test_Add_Breakpoints_In_File_Then_Open()
+  lcd testdata/cpp/simple
+
+  " Set and clear without file open
+  call vimspector#SetLineBreakpoint( 'simple.cpp', 16 )
+  call vimspector#ClearLineBreakpoint( 'simple.cpp', 16 )
+
+  " Clear non-set breakpoint
+  call vimspector#ClearLineBreakpoint( 'simple.cpp', 1 )
+
+  " Re-add
+  call vimspector#SetLineBreakpoint( 'simple.cpp', 16 )
+
+  " Open and expect sign to be added
+  edit simple.cpp
+  call vimspector#test#signs#AssertSignGroupSingletonAtLine( 'VimspectorBP',
+                                                           \ 16,
+                                                           \ 'vimspectorBP',
+                                                           \ 9 )
+  call vimspector#LaunchWithSettings( { 'configuration': 'run-to-breakpoint' } )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 16, 1 )
+
+  call vimspector#test#setup#Reset()
+  lcd -
+  %bwipeout!
+endfunction
+
+function! Test_Add_Breakpoints_In_NonOpenedFile_RunToBreak()
+  lcd testdata/cpp/simple
+
+  " add
+  call vimspector#SetLineBreakpoint( 'simple.cpp', 16 )
+
+  call vimspector#LaunchWithSettings( {
+        \ 'configuration': 'run-to-breakpoint-specify-file',
+        \ 'prog': 'simple'
+        \ } )
+  call WaitFor( {-> bufexists( 'simple.cpp' ) } )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 16, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( 'simple.cpp', 16 )
+
+  call vimspector#test#signs#AssertSignAtLine(
+        \ 'VimspectorCode',
+        \ 16,
+        \ 'vimspectorPCBP',
+        \ 200 )
+
+  call vimspector#test#setup#Reset()
+  lcd -
   %bwipeout!
 endfunction
 
@@ -308,7 +265,6 @@ function! Test_Insert_Code_Above_Breakpoint()
   " Delete it
   call feedkeys( "\<F9>", 'xt' )
   call vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorBP', 26 )
-
 endfunction
 
 function! SetUp_Test_Conditional_Line_Breakpoint()
@@ -360,8 +316,11 @@ function! Test_Conditional_Line_Breakpoint()
         \ 'vimspectorBP',
         \ 9 )
 
-  call setpos( '.', [ 0, 17, 1 ] )
-  call vimspector#ToggleBreakpoint( { 'condition': 'argc == 1' } )
+  call setpos( '.', [ 0, 1, 1 ] )
+  call vimspector#SetLineBreakpoint(
+        \ 'simple.cpp',
+        \ 17,
+        \ { 'condition': 'argc == 1' } )
   call vimspector#test#signs#AssertSignGroupSingletonAtLine(
         \ 'VimspectorBP',
         \ 17,
@@ -723,7 +682,6 @@ function! Test_Custom_Breakpoint_Priority_Partial()
   %bwipeout!
   unlet! g:vimspector_sign_priority
 endfunction
-
 
 function! Test_Add_Line_BP_In_Other_File_While_Debugging()
   let moo = 'moo.py'

--- a/tests/breakpoints_doublewidth.test.vim
+++ b/tests/breakpoints_doublewidth.test.vim
@@ -7,38 +7,6 @@ function! ClearDown()
   call vimspector#test#setup#ClearDown()
 endfunction
 
-function! SetUp_Test_Mappings_Are_Added_HUMAN()
-  let g:vimspector_enable_mappings = 'HUMAN'
-endfunction
-
-function! Test_Mappings_Are_Added_HUMAN()
-  call assert_true( hasmapto( 'vimspector#Continue()' ) )
-  call assert_false( hasmapto( 'vimspector#Launch()' ) )
-  call assert_true( hasmapto( 'vimspector#Stop()' ) )
-  call assert_true( hasmapto( 'vimspector#Restart()' ) )
-  call assert_true( hasmapto( 'vimspector#ToggleBreakpoint()' ) )
-  call assert_true( hasmapto( 'vimspector#AddFunctionBreakpoint' ) )
-  call assert_true( hasmapto( 'vimspector#StepOver()' ) )
-  call assert_true( hasmapto( 'vimspector#StepInto()' ) )
-  call assert_true( hasmapto( 'vimspector#StepOut()' ) )
-endfunction
-
-function! SetUp_Test_Mappings_Are_Added_VISUAL_STUDIO()
-  let g:vimspector_enable_mappings = 'VISUAL_STUDIO'
-endfunction
-
-function! Test_Mappings_Are_Added_VISUAL_STUDIO()
-  call assert_true( hasmapto( 'vimspector#Continue()' ) )
-  call assert_false( hasmapto( 'vimspector#Launch()' ) )
-  call assert_true( hasmapto( 'vimspector#Stop()' ) )
-  call assert_true( hasmapto( 'vimspector#Restart()' ) )
-  call assert_true( hasmapto( 'vimspector#ToggleBreakpoint()' ) )
-  call assert_true( hasmapto( 'vimspector#AddFunctionBreakpoint' ) )
-  call assert_true( hasmapto( 'vimspector#StepOver()' ) )
-  call assert_true( hasmapto( 'vimspector#StepInto()' ) )
-  call assert_true( hasmapto( 'vimspector#StepOut()' ) )
-endfunction
-
 function! SetUp_Test_Signs_Placed_Using_API_Are_Shown()
   let g:vimspector_enable_mappings = 'VISUAL_STUDIO'
 endfunction
@@ -132,7 +100,7 @@ function! Test_Use_Mappings_HUMAN()
 
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 16, 1 )
   call WaitForAssert( {->
-        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'simple.cp', 16 )
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'simple.cpp', 16 )
         \ } )
 
   call vimspector#test#setup#Reset()

--- a/tests/language_go.test.vim
+++ b/tests/language_go.test.vim
@@ -45,3 +45,28 @@ function! Test_Go_Simple()
   lcd -
   %bwipeout!
 endfunction
+
+
+function! Test_Run_To_Cursor()
+  let fn='hello-world.go'
+  lcd ../support/test/go/hello_world
+  exe 'edit ' . fn
+
+  call vimspector#SetLineBreakpoint( fn, 4 )
+  call vimspector#Launch()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 4, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 4 )
+        \ } )
+
+  call cursor( 5, 1 )
+  call vimspector#RunToCursor()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 5, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 5 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+  lcd -
+  %bwipeout!
+endfunction

--- a/tests/lib/autoload/vimspector/test/signs.vim
+++ b/tests/lib/autoload/vimspector/test/signs.vim
@@ -1,6 +1,7 @@
 function! vimspector#test#signs#AssertCursorIsAtLineInBuffer( buffer,
                                                             \ line,
                                                             \ column ) abort
+  call WaitFor( {-> bufexists( a:buffer ) } )
   call WaitForAssert( {->
         \ assert_equal( fnamemodify( a:buffer, ':p' ),
         \               fnamemodify( bufname( '%' ), ':p' ),
@@ -15,6 +16,7 @@ function! vimspector#test#signs#AssertCursorIsAtLineInBuffer( buffer,
 endfunction
 
 function! vimspector#test#signs#AssertPCIsAtLineInBuffer( buffer, line ) abort
+  call WaitFor( {-> bufexists( a:buffer ) } )
   let signs = sign_getplaced( a:buffer, {
     \ 'group': 'VimspectorCode',
     \ } )

--- a/tests/mappings.test.vim
+++ b/tests/mappings.test.vim
@@ -1,0 +1,123 @@
+function! SetUp()
+  call vimspector#test#setup#SetUpWithMappings( v:none )
+endfunction
+
+function! ClearDown()
+  call vimspector#test#setup#ClearDown()
+endfunction
+
+function! SetUp_Test_Mappings_Are_Added_HUMAN()
+  let g:vimspector_enable_mappings = 'HUMAN'
+endfunction
+
+function! Test_Mappings_Are_Added_HUMAN()
+  call assert_true( hasmapto( 'vimspector#Continue()' ) )
+  call assert_false( hasmapto( 'vimspector#Launch()' ) )
+  call assert_true( hasmapto( 'vimspector#Stop()' ) )
+  call assert_true( hasmapto( 'vimspector#Restart()' ) )
+  call assert_true( hasmapto( 'vimspector#ToggleBreakpoint()' ) )
+  call assert_true( hasmapto( 'vimspector#AddFunctionBreakpoint' ) )
+  call assert_true( hasmapto( 'vimspector#StepOver()' ) )
+  call assert_true( hasmapto( 'vimspector#StepInto()' ) )
+  call assert_true( hasmapto( 'vimspector#StepOut()' ) )
+  call assert_true( hasmapto( 'vimspector#RunToCursor()' ) )
+endfunction
+
+function! SetUp_Test_Mappings_Are_Added_VISUAL_STUDIO()
+  let g:vimspector_enable_mappings = 'VISUAL_STUDIO'
+endfunction
+
+function! Test_Mappings_Are_Added_VISUAL_STUDIO()
+  call assert_true( hasmapto( 'vimspector#Continue()' ) )
+  call assert_false( hasmapto( 'vimspector#Launch()' ) )
+  call assert_true( hasmapto( 'vimspector#Stop()' ) )
+  call assert_true( hasmapto( 'vimspector#Restart()' ) )
+  call assert_true( hasmapto( 'vimspector#ToggleBreakpoint()' ) )
+  call assert_true( hasmapto( 'vimspector#AddFunctionBreakpoint' ) )
+  call assert_true( hasmapto( 'vimspector#StepOver()' ) )
+  call assert_true( hasmapto( 'vimspector#StepInto()' ) )
+  call assert_true( hasmapto( 'vimspector#StepOut()' ) )
+endfunction
+
+function! SetUp_Test_Use_Mappings_HUMAN()
+  let g:vimspector_enable_mappings = 'HUMAN'
+endfunction
+
+function! Test_Use_Mappings_HUMAN()
+  call ThisTestIsFlaky()
+  lcd testdata/cpp/simple
+  edit simple.cpp
+  call setpos( '.', [ 0, 15, 1 ] )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 15, 1 )
+  call vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorBP', 15 )
+
+  " Add the breakpoint
+  call feedkeys( "\<F9>", 'xt' )
+  call vimspector#test#signs#AssertSignGroupSingletonAtLine( 'VimspectorBP',
+                                                           \ 15,
+                                                           \ 'vimspectorBP',
+                                                           \ 9 )
+
+  " Disable the breakpoint
+  call feedkeys( "\<F9>", 'xt' )
+  call vimspector#test#signs#AssertSignGroupSingletonAtLine(
+        \ 'VimspectorBP',
+        \ 15,
+        \ 'vimspectorBPDisabled',
+        \ 9 )
+
+  " Delete the breakpoint
+  call feedkeys( "\<F9>", 'xt' )
+  call vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorBP', 15 )
+
+  " Add and clear using API
+  call vimspector#SetLineBreakpoint( 'simple.cpp', 15 )
+  call vimspector#test#signs#AssertSignGroupSingletonAtLine( 'VimspectorBP',
+                                                           \ 15,
+                                                           \ 'vimspectorBP',
+                                                           \ 9 )
+
+  call vimspector#ClearLineBreakpoint( 'simple.cpp', 15 )
+  call vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorBP', 15 )
+
+  " Add it again
+  call feedkeys( "\<F9>", 'xt' )
+  call vimspector#test#signs#AssertSignGroupSingletonAtLine(
+        \ 'VimspectorBP',
+        \ 15,
+        \ 'vimspectorBP',
+        \ 9 )
+
+  " Here we go. Start Debugging
+  call feedkeys( "\<F5>", 'xt' )
+
+  call assert_equal( 2, len( gettabinfo() ) )
+  let cur_tabnr = tabpagenr()
+  call assert_equal( 5, len( gettabinfo( cur_tabnr )[ 0 ].windows ) )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 15, 1 )
+
+  " Step
+  call feedkeys( "\<F10>", 'xt' )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 16, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'simple.cpp', 16 )
+        \ } )
+
+  " Run to cursor
+  call cursor( 9, 1 )
+  call feedkeys( "\\\<F8>", 'xt' )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'simple.cpp', 9, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'simple.cpp', 9 )
+        \ } )
+
+
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction
+

--- a/tests/temporary_breakpoints.test.vim
+++ b/tests/temporary_breakpoints.test.vim
@@ -1,0 +1,200 @@
+function! SetUp()
+  call vimspector#test#setup#SetUpWithMappings( v:none )
+endfunction
+
+function! ClearDown()
+  call vimspector#test#setup#ClearDown()
+endfunction
+
+function s:Start()
+  call vimspector#SetLineBreakpoint( 'moo.py', 13 )
+  call vimspector#Launch()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 1, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 1 )
+  call vimspector#Continue()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 13, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 13 )
+endfunction
+
+function Test_Run_To_Cursor_Simple()
+  " Run to a position that will certainly be executed
+  lcd ../support/test/python/multiple_files
+  call vimspector#SetLineBreakpoint( 'moo.py', 13 )
+  call s:Start()
+
+  call cursor( 8, 27 )
+  call vimspector#RunToCursor()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 8, 27 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 8 )
+        \ } )
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 9, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 9 )
+  " Check there is no breakpoint set on line 8
+  call WaitForAssert( {->
+      \ vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorCode', 8 )
+      \ } )
+  call vimspector#test#setup#Reset()
+  lcd -
+  %bwipe!
+endfunction
+
+function Test_Run_To_Cursor_On_NonBreaking_Line()
+  " Run to a position that will certainly be executed, but is not a real line
+  lcd ../support/test/python/multiple_files
+  call vimspector#SetLineBreakpoint( 'moo.py', 13 )
+  call s:Start()
+
+  call cursor( 7, 1 )
+  " Interestingly, debugpy moves the breakpoint to the previous line, which is
+  " kinda annoying
+  call vimspector#RunToCursor()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 6, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 6 )
+        \ } )
+  call vimspector#StepOver()
+  " It's a loop, so we go up a line
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 5, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 5 )
+
+  " Check there is no breakpoint set on lines 7 and 6:
+  "  7 - where we put the 'temporary' breakpoint
+  "  6 - where it got placed
+  "
+  " FIXME: This is broken, we don't _know_ that the breakpoint that was hit was
+  " the temporary one, and there's no way to know.
+  "
+  " I wonder if the relocated breakpoint can be matched with the _original_
+  " breakpoint
+  call WaitForAssert( {->
+      \ vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorCode', 7 )
+      \ } )
+  call WaitForAssert( {->
+      \ vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorCode', 6 )
+      \ } )
+  call vimspector#test#setup#Reset()
+  lcd -
+  %bwipe!
+endfunction
+
+function Test_Run_To_Cursor_Different_File()
+  " Run into a different file
+  " Run to a position that will certainly be executed, but is not a real line
+  lcd ../support/test/python/multiple_files
+  call vimspector#SetLineBreakpoint( 'moo.py', 13 )
+  call s:Start()
+
+  edit cow.py
+  call cursor( 2, 1 )
+  call vimspector#RunToCursor()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'cow.py', 2, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'cow.py', 2 )
+        \ } )
+
+  bu moo.py
+  call cursor( 9, 12 )
+  call vimspector#RunToCursor()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 9, 12 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 9 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+  lcd -
+  %bwipe!
+endfunction
+
+function Test_Run_To_Cursor_Hit_Another_Breakpoint()
+  " Run to cursor, but hit a non-temporary breakpoint
+  lcd ../support/test/python/multiple_files
+  call vimspector#SetLineBreakpoint( 'moo.py', 13 )
+  call s:Start()
+
+  call vimspector#SetLineBreakpoint( 'moo.py', 5 )
+  call cursor( 6, 1 )
+
+  call vimspector#RunToCursor()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 5, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 5 )
+        \ } )
+
+  " The temporary breakpoint is still there
+  call vimspector#test#signs#AssertSignGroupSingletonAtLine(
+        \ 'VimspectorCode',
+        \ 6,
+        \ 'vimspectorBP',
+        \ 9 )
+
+  call vimspector#ClearLineBreakpoint( 'moo.py', 5 )
+
+  call cursor( 8, 1 )
+  call vimspector#RunToCursor()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 8, 1 )
+  call WaitForAssert( {->
+      \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 8 )
+      \ } )
+  call WaitForAssert( {->
+      \  vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorCode', 6 )
+      \ } )
+
+  call vimspector#test#setup#Reset()
+  lcd -
+  %bwipe!
+endfunction
+
+function! Test_InvalidBreakpoint()
+  " Run to cursor, but hit a non-temporary breakpoint
+  lcd ../support/test/python/multiple_files
+  call vimspector#SetLineBreakpoint( 'moo.py', 13 )
+  call s:Start()
+
+  call vimspector#SetLineBreakpoint( 'moo.py', 9 )
+
+  edit .vimspector.json
+  call cursor( 1, 1 )
+  call vimspector#RunToCursor()
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 9, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 9 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+  lcd -
+  %bwipe!
+endfunction
+
+function! Test_StartDebuggingWithRunToCursor()
+  lcd ../support/test/python/multiple_files
+  edit moo.py
+  call cursor( 9, 1 )
+  call vimspector#RunToCursor()
+  " Stop on entry is still hit
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 1, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 1 )
+  call vimspector#test#signs#AssertSignGroupSingletonAtLine(
+        \ 'VimspectorCode',
+        \ 9,
+        \ 'vimspectorBP',
+        \ 9 )
+
+  call vimspector#Continue()
+  " Runs to cursor
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 9, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 9 )
+
+  call vimspector#StepOver()
+  " And claers the temp breakpoint
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( 'moo.py', 8, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( 'moo.py', 8 )
+
+  call WaitForAssert( {->
+      \ vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorCode', 9 )
+      \ } )
+
+  lcd -
+endfunction

--- a/tests/testdata/cpp/simple/.vimspector.json
+++ b/tests/testdata/cpp/simple/.vimspector.json
@@ -46,6 +46,28 @@
         }
       }
     },
+    "run-to-breakpoint-specify-file": {
+      "adapter": "vscode-cpptools",
+      "configuration": {
+        "request": "launch",
+        "program": "${workspaceRoot}/${prog}",
+        "cwd": "${workspaceRoot}",
+        "externalConsole": false,
+        "stopAtEntry": false,
+        "stopOnEntry": false,
+        "MImode": "${VIMSPECTOR_MIMODE}"
+      },
+      "breakpoints": {
+        "exception": {
+          "cpp_catch": "",
+          "cpp_throw": "",
+          "objc_catch": "",
+          "objc_throw": "",
+          "swift_catch": "",
+          "swift_throw": ""
+        }
+      }
+    },
     "calculate-some-variable": {
       "adapter": "vscode-cpptools",
       "variables": {


### PR DESCRIPTION
Introduce temporary breakpoints, allowing for "run to cursor", which is occasionally more convinient than F9,F5,F9