### PR TITLE
[WIP] Improve Threads Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,17 @@ For a tutorial and usage overview, take a look at the
     * [Supported languages](#supported-languages)
     * [Other languages](#other-languages)
  * [Installation](#installation)
+    * [Quick Start](#quick-start)
     * [Dependencies](#dependencies)
     * [Neovim differences](#neovim-differences)
     * [Windows differences](#windows-differences)
-    * [Clone the plugin](#clone-the-plugin)
+    * [Trying it out](#trying-it-out)
+    * [Cloning the plugin](#cloning-the-plugin)
     * [Install some gadgets](#install-some-gadgets)
        * [VimspectorInstall and VimspectorUpdate commands](#vimspectorinstall-and-vimspectorupdate-commands)
        * [install_gadget.py](#install_gadgetpy)
     * [Manual gadget installation](#manual-gadget-installation)
        * [The gadget directory](#the-gadget-directory)
-    * [Trying it out](#trying-it-out)
     * [Upgrade](#upgrade)
  * [About](#about)
     * [Background](#background)
@@ -33,9 +34,11 @@ For a tutorial and usage overview, take a look at the
     * [Launch and attach by PID:](#launch-and-attach-by-pid)
        * [Launch with options](#launch-with-options)
        * [Debug configuration selection](#debug-configuration-selection)
+       * [Get configurations](#get-configurations)
     * [Breakpoints](#breakpoints)
        * [Exception breakpoints](#exception-breakpoints)
        * [Clear breakpoints](#clear-breakpoints)
+       * [Run to Cursor](#run-to-cursor)
     * [Stepping](#stepping)
     * [Variables and scopes](#variables-and-scopes)
     * [Watches](#watches)
@@ -48,6 +51,7 @@ For a tutorial and usage overview, take a look at the
     * [Closing debugger](#closing-debugger)
  * [Debug adapter configuration](#debug-adapter-configuration)
     * [C, C  , Rust, etc.](#c-c-rust-etc)
+    * [Rust](#rust)
        * [Remote debugging](#remote-debugging)
        * [Remote launch and attach](#remote-launch-and-attach)
     * [Python](#python)
@@ -65,7 +69,6 @@ For a tutorial and usage overview, take a look at the
        * [Usage with YouCompleteMe](#usage-with-youcompleteme)
        * [Other LSP clients](#other-lsp-clients)
     * [Lua](#lua)
-    * [Rust](#rust)
     * [Other servers](#other-servers)
  * [Customisation](#customisation)
     * [Changing the default signs](#changing-the-default-signs)
@@ -80,7 +83,7 @@ For a tutorial and usage overview, take a look at the
  * [License](#license)
  * [Sponsorship](#sponsorship)
 
-<!-- Added by: ben, at: Fri  4 Sep 2020 00:48:17 BST -->
+<!-- Added by: ben, at: Sun 22 Nov 2020 14:35:00 GMT -->
 
 <!--te-->
 
@@ -121,8 +124,6 @@ And a couple of brief demos:
 - logging/stdout display
 - simple stable API for custom tooling (e.g. integrate with language server)
 
-For other languages, you'll need some other way to install the gadget.
-
 ## Supported languages
 
 The following table lists the languages that are "built-in" (along with their
@@ -158,10 +159,12 @@ To use Vimspector with a language that's not "built-in", see this
 
 # Installation
 
+## Quick Start
+
 There are 2 installation methods:
 
-* Using a release tarball, or
-* Manually
+* Using a release tarball and vim packages
+* Using a clone of the repo (e.g. package manager)
 
 Release tarballs come with debug adapters for the default languages
 pre-packaged. To use a release tarball:
@@ -174,14 +177,26 @@ $ mkdir -p $HOME/.vim/pack
 $ curl -L <url> | tar -C $HOME/.vim/pack zxvf -
 ```
 
+3. Add `packadd! vimspector` to you `.vimrc`
+
 3. Configure your project's debug profiles (create `.vimspector.json`)
 
 Alternatively, you can clone the repo and select which gadgets are installed:
 
 1. Check the dependencies
 1. Install the plugin as a Vim package. See `:help packages`.
-2. Install some 'gadgets' (debug adapters)
+2. Add `packadd! vimspector` to you `.vimrc`
+2. Install some 'gadgets' (debug adapters) - see `:VimspectorInstall ...`
 3. Configure your project's debug profiles (create `.vimspector.json`)
+
+If you prefer to use a plugin manager, see the plugin manager's docs. For
+Vundle, use:
+
+```vim
+Plugin 'puremourning/vimspector'
+```
+
+The following sections expand on the above brief overview.
 
 ## Dependencies
 
@@ -239,20 +254,54 @@ The following features are not implemented for Windows:
 
 * Tailing the vimspector log in the Output Window.
 
-## Clone the plugin
+## Trying it out
+
+If you just want to try out vimspector without changing your vim config, there
+are example projects for a number of languages in `support/test`, including:
+
+* Python (`support/test/python/simple_python`)
+* Go (`support/test/go/hello_world`)
+* Nodejs (`support/test/node/simple`)
+* Chrome (`support/test/chrome/`)
+* etc.
+
+To test one of these out, cd to the directory and run:
+
+```
+vim -Nu /path/to/vimspector/tests/vimrc --cmd "let g:vimspector_enable_mappings='HUMAN'"
+```
+
+Then press `<F5>`.
+
+There's also a C++ project in `tests/testdata/cpp/simple/` with a `Makefile`
+which can be used to check everything is working. This is used by the regression
+tests in CI so should always work, and is a good way to check if the problem is
+your configuration rather than a bug.
+
+## Cloning the plugin
+
+If you're not using a release tarball, you'll need to clone this repo to the
+appropriate place.
+
+1. Clone the plugin
 
 There are many Vim plugin managers, and I'm not going to state a particular
-preference, so if you choose to use one, you're on your own with installation
-issues.
+preference, so if you choose to use one, follow the plugin manager's
+documentation. For example, for Vundle, use:
 
-Install vimspector as a Vim package, either by cloning this repository into your
-package path, like this:
+```viml
+Plugin 'puremourning/vimspector'
+```
+
+If you don't use a plugin manager already, install vimspector as a Vim package
+by cloning this repository into your package path, like this:
 
 ```
 $ git clone https://github.com/puremourning/vimspector ~/.vim/pack/vimspector/opt/vimspector
 ```
 
-2. Configure vimspector in your `.vimrc`:
+2. Configure vimspector in your `.vimrc`, for example to enable the standard
+   mapings:
 
 ```viml
 let g:vimspector_enable_mappings = 'HUMAN'
@@ -265,7 +314,7 @@ let g:vimspector_enable_mappings = 'HUMAN'
 packadd! vimspector
 ```
 
-See support/doc/example_vimrc.vim.
+See support/doc/example_vimrc.vim for a minimal example.
 
 ## Install some gadgets
 
@@ -281,11 +330,10 @@ There are a few ways to do this:
   installed for you.
 * Using `:VimspectorInstall <adapter> <args...>` (use TAB `wildmenu` to see the
   options, also accepts any `install_gadget.py` option)
-* Alternatively, using `python3 install_gadget.py <args>` (use `--help` to see
-  all options)
-* When attempting to launch a debug configuration, if the configured adapter
-  can't be found, vimspector might suggest installing one.
-* Use `:VimspectorUpdate` to install the latest supported versions of the
+* Using `python3 install_gadget.py <args>` (use `--help` to see all options)
+* Attempting to launch a debug configuration; if the configured adapter
+  can't be found, vimspector will suggest installing one.
+* Using `:VimspectorUpdate` to install the latest supported versions of the
   gadgets.
 
 Here's a demo of doing somee installs and an upgrade:
@@ -293,7 +341,7 @@ Here's a demo of doing somee installs and an upgrade:
 [![asciicast](https://asciinema.org/a/Hfu4ZvuyTZun8THNen9FQbTay.svg)](https://asciinema.org/a/Hfu4ZvuyTZun8THNen9FQbTay)
 
 Both `install_gadget.py` and `:VimspectorInstall` do the same set of things,
-though the default behaviours are slightly different.  For supported languages,
+though the default behaviours are slightly different. For supported languages,
 they will:
 
 * Download the relevant debug adapter at a version that's been tested from the
@@ -306,7 +354,7 @@ they will:
     broken in this regard.
   * Set up the `gadgetDir` symlinks for the platform.
 
-To install the tested debug adapter for a language, run:
+For example, to install the tested debug adapter for a language, run:
 
 | To install                          | Script                                        | Command                                         |
 | ---                                 | ---                                           | ---                                             |
@@ -467,30 +515,6 @@ Vimspector will also load any fies matching:
 `</path/to/vimspector>/gadgets/<os>/.gadgets.d/*.json`. These have the same
 format as `.gadgets.json` but are not overwritten when running
 `install_gadget.py`.
-
-## Trying it out
-
-If you just want to try out vimspector without changing your vim config, there
-are example projects for a number of languages in `support/test`, including:
-
-* Python (`support/test/python/simple_python`)
-* Go (`support/test/go/hello_world`)
-* Nodejs (`support/test/node/simple`)
-* Chrome (`support/test/chrome/`)
-* etc.
-
-To test one of these out, cd to the directory and run:
-
-```
-vim -Nu /path/to/vimspector/tests/vimrc --cmd "let g:vimspector_enable_mappings='HUMAN'"
-```
-
-Then press `<F5>`.
-
-There's also a C++ project in `tests/testdata/cpp/simple/` with a `Makefile`
-which can be used to check everything is working. This is used by the regression
-tests in CI so should always work, and is a good way to check if the problem is
-your configuration rather than a bug.
 
 ## Upgrade
 

--- a/README.md
+++ b/README.md
@@ -751,6 +751,9 @@ Scopes and variables are represented by the buffer `vimspector.Variables`.
 
 ## Watches
 
+The watch window is used to inspect variables and expressions. Expressions are
+evaluated in the selected stack frame which is "focussed"
+
 The watches window is a prompt buffer, where that's available. Enter insert mode
 to add a new watch expression.
 
@@ -767,7 +770,7 @@ The watches are represented by the buffer `vimspector.StackTrace`.
 
 ### Watch autocompletion
 
-The watch prompt buffer  has its `omnifunc` set to a function that will
+The watch prompt buffer has its `omnifunc` set to a function that will
 calcualte completion for the current expression. This is trivailly used with
 `<Ctrl-x><Ctrl-o>` (see `:help ins-completion`), or integrated with your
 favourite completion system. The filetype in the buffer is set to
@@ -783,8 +786,28 @@ let g:ycm_semantic_triggers =  {
 
 ## Stack Traces
 
-* In the threads window, use `<CR>`, or double-click with left mouse to expand/collapse.
+The stack trace window shows the state of each progream thread. Threads which
+are stopped can be expanded to show the strack trace of that thread.
+
+Often, but not always, all threads are stopped when a breakpoint is hit. The
+status of a thread is show in parentheses after the thread's name. Where
+supported by the underlying debugger, threads can be paused and continued
+individually from within the Stack Trace window.
+
+A particular thread, highlighted with the `CursorLine` highlight group is the
+"focussed" thread. This is the thread that receives commands like "Stop In",
+"Stop Out", "Continue" and "Pause" in the code window. The focussed thread can
+be changed manually to "switch to" that thread.
+
+* Use `<CR>`, or double-click with left mouse to expand/collapse a thread stack
+  trace, or use the WinBar button.
 * Use `<CR>`, or double-click with left mouse on a stack frame to jump to it.
+* Use the WinBar or `vimspector#PauseContinueThread()` to individually pause or
+  continue the selected thread.
+* Use the "Focus" WinBar button, `<leader><CR>` or `vimspector#SetCurrentThread()`
+  to set the "focussed" thread to the currently selected one. If the selected
+  line is a stack frame, set the focussed thread to the thread of that frame and
+  jump to that frame in the code window.
 
 ![stack trace](https://puremourning.github.io/vimspector-web/img/vimspector-callstack-window.png)
 

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -171,11 +171,18 @@ function! vimspector#Pause() abort
   py3 _vimspector_session.Pause()
 endfunction
 
-function! vimspector#PauseThread() abort
+function! vimspector#PauseContinueThread() abort
   if !s:Enabled()
     return
   endif
-  py3 _vimspector_session.PauseThread()
+  py3 _vimspector_session.PauseContinueThread()
+endfunction
+
+function! vimspector#SetCurrentThread() abort
+  if !s:Enabled()
+    return
+  endif
+  py3 _vimspector_session.SetCurrentThread()
 endfunction
 
 function! vimspector#Stop() abort

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -171,6 +171,13 @@ function! vimspector#Pause() abort
   py3 _vimspector_session.Pause()
 endfunction
 
+function! vimspector#PauseThread() abort
+  if !s:Enabled()
+    return
+  endif
+  py3 _vimspector_session.PauseThread()
+endfunction
+
 function! vimspector#Stop() abort
   if !s:Enabled()
     return

--- a/autoload/vimspector/internal/state.vim
+++ b/autoload/vimspector/internal/state.vim
@@ -34,6 +34,7 @@ function! vimspector#internal#state#Reset() abort
   catch /.*/
     echohl WarningMsg
     echom 'Exception while loading vimspector:' v:exception
+    echom 'From:' v:throwpoint
     echom 'Vimspector unavailable: Requires Vim compiled with Python 3.6'
     echohl None
     return v:false

--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -32,6 +32,7 @@ class CodeView( object ):
     self._logger = logging.getLogger( __name__ )
     utils.SetUpLogging( self._logger )
 
+    # FIXME: This ID is by group, so should be module scope
     self._next_sign_id = 1
     self._breakpoints = defaultdict( list )
     self._signs = {

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -492,6 +492,20 @@ class DebugSession( object ):
     } )
 
   @IfConnected()
+  def PauseThread( self ):
+    threadId = self._stackTraceView.GetSelectedThreadId()
+    if threadId is None:
+      utils.UserMessage( 'No thread selected' )
+      return
+
+    self._connection.DoRequest( None, {
+      'command': 'pause',
+      'arguments': {
+        'threadId': threadId,
+      },
+    } )
+
+  @IfConnected()
   def ExpandVariable( self ):
     self._variablesView.ExpandVariable()
 

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -477,8 +477,13 @@ class DebugSession( object ):
       utils.UserMessage( 'No current thread', persist = True )
       return
 
-    def handler( *_ ):
-      self._stackTraceView.OnContinued( { 'threadId': threadId } )
+    def handler( msg ):
+      self._stackTraceView.OnContinued( {
+          'threadId': threadId,
+          'allThreadsContinued': ( msg.get( 'body' ) or {} ).get(
+            'allThreadsContinued',
+            True )
+        } )
       self._codeView.SetCurrentFrame( None )
 
     self._connection.DoRequest( handler, {

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -1150,8 +1150,7 @@ class DebugSession( object ):
     pass
 
   def OnEvent_continued( self, message ):
-    # FIXME: allThreadsContinued ?
-    self._stackTraceView.OnContinued()
+    self._stackTraceView.OnContinued( message[ 'body' ] )
     self._codeView.SetCurrentFrame( None )
 
   def Clear( self ):

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -434,49 +434,59 @@ class DebugSession( object ):
 
   @IfConnected()
   def StepInto( self ):
-    if self._stackTraceView.GetCurrentThreadId() is None:
+    threadId = self._stackTraceView.GetCurrentThreadId()
+    if threadId is None:
       return
 
-    self._connection.DoRequest( None, {
+    def handler( *_ ):
+      self._stackTraceView.OnContinued( { 'threadId': threadId } )
+      self._codeView.SetCurrentFrame( None )
+
+    self._connection.DoRequest( handler, {
       'command': 'stepIn',
       'arguments': {
-        'threadId': self._stackTraceView.GetCurrentThreadId()
+        'threadId': threadId
       },
     } )
-    self._stackTraceView.OnContinued()
-    self._codeView.SetCurrentFrame( None )
 
   @IfConnected()
   def StepOut( self ):
-    if self._stackTraceView.GetCurrentThreadId() is None:
+    threadId = self._stackTraceView.GetCurrentThreadId()
+    if threadId is None:
       return
 
-    self._connection.DoRequest( None, {
+    def handler( *_ ):
+      self._stackTraceView.OnContinued( { 'threadId': threadId } )
+      self._codeView.SetCurrentFrame( None )
+
+    self._connection.DoRequest( handler, {
       'command': 'stepOut',
       'arguments': {
-        'threadId': self._stackTraceView.GetCurrentThreadId()
+        'threadId': threadId
       },
     } )
-    self._stackTraceView.OnContinued()
-    self._codeView.SetCurrentFrame( None )
+
 
   def Continue( self ):
     if not self._connection:
       self.Start()
       return
 
-    if self._stackTraceView.GetCurrentThreadId() is None:
+    threadId = self._stackTraceView.GetCurrentThreadId()
+    if threadId is None:
       utils.UserMessage( 'No current thread', persist = True )
       return
 
-    self._connection.DoRequest( None, {
+    def handler( *_ ):
+      self._stackTraceView.OnContinued( { 'threadId': threadId } )
+      self._codeView.SetCurrentFrame( None )
+
+    self._connection.DoRequest( handler, {
       'command': 'continue',
       'arguments': {
-        'threadId': self._stackTraceView.GetCurrentThreadId(),
+        'threadId': threadId,
       },
     } )
-    self._stackTraceView.OnContinued()
-    self._codeView.SetCurrentFrame( None )
 
   @IfConnected()
   def Pause( self ):

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -1136,6 +1136,7 @@ class DebugSession( object ):
     pass
 
   def OnEvent_continued( self, message ):
+    # FIXME: allThreadsContinued ?
     self._stackTraceView.OnContinued()
     self._codeView.SetCurrentFrame( None )
 

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -492,18 +492,12 @@ class DebugSession( object ):
     } )
 
   @IfConnected()
-  def PauseThread( self ):
-    threadId = self._stackTraceView.GetSelectedThreadId()
-    if threadId is None:
-      utils.UserMessage( 'No thread selected' )
-      return
+  def PauseContinueThread( self ):
+    self._stackTraceView.PauseContinueThread()
 
-    self._connection.DoRequest( None, {
-      'command': 'pause',
-      'arguments': {
-        'threadId': threadId,
-      },
-    } )
+  @IfConnected()
+  def SetCurrentThread( self ):
+    self._stackTraceView.SetCurrentThread()
 
   @IfConnected()
   def ExpandVariable( self ):

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -28,11 +28,12 @@ DEFAULTS = {
 
   # Signs
   'sign_priority': {
-    'vimspectorPC':         200,
-    'vimspectorPCBP':       200,
-    'vimspectorBP':         9,
-    'vimspectorBPCond':     9,
-    'vimspectorBPDisabled': 9,
+    'vimspectorPC':            200,
+    'vimspectorPCBP':          200,
+    'vimspectorBP':            9,
+    'vimspectorBPCond':        9,
+    'vimspectorBPDisabled':    9,
+    'vimspectorCurrentThread': 200
   },
 
   # Installer

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -205,6 +205,10 @@ class StackTraceView( object ):
 
         self._threads.append( thread )
 
+        # If the threads were requested due to a stopped event, update any
+        # stopped thread state. Note we have to do this here (rather than in the
+        # stopped event handler) because we must apply this event to any new
+        # threads that are received here.
         if stopEvent:
           if allThreadsStopped:
             thread.Paused( stopEvent )

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -109,6 +109,13 @@ class StackTraceView( object ):
       vim.command( 'nnoremap <silent> <buffer> <2-LeftMouse> '
                    ':<C-U>call vimspector#GoToFrame()<CR>' )
 
+      if utils.UseWinBar():
+        vim.command( 'nnoremenu 1.2 WinBar.Open '
+                     ':call vimspector#GoToFrame()<CR>' )
+        vim.command( 'nnoremenu 1.1 WinBar.Pause '
+                     ':call vimspector#PauseThread()<CR>' )
+
+
     self._line_to_frame = {}
     self._line_to_thread = {}
 
@@ -264,9 +271,21 @@ class StackTraceView( object ):
     self._connection.DoRequest( consume_stacktrace, {
       'command': 'stackTrace',
       'arguments': {
-        'threadId': thread.thread[ 'id' ],
+        'threadId': thread.id,
       }
     } )
+
+
+  def GetSelectedThreadId( self ):
+    if vim.current.buffer != self._buf:
+      return None
+
+    thread = self._line_to_thread.get( vim.current.window.cursor[ 0 ] )
+    if not thread:
+      return None
+
+    return thread.id
+
 
   def ExpandFrameOrThread( self ):
     if vim.current.buffer != self._buf:

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -200,7 +200,7 @@ class StackTraceView( object ):
       self._requesting_threads = StackTraceView.ThreadRequestState.NO
       self._pending_thread_request = None
 
-      existing_threads = self._threads[:]
+      existing_threads = self._threads[ : ]
       self._threads.clear()
 
       if stopEvent is not None:

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -81,8 +81,8 @@ class StackTraceView( object ):
     PENDING = 2
 
   # FIXME: Make into a dict by id ?
-  _threads: list[ Thread ]
-  _line_to_thread = dict[ int, Thread ]
+  _threads: typing.List[ Thread ]
+  _line_to_thread = typing.Dict[ int, Thread ]
 
   def __init__( self, session, win ):
     self._logger = logging.getLogger( __name__ )
@@ -264,25 +264,26 @@ class StackTraceView( object ):
     else:
       self._next_sign_id = 1
 
-    with ( utils.ModifiableScratchBuffer( self._buf ),
-           utils.RestoreCursorPosition() ):
-      utils.ClearBuffer( self._buf )
+    with utils.ModifiableScratchBuffer( self._buf ):
+      with utils.RestoreCursorPosition():
+        utils.ClearBuffer( self._buf )
 
-      for thread in self._threads:
-        icon = '+' if not thread.IsExpanded() else '-'
-        line = utils.AppendToBuffer(
-          self._buf,
-          f'{icon} Thread: {thread.thread["name"]} ({thread.State()})' )
+        for thread in self._threads:
+          icon = '+' if not thread.IsExpanded() else '-'
+          line = utils.AppendToBuffer(
+            self._buf,
+            f'{icon} Thread {thread.id}: {thread.thread["name"]} '
+            f'({thread.State()})' )
 
-        if self._current_thread == thread.id:
-          signs.PlaceSign( self._next_sign_id,
-                           'VimspectorStackTrace',
-                           'vimspectorCurrentThread',
-                           self._buf.name,
-                           line )
+          if self._current_thread == thread.id:
+            signs.PlaceSign( self._next_sign_id,
+                             'VimspectorStackTrace',
+                             'vimspectorCurrentThread',
+                             self._buf.name,
+                             line )
 
-        self._line_to_thread[ line ] = thread
-        self._DrawStackTrace( thread )
+          self._line_to_thread[ line ] = thread
+          self._DrawStackTrace( thread )
 
   def _LoadStackTrace( self,
                        thread: Thread,

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -329,9 +329,16 @@ class StackTraceView( object ):
     else:
       return do_jump()
 
-  def OnContinued( self, threadId = None ):
+  def OnContinued( self, event = None ):
+    threadId = None
+    allThreadsContinued = True
+
+    if event is not None:
+      threadId = event[ 'threadId' ]
+      allThreadsContinued = event.get( 'allThreadsContinued', False )
+
     for thread in self._threads:
-      if threadId is None:
+      if allThreadsContinued:
         thread.Continued()
       elif thread.id == threadId:
         thread.Continued()

--- a/run_tests
+++ b/run_tests
@@ -142,7 +142,7 @@ echo " * BASEDIR_CMD=$BASEDIR_CMD"
 echo "%SETUP - Building test programs..."
 set -e
   pushd tests/testdata/cpp/simple
-    make all
+    make clean all
   popd
 set +e
 echo "%DONE - built test programs"

--- a/run_tests
+++ b/run_tests
@@ -142,7 +142,7 @@ echo " * BASEDIR_CMD=$BASEDIR_CMD"
 echo "%SETUP - Building test programs..."
 set -e
   pushd tests/testdata/cpp/simple
-    make clean all
+    make all
   popd
 set +e
 echo "%DONE - built test programs"

--- a/support/test/node/simple/simple.js
+++ b/support/test/node/simple/simple.js
@@ -3,7 +3,7 @@ var msg = 'Hello, world!'
 var obj = {
   test: 'testing',
   toast: function() {
-    return 'toasty' . this.test;
+    return 'toasty' + this.test;
   }
 }
 

--- a/tests/breakpoints.test.vim
+++ b/tests/breakpoints.test.vim
@@ -1,5 +1,6 @@
 function! SetUp()
   call vimspector#test#setup#SetUpWithMappings( v:none )
+  call ThisTestIsFlaky()
 endfunction
 
 function! ClearDown()

--- a/tests/breakpoints.test.vim
+++ b/tests/breakpoints.test.vim
@@ -684,6 +684,7 @@ function! Test_Custom_Breakpoint_Priority_Partial()
 endfunction
 
 function! Test_Add_Line_BP_In_Other_File_While_Debugging()
+  call ThisTestIsFlaky()
   let moo = 'moo.py'
   let cow = 'cow.py'
   lcd ../support/test/python/multiple_files

--- a/tests/breakpoints_doublewidth.test.vim
+++ b/tests/breakpoints_doublewidth.test.vim
@@ -1,6 +1,7 @@
 function! SetUp()
   set ambiwidth=double
   call vimspector#test#setup#SetUpWithMappings( v:none )
+  call ThisTestIsFlaky()
 endfunction
 
 function! ClearDown()

--- a/tests/breakpoints_doublewidth.test.vim
+++ b/tests/breakpoints_doublewidth.test.vim
@@ -695,6 +695,7 @@ endfunction
 
 
 function! Test_Add_Line_BP_In_Other_File_While_Debugging()
+  call ThisTestIsFlaky()
   let moo = 'moo.py'
   let cow = 'cow.py'
   lcd ../support/test/python/multiple_files

--- a/tests/ci/image/Dockerfile
+++ b/tests/ci/image/Dockerfile
@@ -4,13 +4,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL C.UTF-8
 
 RUN apt-get update && \
-  apt install -y curl dirmngr apt-transport-https lsb-release ca-certificates \
-                 software-properties-common && \
+  apt-get install -y curl \
+                     dirmngr \
+                     apt-transport-https \
+                     lsb-release \
+                     ca-certificates \
+                     software-properties-common && \
   curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
   add-apt-repository ppa:bartbes/love-stable -y && \
   apt-get update && \
   apt-get -y dist-upgrade && \
-  apt-get -y install python3-dev \
+  apt-get -y install gcc-8 \
+                     g++-8 \
+                     python3-dev \
                      python3-pip \
                      python3-venv \
                      ca-cacert \
@@ -30,6 +36,9 @@ RUN apt-get update && \
 
 RUN ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime && \
   dpkg-reconfigure --frontend noninteractive tzdata
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1 \
+                        --slave   /usr/bin/g++ g++ /usr/bin/g++-8
 
 ## cleanup of files from setup
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/tests/lib/plugin/shared.vim
+++ b/tests/lib/plugin/shared.vim
@@ -51,7 +51,10 @@ func s:WaitForCommon(expr, assert, timeout)
     let start = reltime()
   endif
 
+  let iters = 0
+
   while 1
+    let iters += 1
     let errors_before = len( v:errors )
     if type(a:expr) == v:t_func
       let success = a:expr()
@@ -63,6 +66,10 @@ func s:WaitForCommon(expr, assert, timeout)
 
     if success
       return slept
+    endif
+
+    if iters % 20 == 0
+      redraw!
     endif
 
     if slept >= a:timeout

--- a/tests/lib/plugin/shared.vim
+++ b/tests/lib/plugin/shared.vim
@@ -91,3 +91,31 @@ endfunc
 function! ThisTestIsFlaky()
   let g:test_is_flaky = v:true
 endfunction
+
+function! AssertMatchist( expected, actual ) abort
+  let ret = assert_equal( len( a:expected ), len( a:actual ) )
+  let len = min( [ len( a:expected ), len( a:actual ) ] )
+  let idx = 0
+  while idx < len
+    let ret += assert_match( a:expected[ idx ], a:actual[ idx ] )
+    let idx += 1
+  endwhile
+  return ret
+endfunction
+
+
+function! GetBufLine( buf, start, end  = '$' )
+  if type( a:start ) != v:t_string && a:start < 0
+    let start = getbufinfo( a:buf )[ 0 ].linecount + a:start
+  else
+    let start = a:start
+  endif
+
+  if type( a:end ) != v:t_string && a:end < 0
+    let end = getbufinfo( a:buf )[ 0 ].linecount + a:end
+  else
+    let end = a:end
+  endif
+
+  return getbufline( a:buf, start, end )
+endfunction

--- a/tests/stack_trace.test.vim
+++ b/tests/stack_trace.test.vim
@@ -11,7 +11,7 @@ endfunction
 function! s:StartDebugging()
   exe 'edit ' . s:fn
   call vimspector#SetLineBreakpoint( s:fn, 15 )
-  call vimspector#Launch()
+  call vimspector#LaunchWithSettings( #{ configuration: 'run-to-breakpoint' } )
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 15, 1 )
 endfunction
 
@@ -32,8 +32,8 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '- Thread: Thread #1 (paused)',
-        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \         '- Thread [0-9]\+: .* (paused)',
+        \         '  .*: .*@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 1,
@@ -47,8 +47,8 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '- Thread: Thread #1 (paused)',
-        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \         '- Thread [0-9]\+: .* (paused)',
+        \         '  .*: .*@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 1,
@@ -58,7 +58,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -72,8 +72,8 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '- Thread: Thread #1 (paused)',
-        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \         '- Thread [0-9]\+: .* (paused)',
+        \         '  .*: .*@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 1,
@@ -83,7 +83,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #3 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -97,8 +97,8 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '- Thread: Thread #1 (paused)',
-        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \         '- Thread [0-9]\+: .* (paused)',
+        \         '  .*: .*@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 1,
@@ -108,7 +108,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #4 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -123,8 +123,8 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '- Thread: Thread #1 (paused)',
-        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \         '- Thread [0-9]\+: .* (paused)',
+        \         '  .*: .*@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 1,
@@ -134,7 +134,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #5 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -148,8 +148,8 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '- Thread: Thread #1 (paused)',
-        \         '  .*: threads!main@threads.cpp:' . string( notify_l )
+        \         '- Thread [0-9]\+: .* (paused)',
+        \         '  .*: .*@threads.cpp:' . string( notify_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 1,
@@ -159,7 +159,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #6 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -174,7 +174,13 @@ endfunction
 
 function! Test_Multiple_Threads_Step()
   let thread_l = 67
-  let thread_n = thread_l + 1
+  if $VIMSPECTOR_MIMODE ==# 'lldb'
+    " }
+    let thread_n = thread_l + 1
+  else
+    " for ....
+    let thread_n = 49
+  endif
   let notify_l = 74
 
   call vimspector#SetLineBreakpoint( s:fn, thread_l )
@@ -188,8 +194,8 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '- Thread: Thread #1 (paused)',
-        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \         '- Thread [0-9]\+: .* (paused)',
+        \         '  .*: .*@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 1,
@@ -201,7 +207,7 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -214,7 +220,7 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -226,8 +232,8 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2 (paused)',
-        \         '+ Thread: Thread #3 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -1,
@@ -240,8 +246,8 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2 (paused)',
-        \         '+ Thread: Thread #3 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -1,
@@ -253,9 +259,9 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2 (paused)',
-        \         '+ Thread: Thread #3 (paused)',
-        \         '+ Thread: Thread #4 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -2,
@@ -269,9 +275,9 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2 (paused)',
-        \         '+ Thread: Thread #3 (paused)',
-        \         '+ Thread: Thread #4 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -2,
@@ -283,10 +289,10 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2 (paused)',
-        \         '+ Thread: Thread #3 (paused)',
-        \         '+ Thread: Thread #4 (paused)',
-        \         '+ Thread: Thread #5 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -3,
@@ -300,10 +306,10 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2 (paused)',
-        \         '+ Thread: Thread #3 (paused)',
-        \         '+ Thread: Thread #4 (paused)',
-        \         '+ Thread: Thread #5 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -3,
@@ -315,11 +321,11 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2 (paused)',
-        \         '+ Thread: Thread #3 (paused)',
-        \         '+ Thread: Thread #4 (paused)',
-        \         '+ Thread: Thread #5 (paused)',
-        \         '+ Thread: Thread #6 (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -4,
@@ -334,10 +340,14 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #6',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
+        \         '+ Thread [0-9]\+: .* (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
-        \                 '$',
+        \                 -4,
         \                 '$' )
         \   )
         \ } )

--- a/tests/stack_trace.test.vim
+++ b/tests/stack_trace.test.vim
@@ -33,7 +33,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1',
+        \         '> Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -48,7 +48,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1',
+        \         '> Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -59,7 +59,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2',
+        \         '+ Thread: Thread #2 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -73,7 +73,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1',
+        \         '> Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -84,7 +84,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #3',
+        \         '+ Thread: Thread #3 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -98,7 +98,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1',
+        \         '> Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -109,7 +109,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #4',
+        \         '+ Thread: Thread #4 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -124,7 +124,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1',
+        \         '> Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -135,7 +135,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #5',
+        \         '+ Thread: Thread #5 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -149,7 +149,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1',
+        \         '> Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( notify_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -160,7 +160,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #6',
+        \         '+ Thread: Thread #6 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -189,7 +189,7 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1',
+        \         '> Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -202,7 +202,7 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2',
+        \         '+ Thread: Thread #2 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -215,7 +215,7 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2',
+        \         '+ Thread: Thread #2 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 '$',
@@ -227,8 +227,8 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2',
-        \         '+ Thread: Thread #3',
+        \         '+ Thread: Thread #2 (paused)',
+        \         '+ Thread: Thread #3 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -1,
@@ -241,8 +241,8 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2',
-        \         '+ Thread: Thread #3',
+        \         '+ Thread: Thread #2 (paused)',
+        \         '+ Thread: Thread #3 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -1,
@@ -254,9 +254,9 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2',
-        \         '+ Thread: Thread #3',
-        \         '+ Thread: Thread #4',
+        \         '+ Thread: Thread #2 (paused)',
+        \         '+ Thread: Thread #3 (paused)',
+        \         '+ Thread: Thread #4 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -2,
@@ -270,9 +270,9 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2',
-        \         '+ Thread: Thread #3',
-        \         '+ Thread: Thread #4',
+        \         '+ Thread: Thread #2 (paused)',
+        \         '+ Thread: Thread #3 (paused)',
+        \         '+ Thread: Thread #4 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -2,
@@ -284,10 +284,10 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2',
-        \         '+ Thread: Thread #3',
-        \         '+ Thread: Thread #4',
-        \         '+ Thread: Thread #5',
+        \         '+ Thread: Thread #2 (paused)',
+        \         '+ Thread: Thread #3 (paused)',
+        \         '+ Thread: Thread #4 (paused)',
+        \         '+ Thread: Thread #5 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -3,
@@ -301,10 +301,10 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2',
-        \         '+ Thread: Thread #3',
-        \         '+ Thread: Thread #4',
-        \         '+ Thread: Thread #5',
+        \         '+ Thread: Thread #2 (paused)',
+        \         '+ Thread: Thread #3 (paused)',
+        \         '+ Thread: Thread #4 (paused)',
+        \         '+ Thread: Thread #5 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -3,
@@ -316,11 +316,11 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '+ Thread: Thread #2',
-        \         '+ Thread: Thread #3',
-        \         '+ Thread: Thread #4',
-        \         '+ Thread: Thread #5',
-        \         '+ Thread: Thread #6',
+        \         '+ Thread: Thread #2 (paused)',
+        \         '+ Thread: Thread #3 (paused)',
+        \         '+ Thread: Thread #4 (paused)',
+        \         '+ Thread: Thread #5 (paused)',
+        \         '+ Thread: Thread #6 (paused)',
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
         \                 -4,

--- a/tests/stack_trace.test.vim
+++ b/tests/stack_trace.test.vim
@@ -10,38 +10,338 @@ endfunction
 
 function! s:StartDebugging()
   exe 'edit ' . s:fn
-  call vimspector#SetLineBreakpoint( s:fn, 13 )
+  call vimspector#SetLineBreakpoint( s:fn, 15 )
   call vimspector#Launch()
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 13, 1 )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 15, 1 )
 endfunction
 
-function! Test_Multiple_Threads()
-  call vimspector#SetLineBreakpoint( s:fn, 41 )
-  call vimspector#SetLineBreakpoint( s:fn, 51 )
+function! Test_Multiple_Threads_Continue()
+
+  let thread_l = 67
+  let notify_l = 74
+
+  call vimspector#SetLineBreakpoint( s:fn, thread_l )
+  call vimspector#SetLineBreakpoint( s:fn, notify_l )
   call s:StartDebugging()
 
   call vimspector#Continue()
 
   " As we step through the thread creation we should get Thread events
 
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 41, 1 )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_l, 1 )
+  call cursor( 1, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '> Thread: Thread #1',
+        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 1,
+        \                 2 )
+        \   )
+        \ } )
   call vimspector#Continue()
 
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 41, 1 )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_l, 1 )
+  call cursor( 1, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '> Thread: Thread #1',
+        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 1,
+        \                 2 )
+        \   )
+        \ } )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #2',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 '$',
+        \                 '$' )
+        \   )
+        \ } )
   call vimspector#Continue()
 
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 41, 1 )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_l, 1 )
+  call cursor( 1, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '> Thread: Thread #1',
+        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 1,
+        \                 2 )
+        \   )
+        \ } )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #3',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 '$',
+        \                 '$' )
+        \   )
+        \ } )
   call vimspector#Continue()
 
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 41, 1 )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_l, 1 )
+  call cursor( 1, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '> Thread: Thread #1',
+        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 1,
+        \                 2 )
+        \   )
+        \ } )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #4',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 '$',
+        \                 '$' )
+        \   )
+        \ } )
   call vimspector#Continue()
 
   " This is the last one
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 41, 1 )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_l, 1 )
+  call cursor( 1, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '> Thread: Thread #1',
+        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 1,
+        \                 2 )
+        \   )
+        \ } )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #5',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 '$',
+        \                 '$' )
+        \   )
+        \ } )
   call vimspector#Continue()
 
   " So we break out of the loop
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 51, 1 )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, notify_l, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '> Thread: Thread #1',
+        \         '  .*: threads!main@threads.cpp:' . string( notify_l )
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 1,
+        \                 2 )
+        \   )
+        \ } )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #6',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 '$',
+        \                 '$' )
+        \   )
+        \ } )
+
+  call vimspector#ClearBreakpoints()
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+function! Test_Multiple_Threads_Step()
+  let thread_l = 67
+  let thread_n = thread_l + 1
+  let notify_l = 74
+
+  call vimspector#SetLineBreakpoint( s:fn, thread_l )
+  call vimspector#SetLineBreakpoint( s:fn, notify_l )
+  call s:StartDebugging()
+  call vimspector#Continue()
+
+  " As we step through the thread creation we should get Thread events
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_l, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '> Thread: Thread #1',
+        \         '  .*: threads!main@threads.cpp:' . string( thread_l )
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 1,
+        \                 2 )
+        \   )
+        \ } )
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_n, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #2',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 '$',
+        \                 '$' )
+        \   )
+        \ } )
+  call vimspector#Continue()
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_l, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #2',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 '$',
+        \                 '$' )
+        \   )
+        \ } )
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_n, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #2',
+        \         '+ Thread: Thread #3',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 -1,
+        \                 '$' )
+        \   )
+        \ } )
+  call vimspector#Continue()
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_l, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #2',
+        \         '+ Thread: Thread #3',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 -1,
+        \                 '$' )
+        \   )
+        \ } )
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_n, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #2',
+        \         '+ Thread: Thread #3',
+        \         '+ Thread: Thread #4',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 -2,
+        \                 '$' )
+        \   )
+        \ } )
+  call vimspector#Continue()
+
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_l, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #2',
+        \         '+ Thread: Thread #3',
+        \         '+ Thread: Thread #4',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 -2,
+        \                 '$' )
+        \   )
+        \ } )
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_n, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #2',
+        \         '+ Thread: Thread #3',
+        \         '+ Thread: Thread #4',
+        \         '+ Thread: Thread #5',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 -3,
+        \                 '$' )
+        \   )
+        \ } )
+  call vimspector#Continue()
+
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_l, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #2',
+        \         '+ Thread: Thread #3',
+        \         '+ Thread: Thread #4',
+        \         '+ Thread: Thread #5',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 -3,
+        \                 '$' )
+        \   )
+        \ } )
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, thread_n, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #2',
+        \         '+ Thread: Thread #3',
+        \         '+ Thread: Thread #4',
+        \         '+ Thread: Thread #5',
+        \         '+ Thread: Thread #6',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 -4,
+        \                 '$' )
+        \   )
+        \ } )
+  call vimspector#Continue()
+
+
+  " So we break out of the loop
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, notify_l, 1 )
+  call WaitForAssert( {->
+        \   AssertMatchist(
+        \     [
+        \         '+ Thread: Thread #6',
+        \     ],
+        \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
+        \                 '$',
+        \                 '$' )
+        \   )
+        \ } )
 
   call vimspector#ClearBreakpoints()
   call vimspector#test#setup#Reset()

