### PR TITLE
Fix docker example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -633,19 +633,24 @@ Vimspector then orchestrates the various tools to set you up.
           // Command to launch the debugee and attach the debugger; 
           // %CMD% replaced with the remote-cmdLine configured in the launch
           // configuration. (mandatory)
-          "launchCommmand": [
+          "runCommand": [
             "python", "-m", "debugpy", "--listen", "0.0.0.0:${port}",
             "%CMD%"
           ]
           
-          // Optional alternative to launchCommmand (if you need to run multiple
+          // Optional alternative to runCommand (if you need to run multiple
           // commands)
-          // "launchCommmands":  [
+          // "runCommands":  [
           //   [ /* first command */ ],
           //   [ /* second command */ ]
           // ]
 
         }
+
+        // optional delay to wait after running runCommand(s). This is often
+        // needed because of the way docker handles TCP, or if you're using some
+        // wrapper (e.g. to start the JVM)
+        // "delay": "1000m" // format as per :help sleep
       },
       "attach": {
         "remote": {
@@ -685,6 +690,10 @@ Vimspector then orchestrates the various tools to set you up.
           //   "args": [ "-o", "StrictHostKeyChecking=no" ]
           // },
         }
+        // optional delay to wait after running runCommand(s). This is often
+        // needed because of the way docker handles TCP, or if you're using some
+        // wrapper (e.g. to start the JVM)
+        // "delay": "1000m" // format as per :help sleep
       }
     }
   },
@@ -754,7 +763,7 @@ and have to tell cpptools a few more options.
         "remote": {
           "host": "${host}",
           "account": "${account}",
-          "launchCommmand": [ 
+          "runCommand": [ 
             "gdbserver",
             "--once",
             "--no-startup-with-shell",
@@ -838,19 +847,23 @@ port.
           // Command to launch the debugee and attach the debugger; 
           // %CMD% replaced with the remote-cmdLine configured in the launch
           // configuration. (mandatory)
-          "launchCommmand": [
+          "runCommand": [
             "python", "-m", "debugpy", "--listen", "0.0.0.0:${port}",
             "%CMD%"
           ]
           
-          // Optional alternative to launchCommmand (if you need to run multiple
+          // Optional alternative to runCommand (if you need to run multiple
           // commands)
-          // "launchCommmands":  [
+          // "runCommands":  [
           //   [ /* first command */ ],
           //   [ /* second command */ ]
           // ]
 
         }
+        
+        // optional delay to wait after running runCommand(s). This is often
+        // needed because of the way docker handles TCP
+        "delay": "1000m" // format as per :help sleep
       },
       "attach": {
         "remote": {
@@ -886,6 +899,11 @@ port.
           // ]
 
         }
+
+        // optional delay to wait after running runCommand(s). This is often
+        // needed because of the way docker handles TCP, or if you're using some
+        // wrapper (e.g. to start the JVM)
+        "delay": "1000m" // format as per :help sleep
       }
     }
   },

--- a/docs/schema/vimspector.schema.json
+++ b/docs/schema/vimspector.schema.json
@@ -38,11 +38,144 @@
         ]
       }
     },
