### PR TITLE
Fix node thread

### DIFF
--- a/support/test/tcl/test
+++ b/support/test/tcl/test
@@ -3,6 +3,8 @@
 set SCALAR g
 array set ARRAY {key1 value1 key2 value2}
 
+set LIST [list a b c {def} {g h i j} k l m]
+
 proc Wrap { body } {
   uplevel 1 $body
 }


### PR DESCRIPTION
Fixes #333 

  Fix thread state and PC for starting node app

    The problem is the sequence of events sent by the debug adapter.
    Vimspector requests threads:

    * When the initialisation exchange completes (requests all threads)
    * Whenever a thread event is received
    * whenever a stopped event is received.

    If any of those happens while any other request is in progress, we cache
    the request and handle it later. The latest request is processed when
    the response to the outstanding request is received.

    The problem is if the event is a stopped event, it is the handling of
    the threads request that actually sets the thread state internally to
    stopped. In a sequence where the first event is a stopped event, we end
    up discarding the stopped event. like:

    1. Stopped event (thread 1 = stopped) (request threads)
    2. Initialisation complete (cache request)
    3. threads response received (discard response and process cached request)
    4. response received (but forgotten about the stopped event).

    The solution is to always process the thread response, even if we send
    the cached request. To avoid flicker, we don't draw the screen, or
    expand any threads/stacks in the case where we're sending a cached
    request.