--- a/tests/stack_trace.test.vim
+++ b/tests/stack_trace.test.vim
@@ -347,3 +347,5 @@ function! Test_Multiple_Threads_Step()
   call vimspector#test#setup#Reset()
   %bwipe!
 endfunction
+
+" TODO: Set current frame while thread is running sets the PC

--- a/tests/stack_trace.test.vim
+++ b/tests/stack_trace.test.vim
@@ -16,7 +16,6 @@ function! s:StartDebugging()
 endfunction
 
 function! Test_Multiple_Threads_Continue()
-
   let thread_l = 67
   let notify_l = 74
 
@@ -33,7 +32,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1 (paused)',
+        \         '- Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -48,7 +47,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1 (paused)',
+        \         '- Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -73,7 +72,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1 (paused)',
+        \         '- Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -98,7 +97,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1 (paused)',
+        \         '- Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -124,7 +123,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1 (paused)',
+        \         '- Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -149,7 +148,7 @@ function! Test_Multiple_Threads_Continue()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1 (paused)',
+        \         '- Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( notify_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -189,7 +188,7 @@ function! Test_Multiple_Threads_Step()
   call WaitForAssert( {->
         \   AssertMatchist(
         \     [
-        \         '> Thread: Thread #1 (paused)',
+        \         '- Thread: Thread #1 (paused)',
         \         '  .*: threads!main@threads.cpp:' . string( thread_l )
         \     ],
         \     GetBufLine( winbufnr( g:vimspector_session_windows.stack_trace ),
@@ -347,5 +346,3 @@ function! Test_Multiple_Threads_Step()
   call vimspector#test#setup#Reset()
   %bwipe!
 endfunction
-
-" TODO: Set current frame while thread is running sets the PC

--- a/tests/stack_trace.test.vim
+++ b/tests/stack_trace.test.vim
@@ -1,0 +1,49 @@
+let s:fn='testdata/cpp/simple/threads.cpp'
+
+function! SetUp()
+  call vimspector#test#setup#SetUpWithMappings( 'HUMAN' )
+endfunction
+
+function! ClearDown()
+  call vimspector#test#setup#ClearDown()
+endfunction
+
+function! s:StartDebugging()
+  exe 'edit ' . s:fn
+  call vimspector#SetLineBreakpoint( s:fn, 13 )
+  call vimspector#Launch()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 13, 1 )
+endfunction
+
+function! Test_Multiple_Threads()
+  call vimspector#SetLineBreakpoint( s:fn, 41 )
+  call vimspector#SetLineBreakpoint( s:fn, 51 )
+  call s:StartDebugging()
+
+  call vimspector#Continue()
+
+  " As we step through the thread creation we should get Thread events
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 41, 1 )
+  call vimspector#Continue()
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 41, 1 )
+  call vimspector#Continue()
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 41, 1 )
+  call vimspector#Continue()
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 41, 1 )
+  call vimspector#Continue()
+
+  " This is the last one
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 41, 1 )
+  call vimspector#Continue()
+
+  " So we break out of the loop
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 51, 1 )
+
+  call vimspector#ClearBreakpoints()
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction

--- a/tests/testdata/cpp/simple/.gitignore
+++ b/tests/testdata/cpp/simple/.gitignore
@@ -2,3 +2,4 @@ simple
 variables
 struct
 printer
+threads

--- a/tests/testdata/cpp/simple/.ycm_extra_conf.py
+++ b/tests/testdata/cpp/simple/.ycm_extra_conf.py
@@ -2,6 +2,7 @@ def Settings( **kwargs ):
   return {
     'flags': [
       '-x', 'c++',
+      '-std=c++17',
       '-Wextra', '-Werror', '-Wall'
     ]
   }

--- a/tests/testdata/cpp/simple/Makefile
+++ b/tests/testdata/cpp/simple/Makefile
@@ -3,6 +3,7 @@ CXXFLAGS=-g -O0 -std=c++17
 .PHONY: all
 
 TARGETS=simple variables struct printer threads
+LDLIBS=-lpthread
 
 all: $(TARGETS)
 

--- a/tests/testdata/cpp/simple/Makefile
+++ b/tests/testdata/cpp/simple/Makefile
@@ -2,7 +2,7 @@ CXXFLAGS=-g -O0 -std=c++17
 
 .PHONY: all
 
-TARGETS=simple variables struct printer
+TARGETS=simple variables struct printer threads
 
 all: $(TARGETS)
 

