### PR TITLE
Don't copy the environment to update it

### DIFF
--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -740,11 +740,7 @@ class DebugSession( object ):
 
     self._connection_type = self._api_prefix + self._connection_type
 
-    # TODO: Do we actually need to copy and update or does Vim do that?
-    env = os.environ.copy()
-    if 'env' in self._adapter:
-      env.update( self._adapter[ 'env' ] )
-    self._adapter[ 'env' ] = env
+    self._adapter[ 'env' ] = self._adapter.get( 'env', {} )
 
     if 'cwd' not in self._adapter:
       self._adapter[ 'cwd' ] = os.getcwd()

--- a/support/test/cpp/simple_c_program/.vimspector.json
+++ b/support/test/cpp/simple_c_program/.vimspector.json
@@ -1,7 +1,15 @@
 {
   "configurations": {
-    "simple_c_program - Launch": {
+    "CodeLLDB": {
       "adapter": "CodeLLDB",
+      "configuration": {
+        "request": "launch",
+        "program": "${workspaceRoot}/test",
+        "stopAtEntry": true
+      }
+    },
+    "lldb-vscode": {
+      "adapter": "lldb-vscode",
       "configuration": {
         "request": "launch",
         "program": "${workspaceRoot}/test",

--- a/support/test/cpp/simple_c_program/test_c.cpp
+++ b/support/test/cpp/simple_c_program/test_c.cpp
@@ -1,3 +1,5 @@
+#include <cstdio>
+#include <cstdlib>
 #include <iostream>
 
 namespace Test
@@ -32,6 +34,8 @@ namespace Test
 int main ( int argc, char ** argv )
 {
   int x{ 10 };
+
+  printf( "HOME: %s\n", getenv( "HOME" ) );
 
   Test::TestStruct t{ true, {99} };
   foo( t );

--- a/support/test/python/simple_python/.vimspector.json
+++ b/support/test/python/simple_python/.vimspector.json
@@ -1,8 +1,12 @@
 {
   "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json",
   "adapters": {
-    "test_custom": {
-      "command": "This is a test"
+    "run_with_debugpy": {
+      "command": [ "${workspaceRoot}/run_with_debugpy" ],
+      "port": 9876,
+      "env": {
+        "DEBUG_PORT": "9876"
+      }
     }
   },
   "configurations": {
@@ -33,6 +37,19 @@
     },
     "attach": {
       "adapter": "multi-session",
+      "configuration": {
+        "request": "attach"
+      },
+      "breakpoints": {
+        "exception": {
+          "raised": "N",
+          "uncaught": "",
+          "userUnhandled": ""
+        }
+      }
+    },
+    "attach-run": {
+      "adapter": "run_with_debugpy",
       "configuration": {
         "request": "attach"
       },

--- a/support/test/python/simple_python/run_with_debugpy
+++ b/support/test/python/simple_python/run_with_debugpy
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-PYTHON=python3
-
-if [ -n "$1" ]; then
-  PYTHON=$1
+if [ -z "$DEBUG_PORT" ]; then
+  DEBUG_PORT=5678
 fi
 
 pushd $(dirname $0)
@@ -11,10 +9,11 @@ pushd $(dirname $0)
     rm -rf env
   fi
 
-  $PYTHON -m venv env
+  python3 -m venv env
   . env/bin/activate
   python -m pip install -r requirements.txt
+  echo "using port $DEBUG_PORT"
   echo "*** Launching ***"
-  python -m debugpy --wait-for-client --listen 0.0.0.0:5678 main.py
+  python -m debugpy --wait-for-client --listen 0.0.0.0:${DEBUG_PORT} main.py
 popd
 


### PR DESCRIPTION
This causes problems on windows, and is wasteful anyway. The subprocess
will pick up the environment from its parent.

Fixes #310
Closes #311 

@zoumi can you try this patch ? I took your idea and extended it for all platforms. This seems to work on macOS at least.