### PR TITLE
Fix variable substitution for multiple defaulted vars

### DIFF
--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -460,8 +460,8 @@ VAR_MATCH = re.compile(
       {(?P<braceddefault>               # or An {id:default} - default param, as
         (?P<defname>[_a-z][_a-z0-9]*)   #   an ID
         :                               #   then a colon
-        (?P<default>(?:[^}]|\})*)       #   then anything up to }, or a \}
-      )}                             |  #
+        (?P<default>(?:\\}|[^}])+)      #   then anything up to }, or a \}
+      )}                             |  #   then a }
       (?P<invalid>)                     # or Something else - invalid
     )
   """,

--- a/tests/lib/run_test.vim
+++ b/tests/lib/run_test.vim
@@ -82,6 +82,16 @@ func! Abort( timer_id )
   qa!
 endfunc
 
+func! TestLog( msg )
+  if type( a:msg ) == v:t_string
+    let msg = [ a:msg ]
+  else
+    let msg = a:msg
+  endif
+
+  call extend( s:messages, msg )
+endfunc
+
 func RunTheTest(test)
   echo 'Executing ' . a:test
 
@@ -152,8 +162,6 @@ func RunTheTest(test)
     augroup END
 
     exe 'call ' . a:test
-
-    au! EarlyExit
   catch /^\cskipped/
     call add(s:messages, '    Skipped')
     call add(s:skipped,
@@ -192,6 +200,8 @@ func RunTheTest(test)
 
     call s:TestFailed()
   endtry
+
+  au! EarlyExit
 
   call timer_stop( timer )
 

--- a/tests/python/Test_ExpandReferencesInDict.py
+++ b/tests/python/Test_ExpandReferencesInDict.py
@@ -1,0 +1,79 @@
+import sys
+import unittest
+from unittest.mock import patch
+from vimspector import utils
+
+
+class TestExpandReferencesInDict( unittest.TestCase ):
+  def test_ExpandReferencesInDict( self ):
+    mapping = {
+      'one': 'one',
+      'two': 'TWO',
+      'bool': True,
+      'words': 'these are some words'
+    }
+    calculus = {
+      'three': lambda : 1 + 2
+    }
+    CHOICES = {
+      'five': '5ive!'
+    }
+
+    def AskForInput( prompt, default_value = None ):
+      if default_value is not None:
+        return default_value
+
+      return 'typed text'
+
+    d = {
+      'dollar': '$$',
+      'not_a_var': '$${test}',
+      'one': '${one}',
+      'two': '${one} and ${two}',
+      'three': '${three}',
+      'four': '${four}',
+      'five': '${five}',
+      'list': [ '*${words}' ],
+      'list1': [ 'start', '*${words}', 'end' ],
+      'list2': [ '*${words}', '${three}' ],
+      'list3': [ '${one}', '*${words}', 'three' ],
+      'dict#json': '{ "key": "value" }',
+      'bool#json': 'false',
+      'one_default': '${one_default:one}',
+      'two_default': '${two_default_1:one} and ${two_default_2:two}',
+      'one_default2': '${one_default2:${one\\}}',
+      'two_default2':
+        '${two_default2_1:${one\\}} and ${two_default2_2:${two\\}}',
+    }
+
+    e = {
+      'dollar': '$',
+      'not_a_var': '${test}',
+      'one': 'one',
+      'two': 'one and TWO',
+      'three': '3',
+      'four': 'typed text',
+      'five': '5ive!',
+      'list': [ 'these', 'are', 'some', 'words' ],
+      'list1': [ 'start', 'these', 'are', 'some', 'words', 'end' ],
+      'list2': [ 'these', 'are', 'some', 'words', '3' ],
+      'list3': [ 'one', 'these', 'are', 'some', 'words', 'three' ],
+      'dict': {
+        'key': 'value',
+      },
+      'bool': False,
+      'one_default': 'one',
+      'two_default': 'one and two',
+      'one_default2': 'one',
+      'two_default2': 'one and TWO',
+    }
+
+    with patch( 'vimspector.utils.AskForInput', side_effect = AskForInput ):
+      utils.ExpandReferencesInDict( d, mapping, calculus, CHOICES )
+
+    self.assertDictEqual( d, e )
+
+
+unittest.main( module=__name__,
+               testRunner=unittest.TextTestRunner( sys.stdout ),
+               exit=False )

--- a/tests/utils.test.vim
+++ b/tests/utils.test.vim
@@ -1,0 +1,28 @@
+function! SetUp()
+  call vimspector#test#setup#SetUpWithMappings( v:none )
+  py3 import vim
+  py3 __import__( 'vimspector' )
+endfunction
+
+function! ClearDown()
+  call vimspector#test#setup#ClearDown()
+endfunction
+
+function! s:RunPyFile( file_name )
+  redir => py_output
+  try
+    let v:errmsg = ''
+    silent! execute 'py3file python/' .. a:file_name
+  finally
+    redir END
+    call TestLog( [ a:file_name .. ' output:' ] + split( py_output, '\n' ) )
+  endtry
+
+  if v:errmsg !=# ''
+    call assert_report( v:errmsg )
+  endif
+endfunction
+
+function! Test_ExpandReferencesInDict()
+  call s:RunPyFile( 'Test_ExpandReferencesInDict.py' )
+endfunction


### PR DESCRIPTION
The problem was that the python regex engine is strictly left-to-right,
so matching `[^}]|\\}` against \\}} meant that the `\\` was consumed by
the left of the `|`. The solution is to just switch them around.

Also add a way to run python tests from within vim, so we can actually
test this stuff.

Fixes #340 