--- a/tests/testdata/cpp/simple/threads.cpp
+++ b/tests/testdata/cpp/simple/threads.cpp
@@ -1,0 +1,57 @@
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <string_view>
+#include <system_error>
+#include <thread>
+#include <vector>
+#include <charconv>
+#include <random>
+
+int main( int argc, char ** argv )
+{
+  int numThreads = {};
+  if ( argc < 2 )
+  {
+    numThreads = 5;
+  }
+  else
+  {
+    std::string_view numThreadArg( argv[ 1 ] );
+    if ( auto [ p, ec ] = std::from_chars( numThreadArg.begin(),
+                                           numThreadArg.end(),
+                                           numThreads );
+         ec != std::errc() )
+    {
+      std::cerr << "Usage " << argv[ 0 ] << " <number of threads>\n";
+      return 2;
+    }
+  }
+
+  std::cout << "Creating " << numThreads << " threads" << '\n';
+
+  std::vector<std::thread> threads{};
+  threads.reserve( numThreads );
+
+  auto eng = std::default_random_engine() ;
+  auto dist = std::uniform_int_distribution<int>( 250, 1000 );
+
+  for ( int i = 0; i < numThreads; ++i )
+  {
+    using namespace std::chrono_literals;
+    threads.emplace_back( [&,tnum=i]() {
+      std::cout << "Started thread " << tnum << '\n';
+      std::this_thread::sleep_for(
+        5s + std::chrono::milliseconds( dist( eng ) ) );
+      std::cout << "Completed thread " << tnum << '\n';
+    });
+  }
+
+
+  for ( int i = 0; i < numThreads; ++i )
+  {
+    threads[ i ].join();
+  }
+
+  return 0;
+}

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -8,17 +8,6 @@ function! ClearDown()
   call vimspector#test#setup#ClearDown()
 endfunction
 
