### PR TITLE
Work around neovim WinBar rendering bug

### DIFF
--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -41,14 +41,25 @@ class CodeView( object ):
     self._current_frame = None
 
     with utils.LetCurrentWindow( self._window ):
-      vim.command( 'nnoremenu WinBar.■\\ Stop :call vimspector#Stop()<CR>' )
-      vim.command( 'nnoremenu WinBar.▶\\ Cont :call vimspector#Continue()<CR>' )
-      vim.command( 'nnoremenu WinBar.▷\\ Pause :call vimspector#Pause()<CR>' )
-      vim.command( 'nnoremenu WinBar.↷\\ Next :call vimspector#StepOver()<CR>' )
-      vim.command( 'nnoremenu WinBar.→\\ Step :call vimspector#StepInto()<CR>' )
-      vim.command( 'nnoremenu WinBar.←\\ Out :call vimspector#StepOut()<CR>' )
-      vim.command( 'nnoremenu WinBar.⟲: :call vimspector#Restart()<CR>' )
-      vim.command( 'nnoremenu WinBar.✕ :call vimspector#Reset()<CR>' )
+      if utils.UseWinBar():
+        # Buggy neovim doesn't render correctly when the WinBar is defined:
+        # https://github.com/neovim/neovim/issues/12689
+        vim.command( 'nnoremenu WinBar.■\\ Stop '
+                     ':call vimspector#Stop()<CR>' )
+        vim.command( 'nnoremenu WinBar.▶\\ Cont '
+                     ':call vimspector#Continue()<CR>' )
+        vim.command( 'nnoremenu WinBar.▷\\ Pause '
+                     ':call vimspector#Pause()<CR>' )
+        vim.command( 'nnoremenu WinBar.↷\\ Next '
+                     ':call vimspector#StepOver()<CR>' )
+        vim.command( 'nnoremenu WinBar.→\\ Step '
+                     ':call vimspector#StepInto()<CR>' )
+        vim.command( 'nnoremenu WinBar.←\\ Out '
+                     ':call vimspector#StepOut()<CR>' )
+        vim.command( 'nnoremenu WinBar.⟲: '
+                     ':call vimspector#Restart()<CR>' )
+        vim.command( 'nnoremenu WinBar.✕ '
+                     ':call vimspector#Reset()<CR>' )
 
       if not signs.SignDefined( 'vimspectorPC' ):
         signs.DefineSign( 'vimspectorPC',

--- a/python3/vimspector/output.py
+++ b/python3/vimspector/output.py
@@ -210,6 +210,9 @@ class OutputView( object ):
       utils.CleanUpHiddenBuffer( buf_to_delete )
 
   def _RenderWinBar( self, category ):
+    if not utils.UseWinBar():
+      return
+
     if not self._window.valid:
       return
 

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -785,3 +785,9 @@ def WindowID( window, tab=None ):
   if tab is None:
     tab = window.tabpage
   return int( Call( 'win_getid', window.number, tab.number ) )
+
+
+def UseWinBar():
+  # Buggy neovim doesn't render correctly when the WinBar is defined:
+  # https://github.com/neovim/neovim/issues/12689
+  return not int( Call( 'has', 'nvim' ) )

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -159,12 +159,13 @@ class VariablesView( object ):
       vim.command(
         'nnoremap <buffer> <DEL> :call vimspector#DeleteWatch()<CR>' )
 
-      vim.command( 'nnoremenu 1.1 WinBar.New '
-                   ':call vimspector#AddWatch()<CR>' )
-      vim.command( 'nnoremenu 1.2 WinBar.Expand/Collapse '
-                   ':call vimspector#ExpandVariable()<CR>' )
-      vim.command( 'nnoremenu 1.3 WinBar.Delete '
-                   ':call vimspector#DeleteWatch()<CR>' )
+      if utils.UseWinBar():
+        vim.command( 'nnoremenu 1.1 WinBar.New '
+                     ':call vimspector#AddWatch()<CR>' )
+        vim.command( 'nnoremenu 1.2 WinBar.Expand/Collapse '
+                     ':call vimspector#ExpandVariable()<CR>' )
+        vim.command( 'nnoremenu 1.3 WinBar.Delete '
+                     ':call vimspector#DeleteWatch()<CR>' )
 
     # Set the (global!) balloon expr if supported
     has_balloon      = int( vim.eval( "has( 'balloon_eval' )" ) )


### PR DESCRIPTION
https://github.com/neovim/neovim/issues/12689

don't create the winbar if the vim emulator is neovim. it seems to not know how to render if you create a menu named `WinBar.<anything>`

Too many people are using neovim "0.5" and experiencing horrible UI to wait for it to be fixed, so we work around it.

Fixes #300 