### PR TITLE
Improve lua configuration and test files

### DIFF
--- a/support/test/lua/love-headless/.vimspector.json
+++ b/support/test/lua/love-headless/.vimspector.json
@@ -10,7 +10,8 @@
         "program": {
           "command": "love"
         },
-        "args": ["${workspaceFolder}"]
+        "args": ["${workspaceFolder}"],
+        "stopOnEntry": false
       }
     }
   }

--- a/support/test/lua/love/.vimspector.json
+++ b/support/test/lua/love/.vimspector.json
@@ -10,7 +10,8 @@
         "program": {
           "command": "love"
         },
-        "args": ["${workspaceFolder}"]
+        "args": ["${workspaceFolder}"],
+        "stopOnEntry": false
       }
     }
   }

--- a/support/test/lua/simple/.vimspector.json
+++ b/support/test/lua/simple/.vimspector.json
@@ -9,7 +9,8 @@
         "cwd": "${workspaceFolder}",
         "program": {
           "lua": "lua",
-          "file": "simple.lua"
+          "file": "simple.lua",
+          "stopOnEntry": false
         }
       }
     },
@@ -21,7 +22,8 @@
         "cwd": "${workspaceFolder}",
         "program": {
           "lua": "luajit",
-          "file": "simple.lua"
+          "file": "simple.lua",
+          "stopOnEntry": false
         }
       }
     }

--- a/support/test/lua/simple/simple.lua
+++ b/support/test/lua/simple/simple.lua
@@ -1,7 +1,3 @@
-if pcall(require, 'lldebugger') then
-  require('lldebugger').start()
-end
-
 local separator = ' '
 
 

--- a/tests/language_lua.test.vim
+++ b/tests/language_lua.test.vim
@@ -13,30 +13,20 @@ function! BaseTest( configuration )
   lcd ../support/test/lua/simple
   exe 'edit ' . fn
 
-  call vimspector#SetLineBreakpoint( fn, 9 )
+  call vimspector#SetLineBreakpoint( fn, 5 )
   call vimspector#LaunchWithSettings( { 'configuration': a:configuration } )
 
-  " This debugger is ignoring stopOnEntry when not running a custom executable
-  " and always stopping on the first line after setting the hook. This first
-  " check assumes that behavior.
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 5, 1 )
   call WaitForAssert( {->
         \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 5 )
-        \ } )
-  " Continue
-  call feedkeys( "\<F5>", 'xt' )
-
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 9, 1 )
-  call WaitForAssert( {->
-        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 9 )
         \ } )
 
   " Step
   call feedkeys( "\<F10>", 'xt' )
 
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 10, 1 )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 6, 1 )
   call WaitForAssert( {->
-        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 10 )
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 6 )
         \ } )
 
   call vimspector#test#setup#Reset()


### PR DESCRIPTION
Change lua test files to call `require 'lldebugger'` only when using love, because it's not needed with lua or luajit. Also add `stopOnEntry` key to test `.vimspector.json` because it works correctly with this change.

Did this change after talking to the developer of local-lua-debugger-vscode about stopOnEntry not working correctly and it turned out my configuration was wrong and it actually works. Changed all relevant files here to reflect the correct usage.