### PR TITLE
Add lua support through local-lua-debugger-vscode

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,7 +86,7 @@ jobs:
     - run: |
         brew update-reset
         brew doctor || true
-        for p in macvim tcl-tk llvm; do
+        for p in macvim tcl-tk llvm lua luajit love; do
           brew install $p
           brew outdated $p || brew upgrade $p
         done

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tests/*.res
 tests/messages
 tests/debuglog
 test.log
+*.testlog
 gadgets/
 package/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ runtime dependencies). They are categorised by their level of support:
 | Node.js            | Supported    | `--force-enable-node`            | vscode-node-debug2                 | 6 < Node < 12, Npm                         |
 | Javascript         | Supported    | `--force-enable-chrome`          | debugger-for-chrome                | Chrome                                     |
 | Java               | Supported    | `--force-enable-java  `          | vscode-java-debug                  | Compatible LSP plugin (see [later](#java)) |
+| Lua                | Supported    | `--force-enable-lua`             | local-lua-debugger-vscode          | Node, Npm, Lua interpreter                 |
 | C# (dotnet core)   | Experimental | `--force-enable-csharp`          | netcoredbg                         | DotNet core                                |
 | C# (mono)          | Experimental | `--force-enable-csharp`          | vscode-mono-debug                  | Mono                                       |
 | Python.legacy      | Legacy       | `--force-enable-python.legacy`   | vscode-python                      | Node 10, Python 2.7 or Python 3            |
@@ -1309,7 +1310,7 @@ https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome
 
 It allows you to debug scripts running inside chrome from within Vim.
 
-* `./install_gadget.py --force-enable-chrome` or `:VimspectorInstall 
+* `./install_gadget.py --force-enable-chrome` or `:VimspectorInstall
   debugger-for-chrome`
 * Example: `support/test/chrome`
 
@@ -1345,7 +1346,7 @@ use it with Vimspector.
 * Set up [YCM for java][YcmJava].
 * Get Vimspector to download the java debug plugin:
    `install_gadget.py --force-enable-java <other options...>` or
-   `:VimspectorInstall java-debug-adapter` 
+   `:VimspectorInstall java-debug-adapter`
 * Configure Vimspector for your project using the `vscode-java` adapter, e.g.:
 
 ```json
@@ -1409,6 +1410,60 @@ For the launch arguments, see the
 
 See [this issue](https://github.com/puremourning/vimspector/issues/3) for more
 background.
+
+## Lua
+
+Lua is supported through
+[local-lua-debugger-vscode](https://github.com/tomblind/local-lua-debugger-vscode).
+This debugger uses stdio to communicate with the running process, so calls to
+`io.read` will cause problems.
+
+* `./install_gadget.py --force-enable-lua` or `:VimspectorInstall local-lua-debugger-vscode`
+* Examples: `support/test/lua/simple` and `support/test/lua/love`
+
+```json
+{
+  "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json#",
+  "configurations": {
+    "lua": {
+      "adapter": "lua-local",
+      "configuration": {
+        "request": "launch",
+        "type": "lua-local",
+        "cwd": "${workspaceFolder}",
+        "program": {
+          "lua": "lua",
+          "file": "${file}"
+        }
+      }
+    },
+    "luajit": {
+      "adapter": "lua-local",
+      "configuration": {
+        "request": "launch",
+        "type": "lua-local",
+        "cwd": "${workspaceFolder}",
+        "program": {
+          "lua": "luajit",
+          "file": "${file}"
+        }
+      }
+    },
+    "love": {
+      "adapter": "lua-local",
+      "configuration": {
+        "request": "launch",
+        "type": "lua-local",
+        "cwd": "${workspaceFolder}",
+        "program": {
+          "command": "love"
+        },
+        "args": ["${workspaceFolder}"]
+      }
+    }
+  }
+}
+```
 
 ## Other servers
 
@@ -1685,7 +1740,7 @@ augroup END
    comment](https://github.com/puremourning/vimspector/issues/90#issuecomment-577857322)
 4. Can I specify answers to the annoying questions about exception breakpoints
    in my `.vimspector.json` ? Yes, see [here][vimspector-ref-exception].
-5. Do I have to specify the file to execute in `.vimspector.json`, or could it be the current vim file? 
+5. Do I have to specify the file to execute in `.vimspector.json`, or could it be the current vim file?
    You don't need to. You can specify $file for the current active file. See [here][vimspector-ref-var] for complete list of replacements in the configuration file.
 6. You allow comments in `.vimspector.json`, but Vim highlights these as errors,
    do you know how to make this not-an-error? Yes, put this in
@@ -1733,7 +1788,7 @@ A message from the author about the motivation for this plugin:
 >
 > I created Vimspector because I find changing tools frustrating. `gdb` for c++,
 > `pdb` for python, etc. Each has its own syntax. Each its own lexicon. Each its
-> own foibles. 
+> own foibles.
 >
 > I designed the configuration system in such a way that the configuration can
 > be committed to source control so that it _just works_ for any of your

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ For a tutorial and usage overview, take a look at the
     * [Java](#java)
        * [Usage with YouCompleteMe](#usage-with-youcompleteme)
        * [Other LSP clients](#other-lsp-clients)
+    * [Lua](#lua)
     * [Rust](#rust)
     * [Other servers](#other-servers)
  * [Customisation](#customisation)

--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ runtime dependencies). They are categorised by their level of support:
 | Go                 | Tested       | `--enable-go`                    | vscode-go                          | Go, [Delve][]                              |
 | TCL                | Supported    | `--all` or `--enable-tcl`        | tclpro                             | TCL 8.5                                    |
 | Bourne Shell       | Supported    | `--all` or `--enable-bash`       | vscode-bash-debug                  | Bash v??                                   |
+| Lua                | Supported    | `--all` or `--enable-lua`        | local-lua-debugger-vscode          | Node >=12.13.0, Npm, Lua interpreter       |
 | Node.js            | Supported    | `--force-enable-node`            | vscode-node-debug2                 | 6 < Node < 12, Npm                         |
 | Javascript         | Supported    | `--force-enable-chrome`          | debugger-for-chrome                | Chrome                                     |
 | Java               | Supported    | `--force-enable-java  `          | vscode-java-debug                  | Compatible LSP plugin (see [later](#java)) |
-| Lua                | Supported    | `--force-enable-lua`             | local-lua-debugger-vscode          | Node, Npm, Lua interpreter                 |
 | C# (dotnet core)   | Experimental | `--force-enable-csharp`          | netcoredbg                         | DotNet core                                |
 | C# (mono)          | Experimental | `--force-enable-csharp`          | vscode-mono-debug                  | Mono                                       |
 | Python.legacy      | Legacy       | `--force-enable-python.legacy`   | vscode-python                      | Node 10, Python 2.7 or Python 3            |
@@ -1419,7 +1419,7 @@ Lua is supported through
 This debugger uses stdio to communicate with the running process, so calls to
 `io.read` will cause problems.
 
-* `./install_gadget.py --force-enable-lua` or `:VimspectorInstall local-lua-debugger-vscode`
+* `./install_gadget.py --enable-lua` or `:VimspectorInstall local-lua-debugger-vscode`
 * Examples: `support/test/lua/simple` and `support/test/lua/love`
 
 ```json

--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -497,10 +497,10 @@ GADGETS = {
   },
   'local-lua-debugger-vscode': {
     'language': 'lua',
-    'enabled': False,
+    'enabled': True,
     'repo': {
       'url': 'https://github.com/tomblind/local-lua-debugger-vscode.git',
-      'ref': 'release-0.2.0'
+      'ref': 'release-${version}'
     },
     'all': {
       'version': '0.2.0',

--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -495,4 +495,31 @@ GADGETS = {
       },
     },
   },
+  'local-lua-debugger-vscode': {
+    'language': 'lua',
+    'enabled': False,
+    'repo': {
+      'url': 'https://github.com/tomblind/local-lua-debugger-vscode.git',
+      'ref': 'release-0.2.0'
+    },
+    'all': {
+      'version': '0.2.0',
+    },
+    'do': lambda name, root, gadget: installer.InstallLuaLocal( name,
+                                                                root,
+                                                                gadget ),
+    'adapters': {
+      'lua-local': {
+        'command': [
+          'node',
+          '${gadgetDir}/local-lua-debugger-vscode/extension/debugAdapter.js'
+        ],
+        'name': 'lua-local',
+        'configuration': {
+          'interpreter': 'lua',
+          'extensionPath': '${gadgetDir}/local-lua-debugger-vscode'
+        }
+      }
+    },
+  },
 }

--- a/python3/vimspector/installer.py
+++ b/python3/vimspector/installer.py
@@ -425,6 +425,13 @@ def InstallNodeDebug( name, root, gadget ):
   MakeSymlink( name, root )
 
 
+def InstallLuaLocal( name, root, gadget ):
+  with CurrentWorkingDir( root ):
+    CheckCall( [ 'npm', 'install' ] )
+    CheckCall( [ 'npm', 'run', 'build' ] )
+  MakeSymlink( name, root )
+
+
 def InstallGagdet( name: str,
                    gadget: dict,
                    manifest: Manifest,

--- a/support/test/lua/love-headless/.vimspector.json
+++ b/support/test/lua/love-headless/.vimspector.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json#",
+  "configurations": {
+    "love": {
+      "adapter": "lua-local",
+      "configuration": {
+        "request": "launch",
+        "type": "lua-local",
+        "cwd": "${workspaceFolder}",
+        "program": {
+          "command": "love"
+        },
+        "args": ["${workspaceFolder}"]
+      }
+    }
+  }
+}

--- a/support/test/lua/love-headless/conf.lua
+++ b/support/test/lua/love-headless/conf.lua
@@ -1,0 +1,12 @@
+function love.conf(t)
+    t.modules.audio = false
+    t.modules.font = false
+    t.modules.graphics = false
+    t.modules.image = false
+    t.modules.mouse = false
+    t.modules.physics = false
+    t.modules.sound = false
+    t.modules.touch = false
+    t.modules.video = false
+    t.modules.window = false
+end

--- a/support/test/lua/love-headless/main.lua
+++ b/support/test/lua/love-headless/main.lua
@@ -1,0 +1,10 @@
+if pcall(require, 'lldebugger') then
+  require('lldebugger').start()
+end
+
+local time = 0
+
+function love.update(dt)
+  time = time + dt
+  love.event.quit()
+end

--- a/support/test/lua/love/.vimspector.json
+++ b/support/test/lua/love/.vimspector.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json#",
+  "configurations": {
+    "love": {
+      "adapter": "lua-local",
+      "configuration": {
+        "request": "launch",
+        "type": "lua-local",
+        "cwd": "${workspaceFolder}",
+        "program": {
+          "command": "love"
+        },
+        "args": ["${workspaceFolder}"]
+      }
+    }
+  }
+}

--- a/support/test/lua/love/main.lua
+++ b/support/test/lua/love/main.lua
@@ -1,0 +1,21 @@
+if pcall(require, 'lldebugger') then
+  require('lldebugger').start()
+end
+
+local rect = {0, 0, 64, 64}
+
+
+function love.update(dt)
+  rect[1] = rect[1] + 10 * dt
+  rect[2] = rect[2] + 10 * dt
+end
+
+
+function love.draw()
+  love.graphics.rectangle('fill', rect[1], rect[2], rect[3], rect[4])
+end
+
+
+function love.keypressed()
+  love.event.quit()
+end

--- a/support/test/lua/simple/.vimspector.json
+++ b/support/test/lua/simple/.vimspector.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json#",
+  "configurations": {
+    "lua": {
+      "adapter": "lua-local",
+      "configuration": {
+        "request": "launch",
+        "type": "lua-local",
+        "cwd": "${workspaceFolder}",
+        "program": {
+          "lua": "lua",
+          "file": "simple.lua"
+        }
+      }
+    },
+    "luajit": {
+      "adapter": "lua-local",
+      "configuration": {
+        "request": "launch",
+        "type": "lua-local",
+        "cwd": "${workspaceFolder}",
+        "program": {
+          "lua": "luajit",
+          "file": "simple.lua"
+        }
+      }
+    }
+  }
+}

--- a/support/test/lua/simple/simple.lua
+++ b/support/test/lua/simple/simple.lua
@@ -1,0 +1,25 @@
+if pcall(require, 'lldebugger') then
+  require('lldebugger').start()
+end
+
+local separator = ' '
+
+
+local function createMessage()
+  local words = {}
+  table.insert(words, 'Hello')
+  table.insert(words, 'world')
+  return table.concat(words, separator)
+end
+
+
+local function withEmphasis(func)
+  return function()
+    return func() .. '!'
+  end
+end
+
+
+createMessage = withEmphasis(createMessage)
+
+print(createMessage())

--- a/tests/ci/image/Dockerfile
+++ b/tests/ci/image/Dockerfile
@@ -4,6 +4,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL C.UTF-8
 
 RUN apt-get update && \
+  apt install -y curl dirmngr apt-transport-https lsb-release ca-certificates \
+                 software-properties-common && \
+  curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+  add-apt-repository ppa:bartbes/love-stable -y && \
+  apt-get update && \
   apt-get -y dist-upgrade && \
   apt-get -y install python3-dev \
                      python3-pip \
@@ -17,9 +22,10 @@ RUN apt-get update && \
                      tcllib \
                      gdb \
                      lldb \
-                     curl \
                      nodejs \
-                     npm && \
+                     lua5.1 \
+                     luajit \
+                     love && \
   apt-get -y autoremove
 
 RUN ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime && \

--- a/tests/language_lua.test.vim
+++ b/tests/language_lua.test.vim
@@ -1,0 +1,84 @@
+function! SetUp()
+  let g:vimspector_enable_mappings = 'HUMAN'
+  call vimspector#test#setup#SetUpWithMappings( v:none )
+endfunction
+
+function! ClearDown()
+  call vimspector#test#setup#ClearDown()
+endfunction
+
+
+function! BaseTest( configuration )
+  let fn='simple.lua'
+  lcd ../support/test/lua/simple
+  exe 'edit ' . fn
+
+  call vimspector#SetLineBreakpoint( fn, 9 )
+  call vimspector#LaunchWithSettings( { 'configuration': a:configuration } )
+
+  " This debugger is ignoring stopOnEntry when not running a custom executable
+  " and always stopping on the first line after setting the hook. This first
+  " check assumes that behavior.
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 5, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 5 )
+        \ } )
+  " Continue
+  call feedkeys( "\<F5>", 'xt' )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 9, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 9 )
+        \ } )
+
+  " Step
+  call feedkeys( "\<F10>", 'xt' )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 10, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 10 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction
+
+
+function! Test_Lua_Simple()
+  call BaseTest( 'lua' )
+endfunction
+
+
+function! Test_Lua_Luajit()
+  call BaseTest( 'luajit' )
+endfunction
+
+
+function! Test_Lua_Love()
+  let fn='main.lua'
+  lcd ../support/test/lua/love-headless
+  exe 'edit ' . fn
+
+  call vimspector#SetLineBreakpoint( fn, 8 )
+  call vimspector#LaunchWithSettings( { 'configuration': 'love' } )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 8, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 8 )
+        \ } )
+
+  " Step
+  call feedkeys( "\<F10>", 'xt' )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 9, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 9 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction


### PR DESCRIPTION
Add the lua adapter to gadgets.py and installer.py, update the README.md file and create basic tests using lua, luajit and love.

I tested installing the lua debugger with both install_gadget.py and VimspectorInstall and tested debugging in both test cases added to support/test/lua.

I decided to add it as Supported and set `'enabled': False` in `gadgets.py`. If I'm wrong just tell me and I'll change it. 