-    "adapter-common": {
+    "adapter-launchattach": {
+      "properties": {
+        "launch": {
+          "allOf": [
+            { "$ref": "#/definitions/adapter-remote" },
+            {
+              "properties": {
+                "delay": {
+                  "type": "string",
+                  "description": "A time in the format understood by :help :sleep to wait after running the attachCommand(s)"
+                }
+              }
+            }
+          ]
+        },
+        "attach": {
+          "allOf": [
+            { "$ref": "#/definitions/adapter-remote" },
+            {
+              "type": "object",
+              "required": [ "pidSelect" ],
+              "properties": {
+                "pidSelect": {
+                  "enum": [ "ask", "none" ]
+                },
+                "pidProperty": {
+                  "type": "string",
+                  "description": "The launch config property which the PID should be injected into. Required when 'pidSelect' is 'ask'."
+                },
+                "delay": {
+                  "type": "string",
+                  "description": "A time in the format understood by :help :sleep to wait after running the attachCommand(s)"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "adapter-remote": {
+      "type": "object",
+      "properties": {
+        "remote": {
+          "type": "object",
+          "description": "Configures how Vimspector will marshal remote debugging requests. When remote debugging, Vimspector will either ssh to 'account'@'host' or docker exec -it to 'container' and run 'pidCommand', 'attachCommands', 'runCommands', etc. based on the 'remote-command' option in the debug configuration. If 'remote-command' is 'launch', it runs 'runCommand(s)', otherwise (it's 'attach') vimspector runs 'pidCommand', followed by 'attachCommand(s)'.Then it starts up the debug adapter with the debug configuration as normal. Usually this is configured with an 'attach' request (whether we remotely 'launched' or not). Once the initialization exchange is complete, Vimspector runs the optional 'initCompleteCommand' which can be used to force the application to break, e.g. by sending it SIGINT. This is required on some platforms which have buggy gdbservers (for example)",
+          "allOf": [
+            {
+              "oneOf": [
+                { "required": [ "host" ] },
+                { "required": [ "container" ] }
+              ]
+            },
+            {
+              "properties": {
+                "account": {
+                  "type": "string",
+                  "description": "Remote account name used when ssh'ing. Defaults to the current user account."
+                },
+                "host": {
+                  "type": "string",
+                  "description": "Name of the remote host to connect to (via passwordless SSH)."
+                },
+                "container": {
+                  "type": "string",
+                  "description": "Name or container id of the docker run container to connect to (via docker exec). Note the container must already be running (Vimspector will not start it) and it must have the port forwarded to the host if subsequently connecting via a port (for example <tt>docker run -p 8765:8765 -it simple_python</tt>)."
+                }
+              }
+            },
+            {
+              "oneOf": [
+                {
+                  "allOf": [
+                    {
+                      "oneOf": [
+                        { "required": [ "attachCommand" ] },
+                        { "required": [ "attachCommands" ] }
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "initCompleteCommand": {
+                          "type": "array",
+                          "items": { "type": "string" },
+                          "description": "For remote-attach. Remote command to execute after initialization of the debug adapter. Can be used to work around buggy attach behaviour on certain platforms (advanced usage). Can contain the special token %PID% which is replaced with the PID returned by 'pidCommand'"
+                        },
+                        "pidCommand": {
+                          "type": "array",
+                          "items": { "type": "string" },
+                          "description": "Required for remote-attach. Remote command to execute to return the PID to attach to."
+                        },
+                        "attachCommands": {
+                          "type": [ "array" ],
+                          "items": { "type": "array", "items": { "type": "string" } },
+                          "description": "For remote-attach. List of commands to execute remotely to set up the attach. Can contain the special token %PID% which is replaced with the PID returned by the remote 'pidCommand'."
+                        },
+                        "attachCommand": {
+                          "type": "array",
+                          "items": { "type": "string" },
+                          "description": "A single command to execute for remote-attach. Like attachCommands but for a single command. If attachCommands is supplied, this is not used."
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "oneOf": [
+                        { "required": [ "runCommand" ] },
+                        { "required": [ "runCommands" ] }
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "runCommands": {
+                          "type": [ "array" ],
+                          "items": { "type": "array", "items": { "type": "string" } },
+                          "description": "For remote-launch. List of commands to execute remotely to set up the launch. An entry in the array can be the special token '%CMD%' which is replaced with the evaluated 'remote-cmdLine' value in the debug configuration. This is useful to parameterize launcging remotely under something like gdbserver."
+                        },
+                        "runCommand": {
+                          "type": "array",
+                          "items": { "type": "string" },
+                          "description": "A single command to execute for remote-launch. Like runCommands but for a single command."
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "adapter": {
       "allOf": [
+        { "type": "object" },
         { "$ref": "#/definitions/variables" },
-        { "$ref": "#/definitions/adapter-remote" },
-        { "$ref": "#/definitions/adapter-attach" },
         {
           "properties": {
             "name": {
@@ -54,136 +187,30 @@
               "description": "Base debug configuration. Can be used to set default values for all debug configurations. When reading individual debug configurations from 'configurations', those configurations are merged with this object. Definitions in the debug configuration override anything in this object. Typical usage for this is to set the 'type' parameter, which some debug adapters are very picky about, or to set e.g. the path to an underlying debugger."
             }
           }
-        }
-      ]
-    },
-    "adapter-attach": {
-      "properties": {
-        "attach": {
-          "type": "object",
-          "required": [ "pidSelect" ],
-          "properties": {
-            "pidSelect": {
-              "enum": [ "ask", "none" ]
-            },
-            "pidProperty": {
-              "type": "string",
-              "description": "The launch config property which the PID should be injected into. Required when 'pidSelect' is 'ask'."
-            }
-          }
-        }
-      }
-    },
-    "adapter-remote": {
-      "properties": {
-        "remote": {
-          "type": "object",
-          "oneOf": [
-            {
-              "required": [
-                "host"
-              ]
-            },
-            {
-              "required": [
-                "container"
-              ]
-            }
-          ],
-          "description": "Configures how Vimspector will marshal remote debugging requests. When remote debugging, Vimspector will either ssh to 'account'@'host' or docker exec -it to 'container' and run 'pidCommand', 'attachCommands', 'runCommands', etc. based on the 'remote-command' option in the debug configuration. If 'remote-command' is 'launch', it runs 'runCommand(s)', otherwise (it's 'attach') vimspector runs 'pidCommand', followed by 'attachCommand(s)'.Then it starts up the debug adapter with the debug configuration as normal. Usually this is configured with an 'attach' request (whether we remotely 'launched' or not). Once the initialization exchange is complete, Vimspector runs the optional 'initCompleteCommand' which can be used to force the application to break, e.g. by sending it SIGINT. This is required on some platforms which have buggy gdbservers (for example)",
-          "properties": {
-            "account": {
-              "type": "string",
-              "description": "Remote account name used when ssh'ing. Defaults to the current user account."
-            },
-            "host": {
-              "type": "string",
-              "description": "Name of the remote host to connect to (via passwordless SSH)."
-            },
-            "container": {
-              "type": "string",
-              "description": "Name or container id of the docker run container to connect to (via docker exec -it)."
-            },
-            "pidCommand": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "Required for remote-attach. Remote command to execute to return the PID to attach to."
-            },
-            "initCompleteCommand": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "For remote-attach. Remote command to execute after initialization of the debug adapter. Can be used to work around buggy attach behaviour on certain platforms (advanced usage). Can contain the special token %PID% which is replaced with the PID returned by 'pidCommand'"
-            },
-            "attachCommands": {
-              "type": [ "array" ],
-              "items": { "type": "array", "items": { "type": "string" } },
-              "description": "For remote-attach. List of commands to execute remotely to set up the attach. Can contain the special token %PID% which is replaced with the PID returned by the remote 'pidCommand'."
-            },
-            "attachCommand": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "A single command to execute for remote-attach. Like attachCommands but for a single command. If attachCommands is supplied, this is not used."
-            },
-            "runCommands": {
-              "type": [ "array" ],
-              "items": { "type": "array", "items": { "type": "string" } },
-              "description": "For remote-launch. List of commands to execute remotely to set up the launch. An entry in the array can be the special token '%CMD%' which is replaced with the evaluated 'remote-cmdLine' value in the debug configuration. This is useful to parameterize launcging remotely under something like gdbserver."
-            },
-            "runCommand": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "A single command to execute for remote-launch. Like runCommands but for a single command."
-            }
-          }
-        }
-      }
-    },
-    "adapter": {
-      "oneOf": [
+        },
+        { "$ref": "#/definitions/adapter-launchattach" },
         {
-          "allOf": [
-            { "$ref": "#/definitions/adapter-common" },
-            {
-              "required": [ "port" ],
-              "properties": {
-                "port": {
-                  "oneOf": [
-                    {
-                      "type": "string",
-                      "enum": [ "ask" ]
-                    },
-                    {
-                      "type": "integer"
-                    }
-                  ],
-                  "description": "If supplied, indicates that a socket connection should be made to this port on 'localhost'. If the value is 'ask', then the user is asked to enter the port number to connect to."
-                }
-              }
-            }
+          "anyOf": [
+            { "required": [ "command" ] },
+            { "required": [ "port" ] },
+            { "required": [ "command", "port" ] }
           ]
         },
         {
-          "allOf": [
-            { "$ref": "#/definitions/adapter-common" },
-            {
-              "required": [ "command" ],
-              "properties": {
-                "command": {
-                  "type": [ "string", "array" ],
-                  "description": "Command line to execute the debug adapter.",
-                  "items": { "type": "string" }
-                },
-                "env": {
-                  "type": "object",
-                  "description": "Name/value pairs to set in the environment when starting the adapter."
-                },
-                "cwd": {
-                  "type": "string",
-                  "description": "Directory from which to start the adapter. Defaults to the working directory of the window on launch"
-                }
-              }
+          "properties": {
+            "host": {
+              "type": "string",
+              "default": "localhost",
+              "description": "Connect to this host in multi-session mode"
+            },
+            "port": {
+              "oneOf": [
+                { "type": "string" },
+                { "type": "integer" }
+              ],
+              "description": "If supplied, indicates that a socket connection should be made to this port on 'host'. If the value is 'ask', then the user is asked to enter the port number to connect to."
             }
-          ]
+          }
         }
       ]
     }

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -68,6 +68,7 @@ class DebugSession( object ):
 
     self._configuration = None
     self._adapter = None
+    self._launch_config = None
 
     self._ResetServerState()
 
@@ -108,6 +109,7 @@ class DebugSession( object ):
                        launch_variables )
     self._configuration = None
     self._adapter = None
+    self._launch_config = None
 
     current_file = utils.GetBufferFilepath( vim.current.buffer )
     adapters = {}
@@ -280,6 +282,7 @@ class DebugSession( object ):
     def start():
       self._configuration = configuration
       self._adapter = adapter
+      self._launch_config = None
 
       self._logger.info( 'Configuration: %s',
                          json.dumps( self._configuration ) )
@@ -291,6 +294,7 @@ class DebugSession( object ):
       else:
         vim.current.tabpage = self._uiTab
 
+      self._Prepare()
       self._StartDebugAdapter()
       self._Initialise()
 
@@ -723,7 +727,6 @@ class DebugSession( object ):
                        json.dumps( self._adapter ) )
 
     self._init_complete = False
-    self._on_init_complete_handlers = []
     self._launch_complete = False
     self._run_on_server_exit = None
 
@@ -739,6 +742,7 @@ class DebugSession( object ):
         self._adapter[ 'port' ] = port
 
     self._connection_type = self._api_prefix + self._connection_type
+    self._logger.debug( f"Connection Type: { self._connection_type }" )
 
     self._adapter[ 'env' ] = self._adapter.get( 'env', {} )
 
@@ -794,16 +798,16 @@ class DebugSession( object ):
 
 
   def _PrepareAttach( self, adapter_config, launch_config ):
-    atttach_config = adapter_config.get( 'attach' )
+    attach_config = adapter_config.get( 'attach' )
 
-    if not atttach_config:
+    if not attach_config:
       return
 
-    if 'remote' in atttach_config:
+    if 'remote' in attach_config:
       # FIXME: We almost want this to feed-back variables to be expanded later,
       # e.g. expand variables when we use them, not all at once. This would
       # remove the whole %PID% hack.
-      remote = atttach_config[ 'remote' ]
+      remote = attach_config[ 'remote' ]
       remote_exec_cmd = self._GetRemoteExecCommand( remote )
 
       # FIXME: Why does this not use self._GetCommands ?
@@ -844,20 +848,23 @@ class DebugSession( object ):
             self._codeView._window,
             self._remote_term )
     else:
-      if atttach_config[ 'pidSelect' ] == 'ask':
-        prop = atttach_config[ 'pidProperty' ]
+      if attach_config[ 'pidSelect' ] == 'ask':
+        prop = attach_config[ 'pidProperty' ]
         if prop not in launch_config:
           pid = utils.AskForInput( 'Enter PID to attach to: ' )
           if pid is None:
             return
           launch_config[ prop ] = pid
         return
-      elif atttach_config[ 'pidSelect' ] == 'none':
+      elif attach_config[ 'pidSelect' ] == 'none':
         return
 
       raise ValueError( 'Unrecognised pidSelect {0}'.format(
-        atttach_config[ 'pidSelect' ] ) )
+        attach_config[ 'pidSelect' ] ) )
 
+    if 'delay' in attach_config:
+      utils.UserMessage( f"Waiting ( { attach_config[ 'delay' ] } )..." )
+      vim.command( f'sleep { attach_config[ "delay" ] }' )
 
 
   def _PrepareLaunch( self, command_line, adapter_config, launch_config ):
@@ -889,6 +896,11 @@ class DebugSession( object ):
             },
             self._codeView._window,
             self._remote_term )
+
+    if 'delay' in run_config:
+      utils.UserMessage( f"Waiting ( {run_config[ 'delay' ]} )..." )
+      vim.command( f'sleep { run_config[ "delay" ] }' )
+
 
 
   def _GetSSHCommand( self, remote ):
@@ -988,16 +1000,18 @@ class DebugSession( object ):
                                                               message )
     self._outputView.Print( 'server', msg )
 
-  def _Launch( self ):
+
+  def _Prepare( self ):
+    self._on_init_complete_handlers = []
+
     self._logger.debug( "LAUNCH!" )
-    adapter_config = self._adapter
-    launch_config = {}
-    launch_config.update( self._adapter.get( 'configuration', {} ) )
-    launch_config.update( self._configuration[ 'configuration' ] )
+    self._launch_config = {}
+    self._launch_config.update( self._adapter.get( 'configuration', {} ) )
+    self._launch_config.update( self._configuration[ 'configuration' ] )
 
     request = self._configuration.get(
       'remote-request',
-      launch_config.get( 'request', 'launch' ) )
+      self._launch_config.get( 'request', 'launch' ) )
 
     if request == "attach":
       self._splash_screen = utils.DisplaySplash(
@@ -1005,7 +1019,7 @@ class DebugSession( object ):
         self._splash_screen,
         "Attaching to debugee..." )
 
-      self._PrepareAttach( adapter_config, launch_config )
+      self._PrepareAttach( self._adapter, self._launch_config )
     elif request == "launch":
       self._splash_screen = utils.DisplaySplash(
         self._api_prefix,
@@ -1014,14 +1028,16 @@ class DebugSession( object ):
 
       # FIXME: This cmdLine hack is not fun.
       self._PrepareLaunch( self._configuration.get( 'remote-cmdLine', [] ),
-                           adapter_config,
-                           launch_config )
+                           self._adapter,
+                           self._launch_config )
 
     # FIXME: name is mandatory. Forcefully add it (we should really use the
     # _actual_ name, but that isn't actually remembered at this point)
-    if 'name' not in launch_config:
-      launch_config[ 'name' ] = 'test'
+    if 'name' not in self._launch_config:
+      self._launch_config[ 'name' ] = 'test'
 
+
+  def _Launch( self ):
     def failure_handler( reason, msg ):
       text = [
         'Launch Failed',
@@ -1034,12 +1050,11 @@ class DebugSession( object ):
                                                  self._splash_screen,
                                                  text )
 
-
     self._connection.DoRequest(
       lambda msg: self._OnLaunchComplete(),
       {
-        'command': launch_config[ 'request' ],
-        'arguments': launch_config
+        'command': self._launch_config[ 'request' ],
+        'arguments': self._launch_config
       },
       failure_handler )
 

--- a/support/test/python/simple_python/.vimspector.json
+++ b/support/test/python/simple_python/.vimspector.json
@@ -7,6 +7,23 @@
       "env": {
         "DEBUG_PORT": "9876"
       }
+    },
+    "python-remote-docker": {
+      "variables": {
+        "port": "8765"
+      },
+      "port": "${port}",
+      "launch": {
+        "remote": {
+          "container": "${ContainerID}",
+          "runCommand": [
+            "python3", "-m", "debugpy", "--listen", "0.0.0.0:${port}",
+                                        "--wait-for-client",
+                                        "%CMD%"
+          ]
+        },
+        "delay": "5000m"
+      }
     }
   },
   "configurations": {
@@ -59,6 +76,20 @@
           "uncaught": "",
           "userUnhandled": ""
         }
+      }
+    },
+    "docker-attach": {
+      "adapter": "python-remote-docker",
+      "remote-cmdLine": [ "/root/main.py" ],
+      "remote-request": "launch",
+      "configuration": {
+        "request": "attach",
+        "pathMappings": [
+          {
+            "localRoot": "${workspaceRoot}",
+            "remoteRoot": "/root"
+          }
+        ]
       }
     },
     "run": {

--- a/support/test/python/simple_python/Dockerfile
+++ b/support/test/python/simple_python/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+  apt-get -y dist-upgrade && \
+  apt-get -y install sudo \
+                     lsb-release \
+                     ca-certificates \
+                     python3-dev \
+                     python3-pip \
+                     ca-cacert \
+                     locales \
+                     language-pack-en \
+                     libncurses5-dev libncursesw5-dev \
+                     git && \
+  apt-get -y autoremove
+
+## cleanup of files from setup
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN pip3 install debugpy
+
+ADD main.py /root/main.py

--- a/support/test/python/simple_python/build-container
+++ b/support/test/python/simple_python/build-container
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "$1" = "--continue" ]; then
+  OPTS=""
+else
+  OPTS="--no-cache"
+fi
+
+docker build ${OPTS} -t puremourning/vimspector:simple_python .


### PR DESCRIPTION
    The example was was using 'launchCommand' which is not valid according
    to the schema; it should be 'runCommand'.

    But also, it never really worked. Vimspector would start the "adapter"
    (in this case, try and connect to the TCP port) before running the
    "prepare" commands, wich in this case would actually start debugpy
    listening. So to solve that we run the prepare commands earlier.
    Hopefully this won't cause a regression for Java and C++ remote attach,
    which we don't really have tests for.

    Finally, due to the way docker works, when you forward a port and
    nothing is listening on it, docker _accepts_ the connection then
    immediately drops it. This is _super_ annoying meaning that it looks to
    vimspector liek the server instantly dies if it takes nonzero time for
    the remote commands to open the port. So to solve this we add loaunch
    and attach delays which can be configured in the adapter config. This
    actually solves a prolem where the java debugger just takes agest to
    attach on remote launch too.

    (Finally, finally...) updated the vimspector schema to represent
    the real launch/attach remote configuration, which was incorrectly
    spec'd at the adapter level, but it's actually per launch/attach block.


cc @evdoks