-function! s:assert_match_list( expected, actual ) abort
-  let ret = assert_equal( len( a:expected ), len( a:actual ) )
-  let len = min( [ len( a:expected ), len( a:actual ) ] )
-  let idx = 0
-  while idx < len
-    let ret += assert_match( a:expected[ idx ], a:actual[ idx ] )
-    let idx += 1
-  endwhile
-  return ret
-endfunction
-
 function! s:StartDebugging( ... )
   if a:0 == 0
     let config = #{
@@ -222,7 +211,7 @@ function! Test_ExpandVariables()
   call feedkeys( "\<CR>", 'xt' )
 
   call WaitForAssert( {->
-        \   s:assert_match_list(
+        \   AssertMatchist(
         \     [
         \       '- Scope: Locals',
         \       ' \*- t (Test): {...}',
@@ -240,7 +229,7 @@ function! Test_ExpandVariables()
   " Step - stays expanded
   call vimspector#StepOver()
   call WaitForAssert( {->
-        \   s:assert_match_list(
+        \   AssertMatchist(
         \     [
         \       '- Scope: Locals',
         \       '  - t (Test): {...}',
@@ -289,7 +278,7 @@ function! Test_ExpandVariables()
   call setpos( '.', [ 0, 2, 1 ] )
   call feedkeys( "\<CR>", 'xt' )
   call WaitForAssert( {->
-        \   s:assert_match_list(
+        \   AssertMatchist(
         \     [
         \       '- Scope: Locals',
         \       '  - t (Test): {...}',
@@ -389,7 +378,7 @@ function! Test_ExpandWatch()
   call feedkeys( "\<CR>", 'xt' )
 
   call WaitForAssert( {->
-        \   s:assert_match_list(
+        \   AssertMatchist(
         \     [
         \       'Watches: ----',
         \       'Expression: t',
@@ -408,7 +397,7 @@ function! Test_ExpandWatch()
   " Step - stays expanded
   call vimspector#StepOver()
   call WaitForAssert( {->
-        \   s:assert_match_list(
+        \   AssertMatchist(
         \     [
         \       'Watches: ----',
         \       'Expression: t',
@@ -460,7 +449,7 @@ function! Test_ExpandWatch()
   call setpos( '.', [ 0, 3, 1 ] )
   call feedkeys( "\<CR>", 'xt' )
   call WaitForAssert( {->
-        \   s:assert_match_list(
+        \   AssertMatchist(
         \     [
         \       'Watches: ----',
         \       'Expression: t',


### PR DESCRIPTION
Fixes #285 

Specification:

> Whenever the generic debugger receives a stopped or a thread event, the development tool requests all threads that exist at that point in time. Thread events are optional, but a debug adapter can send them to force the development tool to update the threads UI dynamically even when not in a stopped state. If a debug adapter decides not to emit Thread events, the thread UI in the development tool will only update if a stopped event is received.

> After a successful launch or attach, the development tool requests the baseline of currently existing threads with the threads request and then starts to listen for thread events to detect new or terminated threads. Even if a debug adapter does not support multiple threads, it must implement the threads request and return a single (dummy) thread. The thread id must be used in all requests which refer to a thread, e.g. stacktrace, pause, continue, next, stepIn, and stepOut.

So now, we do that:

- always request threads on `thread` event
- always request threads on `stopped` event

Previously, we didn't do this I think because of flickering redrawing the UI. It's also super inefficient, but the protocol is the protocol.

Visible changes include:

* Indicate when threads are `(running)` (current this is all or nothing which is wrong)
* Fix annoying cursor moving when expanding threads to get stack trace
* indicate which thread is the "current" thread (currently this is in hieroglyphs, so need a better way)

Internal changes include:

* Move the dodgy continue/pause thing out of stack trace and back to debug session, replace with OnContinued/OnStopped
* Don't clear the world on every step to avoid flickering
* Fix the delayed-threads-load which was broken for some time
* Avoid flickering when stepping now that we load the threads on each stopped event

TODO:

* [x] indicate the current thread with a line highlight - suggestion to use a sign, but set sign column= no, then use linehl in the sign definition to set cursorline
* [x] track running state for each thread individually, and properly handle `allThreadsStopped`
* [x] add continue/pause buttons to the thread window as well as the code window, allowing individual thread control
* [ ] add expand all / collapse all per gitter discussion?
* [x] test what happens with like 1000 coroutines
* [x] include the thread ID in the thread window, as this is what's included in the message "Stopped in thread <id> due to <reason>"
* [ ] moar tests
* [ ] move the pause/contnue/step functionality back into the stack_trace to avoid duplication of the 'continue' behaviour (or move the PauseContinue _out_ of StackTrace, which seems retrograde)]
* [x] add keyboard mappings for focus thread
* [ ] make focus thread, continue/pause work when on a stack frame (apply to nearest thread)
* [x] update docs and tutorial ?
