### PR TITLE
README: Note that prompt buffers work in neovim master/0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ neovim doesn't implement some features Vimspector relies on:
 
 * WinBar - used for the buttons at the top of the code window and for changing
   the output window's current output.
-* Prompt Buffers - used to send commands in the Console and add Watches
+* ~~Prompt Buffers - used to send commands in the Console and add Watches.~~ Prompt buffers are available inside **5.0** nightly release ([see](https://github.com/neovim/neovim/releases/nightly))
 * Balloons - used to display the values of variables when debugging.
 
 Workarounds are in place as follows:


### PR DESCRIPTION
This is a simple readme update to reflect the fact that neovim now supports `promt-buffer` type as of v5.0 nightly release. See [this issue](https://github.com/neovim/neovim/issues/10431) for details.