### PR TITLE
Set variable value 

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,7 +914,8 @@ breakpoint when it is hit.
 
 * Current scope shows values of locals.
 * Use `<CR>`, or double-click with left mouse to expand/collapse (+, -).
-* Set the value of the variable with `<C-CR>` (control + `<CR>`)
+* Set the value of the variable with `<C-CR>` (control + `<CR>`) or
+  `<leader><CR>` (if `modifyOtherKeys` doesn't work for you)
 * When changing the stack frame the locals window updates.
 * While paused, hover to see values
 
@@ -931,7 +932,8 @@ All rules for `Variables and scopes` apply plus the following:
   and get its result.
 * Make a normal mode (`nmap`) and visual mode (`xmap`) mapping to
   `<Plug>VimspectorBalloonEval` to manually trigger the popup.
-  * Set the value of the variable with `<C-CR>` (control + `<CR>`)
+  * Set the value of the variable with `<C-CR>` (control + `<CR>`) or
+    `<leader><CR>` (if `modifyOtherKeys` doesn't work for you)
   * Use regular nagivation keys (`j`, `k`) to choose the current selection; `<Esc>`
     (or leave the tooltip window) to close the tooltip.
 
@@ -950,7 +952,8 @@ to add a new watch expression.
 * Alternatively, use `:VimspectorWatch <expression>`. Tab-completion for
   expression is available in some debug adapters.
 * Expand result with `<CR>`, or double-click with left mouse.
-* Set the value of the variable with `<C-CR>` (control + `<CR>`)
+* Set the value of the variable with `<C-CR>` (control + `<CR>`) or
+  `<leader><CR>` (if `modifyOtherKeys` doesn't work for you)
 * Delete with `<DEL>`.
 
 ![watch window](https://puremourning.github.io/vimspector-web/img/vimspector-watch-window.png)
@@ -2054,3 +2057,4 @@ hi link jsonComment Comment
 [debugpy]: https://github.com/microsoft/debugpy
 [YouCompleteMe]: https://github.com/ycm-core/YouCompleteMe#java-semantic-completion
 [remote-debugging]: https://puremourning.github.io/vimspector/configuration.html#remote-debugging-support
+[YcmJava]: https://github.com/ycm-core/YouCompleteMe#java-semantic-completion

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ And a couple of brief demos:
 - remote launch, remote attach
 - locals and globals display
 - watch expressions with autocompletion
+- variable inspection tooltip on hover
+- set variable value in locals, watch and hover windows
 - call stack display and navigation
 - hierarchical variable value display popup (see `<Plug>VimspectorBalloonEval`)
 - interactive debug console with autocompletion
@@ -912,6 +914,7 @@ breakpoint when it is hit.
 
 * Current scope shows values of locals.
 * Use `<CR>`, or double-click with left mouse to expand/collapse (+, -).
+* Set the value of the variable with `<C-CR>` (control + `<CR>`)
 * When changing the stack frame the locals window updates.
 * While paused, hover to see values
 
@@ -928,8 +931,9 @@ All rules for `Variables and scopes` apply plus the following:
   and get its result.
 * Make a normal mode (`nmap`) and visual mode (`xmap`) mapping to
   `<Plug>VimspectorBalloonEval` to manually trigger the popup.
-* Use regular nagivation keys (`j`, `k`) to choose the current selection; `<Esc>`
-  (or leave the tooltip window) to close the tooltip.
+  * Set the value of the variable with `<C-CR>` (control + `<CR>`)
+  * Use regular nagivation keys (`j`, `k`) to choose the current selection; `<Esc>`
+    (or leave the tooltip window) to close the tooltip.
 
 ![variable eval hover](https://puremourning.github.io/vimspector-web/img/vimspector-variable-eval-hover.png)
 
@@ -946,6 +950,7 @@ to add a new watch expression.
 * Alternatively, use `:VimspectorWatch <expression>`. Tab-completion for
   expression is available in some debug adapters.
 * Expand result with `<CR>`, or double-click with left mouse.
+* Set the value of the variable with `<C-CR>` (control + `<CR>`)
 * Delete with `<DEL>`.
 
 ![watch window](https://puremourning.github.io/vimspector-web/img/vimspector-watch-window.png)

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -235,7 +235,9 @@ function! vimspector#AddWatch( ... ) abort
     return
   endif
   if a:0 == 0
-    let expr = input( 'Enter watch expression: ' )
+    let expr = input( 'Enter watch expression: ',
+                    \ '',
+                    \ 'custom,vimspector#CompleteExpr' )
   else
     let expr = a:1
   endif

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -209,11 +209,15 @@ function! vimspector#ExpandVariable() abort
   py3 _vimspector_session.ExpandVariable()
 endfunction
 
-function! vimspector#SetVariableValue() abort
+function! vimspector#SetVariableValue( ... ) abort
   if !s:Enabled()
     return
   endif
-  py3 _vimspector_session.SetVariableValue()
+  if a:0 == 0
+    py3 _vimspector_session.SetVariableValue()
+  else
+    py3 _vimspector_session.SetVariableValue( new_value = vim.eval( 'a:1' ) )
+  endif
 endfunction
 
 function! vimspector#DeleteWatch() abort

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -209,6 +209,13 @@ function! vimspector#ExpandVariable() abort
   py3 _vimspector_session.ExpandVariable()
 endfunction
 
+function! vimspector#SetVariableValue() abort
+  if !s:Enabled()
+    return
+  endif
+  py3 _vimspector_session.SetVariableValue()
+endfunction
+
 function! vimspector#DeleteWatch() abort
   if !s:Enabled()
     return

--- a/autoload/vimspector/internal/balloon.vim
+++ b/autoload/vimspector/internal/balloon.vim
@@ -135,18 +135,21 @@ function! vimspector#internal#balloon#MouseFilter( winid, key ) abort
 endfunction
 
 function! s:MatchKey( key, candidates ) abort
-  let mapped = ''
   for candidate in a:candidates
-    try
-      " Try and expand the key code. Note this won't work for non-special keys
-      " and it won't work for multple keys, which is kinda shitty.
-      "
-      " There's no vim api to run expand_keycodes() i don't think.
-      execute 'let mapped = "\' . candidate . '"'
-      if mapped ==# a:key
-        return v:true
-      endif
-    endtry
+    " If the mapping string looks like a special character, then try and
+    " expand it. This is... a hack. The whole thing only works if the mapping
+    " is a single key (anyway), and so we assume any string starting with < is a
+    " special key (which will be the common case) and try and map it. If it
+    " fails... it fails.
+    if candidate[ 0 ] == '<'
+      try
+        execute 'let candidate = "\' . candidate . '"'
+      endtry
+    endif
+
+    if candidate ==# a:key
+      return v:true
+    endif
   endfor
 
   return v:false

--- a/autoload/vimspector/internal/balloon.vim
+++ b/autoload/vimspector/internal/balloon.vim
@@ -124,8 +124,6 @@ function! vimspector#internal#balloon#MouseFilter( winid, key ) abort
 
   " expand the variable if we got double click
   if a:key ==? "\<2-leftmouse>"
-    " forward line number to python, since vim does not allow us to focus
-    " the correct window
     call py3eval( '_vimspector_session.ExpandVariable('
                 \ . 'buf = vim.buffers[ ' .  winbufnr( a:winid ) . ' ],'
                 \ . 'line_num = ' . line( '.', a:winid )
@@ -138,9 +136,13 @@ endfunction
 
 function! vimspector#internal#balloon#CursorFilter( winid, key ) abort
   if a:key ==? "\<CR>"
-    " forward line number to python, since vim does not allow us to focus
-    " the correct window
     call py3eval( '_vimspector_session.ExpandVariable('
+                \ . 'buf = vim.buffers[ ' .  winbufnr( a:winid ) . ' ],'
+                \ . 'line_num = ' . line( '.', a:winid )
+                \ . ')' )
+    return 1
+  elseif a:key ==? "\<C-CR>"
+    call py3eval( '_vimspector_session.SetVariableValue('
                 \ . 'buf = vim.buffers[ ' .  winbufnr( a:winid ) . ' ],'
                 \ . 'line_num = ' . line( '.', a:winid )
                 \ . ')' )
@@ -293,6 +295,8 @@ function! s:CreateNeovimTooltip( body ) abort
 
   nnoremap <silent> <buffer> <CR>
         \ <cmd>call vimspector#ExpandVariable()<CR>
+  nnoremap <silent> <buffer> <C-CR>
+        \ <cmd>call vimspector#SetVariableValue()<CR>
   nnoremap <silent> <buffer> <Esc>
         \ <cmd>quit<CR>
   nnoremap <silent> <buffer> <2-LeftMouse>

--- a/autoload/vimspector/internal/balloon.vim
+++ b/autoload/vimspector/internal/balloon.vim
@@ -315,14 +315,10 @@ function! s:CreateNeovimTooltip( body ) abort
   " interract with the popup in neovim
   noautocmd call win_gotoid( s:popup_win_id )
 
-  nnoremap <silent> <buffer> <CR>
-        \ <cmd>call vimspector#ExpandVariable()<CR>
-  nnoremap <silent> <buffer> <C-CR>
-        \ <cmd>call vimspector#SetVariableValue()<CR>
-  nnoremap <silent> <buffer> <Esc>
-        \ <cmd>quit<CR>
-  nnoremap <silent> <buffer> <2-LeftMouse>
-        \ <cmd>call vimspector#ExpandVariable()<CR>
+  nnoremap <silent> <buffer> <Esc> <cmd>quit<CR>
+  call py3eval( "__import__( 'vimspector', "
+              \."            fromlist = [ 'variables' ] )."
+              \.'               variables.AddExpandMappings()' )
 
   " Close the popup whenever we leave this window
   augroup vimspector#internal#balloon#nvim_float

--- a/autoload/vimspector/internal/balloon.vim
+++ b/autoload/vimspector/internal/balloon.vim
@@ -138,7 +138,10 @@ function! s:MatchKey( key, candidates ) abort
   let mapped = ''
   for candidate in a:candidates
     try
-      " Try and expand the key code
+      " Try and expand the key code. Note this won't work for non-special keys
+      " and it won't work for multple keys, which is kinda shitty.
+      "
+      " There's no vim api to run expand_keycodes() i don't think.
       execute 'let mapped = "\' . candidate . '"'
       if mapped ==# a:key
         return v:true

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -129,6 +129,7 @@ augroup VimspectorUserAutoCmds
   autocmd user VimspectorDebugEnded     silent
 augroup END
 
+" FIXME: Only register this _while_ debugging is active
 augroup Vimspector
   autocmd!
   autocmd BufNew * call vimspector#OnBufferCreated( expand( '<afile>' ) )

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -526,8 +526,8 @@ class DebugSession( object ):
     self._variablesView.ExpandVariable( buf, line_num )
 
   @IfConnected()
-  def SetVariableValue( self, buf = None, line_num = None ):
-    self._variablesView.SetVariableValue( buf, line_num )
+  def SetVariableValue( self, new_value = None, buf = None, line_num = None ):
+    self._variablesView.SetVariableValue( new_value, buf, line_num )
 
   @IfConnected()
   def AddWatch( self, expression ):

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -526,9 +526,8 @@ class DebugSession( object ):
     self._variablesView.ExpandVariable( buf, line_num )
 
   @IfConnected()
-  def SetVariableValue( self ):
-    # TODO: , buf = None, line_num = None ):
-    self._variablesView.SetVariableValue()
+  def SetVariableValue( self, buf = None, line_num = None ):
+    self._variablesView.SetVariableValue( buf, line_num )
 
   @IfConnected()
   def AddWatch( self, expression ):

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -526,6 +526,11 @@ class DebugSession( object ):
     self._variablesView.ExpandVariable( buf, line_num )
 
   @IfConnected()
+  def SetVariableValue( self ):
+    # TODO: , buf = None, line_num = None ):
+    self._variablesView.SetVariableValue()
+
+  @IfConnected()
   def AddWatch( self, expression ):
     self._variablesView.AddWatch( self._stackTraceView.GetCurrentFrame(),
                                   expression )
@@ -999,6 +1004,7 @@ class DebugSession( object ):
     def handle_initialize_response( msg ):
       self._server_capabilities = msg.get( 'body' ) or {}
       self._breakpoints.SetServerCapabilities( self._server_capabilities )
+      self._variablesView.SetServerCapabilities( self._server_capabilities )
       self._Launch()
 
     self._connection.DoRequest( handle_initialize_response, {

--- a/python3/vimspector/output.py
+++ b/python3/vimspector/output.py
@@ -234,7 +234,7 @@ class OutputView( object ):
           raise
 
       vim.command(
-        "nnoremenu  1.{0} WinBar.{1}{2} "
+        "nnoremenu <silent> 1.{0} WinBar.{1}{2} "
         ":call vimspector#ShowOutputInWindow( {3}, '{1}' )<CR>".format(
           tab_buffer.index,
           utils.Escape( category ),

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -45,7 +45,7 @@ DEFAULTS = {
     'variables': {
       'expand_collapse': [ '<CR>', '<2-LeftMouse>' ],
       'delete': [ '<Del>' ],
-      'set_value': [ '<C-CR>' ]
+      'set_value': [ '<C-CR>', '<leader><CR>' ]
     },
     'stack_trace': {
       'expand_or_jump': [ '<CR>', '<2-LeftMouse>' ],

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -17,7 +17,6 @@
 import vim
 import builtins
 from vimspector import utils
-from collections.abc import Mapping
 
 DEFAULTS = {
   # UI
@@ -85,9 +84,7 @@ if hasattr( vim, 'Dictionary' ):
 
 def Dict( option ):
   return _UpdateDict( DICT_TYPE( DEFAULTS.get( option, {} ) ),
-                      utils.GetVimValue( vim.vars,
-                                         f'vimspector_{ option }',
-                                         {} ) )
+                      vim.vars.get( f'vimspector_{ option }', DICT_TYPE() ) )
 
 
 def _UpdateDict( target, override ):
@@ -118,9 +115,9 @@ def _UpdateDict( target, override ):
 
   for key, value in override.items():
     current_value = target.get( key )
-    if not isinstance( current_value, Mapping ):
+    if not isinstance( current_value, DICT_TYPE ):
       target[ key ] = value
-    elif isinstance( value, Mapping ):
+    elif isinstance( value, DICT_TYPE ):
       target[ key ] = _UpdateDict( current_value, value )
     else:
       target[ key ] = value

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -17,6 +17,7 @@
 import vim
 import builtins
 from vimspector import utils
+from collections.abc import Mapping
 
 DEFAULTS = {
   # UI
@@ -38,6 +39,19 @@ DEFAULTS = {
 
   # Installer
   'install_gadgets': [],
+
+  # Mappings
+  'mappings': {
+    'variables': {
+      'expand_collapse': [ '<CR>', '<2-LeftMouse>' ],
+      'delete': [ '<Del>' ],
+      'set_value': [ '<C-CR>' ]
+    },
+    'stack_trace': {
+      'expand_or_jump': [ '<CR>', '<2-LeftMouse>' ],
+      'focus_thread': [ '<leader><CR>' ],
+    }
+  }
 }
 
 
@@ -69,9 +83,46 @@ if hasattr( vim, 'Dictionary' ):
   DICT_TYPE = vim.Dictionary
 
 
-def Dict( option: str ):
-  d = DICT_TYPE( DEFAULTS.get( option, {} ) )
-  d.update( utils.GetVimValue( vim.vars,
-                               f'vimspector_{ option }',
-                               {} ) )
-  return d
+def Dict( option ):
+  return _UpdateDict( DICT_TYPE( DEFAULTS.get( option, {} ) ),
+                      utils.GetVimValue( vim.vars,
+                                         f'vimspector_{ option }',
+                                         {} ) )
+
+
+def _UpdateDict( target, override ):
+  """Apply the updates in |override| to the dict |target|. This is like
+  dict.update, but recursive. i.e. if the existing element is a dict, then
+  override elements of the sub-dict rather than wholesale replacing.
+  e.g.
+  UpdateDict(
+    {
+      'outer': { 'inner': { 'key': 'oldValue', 'existingKey': True } }
+    },
+    {
+      'outer': { 'inner': { 'key': 'newValue' } },
+      'newKey': { 'newDict': True },
+    }
+  )
+  yields:
+    {
+      'outer': {
+        'inner': {
+           'key': 'newValue',
+           'existingKey': True
+        }
+      },
+      'newKey': { newDict: True }
+    }
+  """
+
+  for key, value in override.items():
+    current_value = target.get( key )
+    if not isinstance( current_value, Mapping ):
+      target[ key ] = value
+    elif isinstance( value, Mapping ):
+      target[ key ] = _UpdateDict( current_value, value )
+    else:
+      target[ key ] = value
+
+  return target

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -18,7 +18,7 @@ import os
 import logging
 import typing
 
-from vimspector import utils, signs
+from vimspector import utils, signs, settings
 
 
 class Thread:
@@ -107,13 +107,16 @@ class StackTraceView( object ):
     utils.SetUpHiddenBuffer( self._buf, 'vimspector.StackTrace' )
     utils.SetUpUIWindow( win )
 
+    mappings = settings.Dict( 'mappings' )[ 'stack_trace' ]
+
     with utils.LetCurrentWindow( win ):
-      vim.command( 'nnoremap <silent> <buffer> <CR> '
-                   ':<C-U>call vimspector#GoToFrame()<CR>' )
-      vim.command( 'nnoremap <silent> <buffer> <leader><CR> '
-                   ':<C-U>call vimspector#SetCurrentThread()<CR>' )
-      vim.command( 'nnoremap <silent> <buffer> <2-LeftMouse> '
-                   ':<C-U>call vimspector#GoToFrame()<CR>' )
+      for mapping in utils.GetVimList( mappings, 'expand_or_jump' ):
+        vim.command( f'nnoremap <silent> <buffer> { mapping } '
+                     ':<C-U>call vimspector#GoToFrame()<CR>' )
+
+      for mapping in utils.GetVimList( mappings, 'focus_thread' ):
+        vim.command( f'nnoremap <silent> <buffer> { mapping } '
+                     ':<C-U>call vimspector#SetCurrentThread()<CR>' )
 
       if utils.UseWinBar():
         vim.command( 'nnoremenu <silent> 1.1 WinBar.Pause/Continue '

--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -116,11 +116,11 @@ class StackTraceView( object ):
                    ':<C-U>call vimspector#GoToFrame()<CR>' )
 
       if utils.UseWinBar():
-        vim.command( 'nnoremenu 1.1 WinBar.Pause/Continue '
+        vim.command( 'nnoremenu <silent> 1.1 WinBar.Pause/Continue '
                      ':call vimspector#PauseContinueThread()<CR>' )
-        vim.command( 'nnoremenu 1.2 WinBar.Expand/Collapse '
+        vim.command( 'nnoremenu <silent> 1.2 WinBar.Expand/Collapse '
                      ':call vimspector#GoToFrame()<CR>' )
-        vim.command( 'nnoremenu 1.3 WinBar.Focus '
+        vim.command( 'nnoremenu <silent> 1.3 WinBar.Focus '
                      ':call vimspector#SetCurrentThread()<CR>' )
 
     win.options[ 'cursorline' ] = False

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -356,16 +356,21 @@ def SelectFromList( prompt, options ):
       return None
 
 
-def AskForInput( prompt, default_value = None ):
+def AskForInput( prompt, default_value = None, completion = None ):
   if default_value is None:
-    default_option = ''
-  else:
-    default_option = ", '{}'".format( Escape( default_value ) )
+    default_value = ''
+
+  args = [ prompt, default_value ]
+
+  if completion is not None:
+    if completion == 'expr':
+      args.append( 'custom,vimspector#CompleteExpr' )
+    else:
+      args.append( completion )
 
   with InputSave():
     try:
-      return vim.eval( "input( '{}' {} )".format( Escape( prompt ),
-                                                  default_option ) )
+      return Call( 'input', *args )
     except ( KeyboardInterrupt, vim.error ):
       return None
 

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -518,7 +518,7 @@ class VariablesView( object ):
       },
     } )
 
-  def SetVariableValue( self, buf = None, line_num = None ):
+  def SetVariableValue( self, new_value = None, buf = None, line_num = None ):
     variable: Variable
     view: View
 
@@ -532,9 +532,10 @@ class VariablesView( object ):
     if not variable.IsContained():
       return
 
-    new_value = utils.AskForInput( 'New Value: ',
-                                   variable.variable.get( 'value', '' ),
-                                   completion = 'expr' )
+    if new_value is None:
+      new_value = utils.AskForInput( 'New Value: ',
+                                     variable.variable.get( 'value', '' ),
+                                     completion = 'expr' )
 
     if new_value is None:
       return

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -153,6 +153,18 @@ class BufView( View ):
     self.buf = buf
 
 
+def AddExpandMappings( mappings = None ):
+  if mappings is None:
+    mappings = settings.Dict( 'mappings' )[ 'variables' ]
+  for mapping in utils.GetVimList( mappings, 'expand_collapse' ):
+    vim.command( f'nnoremap <silent> <buffer> { mapping } '
+                 ':<C-u>call vimspector#ExpandVariable()<CR>' )
+
+  for mapping in utils.GetVimList( mappings, 'set_value' ):
+    vim.command( f'nnoremap <silent> <buffer> { mapping } '
+                 ':<C-u>call vimspector#SetVariableValue()<CR>' )
+
+
 class VariablesView( object ):
   def __init__( self, variables_win, watches_win ):
     self._logger = logging.getLogger( __name__ )
@@ -167,15 +179,6 @@ class VariablesView( object ):
 
     mappings = settings.Dict( 'mappings' )[ 'variables' ]
 
-    def AddExpandMappings():
-      for mapping in utils.GetVimList( mappings, 'expand_collapse' ):
-        vim.command( f'nnoremap <silent> <buffer> { mapping } '
-                     ':<C-u>call vimspector#ExpandVariable()<CR>' )
-
-      for mapping in utils.GetVimList( mappings, 'set_value' ):
-        vim.command( f'nnoremap <silent> <buffer> { mapping } '
-                     ':<C-u>call vimspector#SetVariableValue()<CR>' )
-
     # Set up the "Variables" buffer in the variables_win
     self._scopes: typing.List[ Scope ] = []
     self._vars = View( variables_win, {}, self._DrawScopes )
@@ -184,7 +187,7 @@ class VariablesView( object ):
       if utils.UseWinBar():
         vim.command( 'nnoremenu <silent> 1.1 WinBar.Set '
                      ':call vimspector#SetVariableValue()<CR>' )
-      AddExpandMappings()
+      AddExpandMappings( mappings )
 
     # Set up the "Watches" buffer in the watches_win (and create a WinBar in
     # there)
@@ -196,7 +199,7 @@ class VariablesView( object ):
                              'vimspector#AddWatchPrompt',
                              'vimspector#OmniFuncWatch' )
     with utils.LetCurrentWindow( watches_win ):
-      AddExpandMappings()
+      AddExpandMappings( mappings )
       for mapping in utils.GetVimList( mappings, 'delete' ):
         vim.command(
           f'nnoremap <buffer> { mapping } :call vimspector#DeleteWatch()<CR>' )

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -246,10 +246,6 @@ class VariablesView( object ):
   def SetServerCapabilities( self, capabilities ):
     self._server_capabilities = capabilities
 
-    if self._server_capabilities.get( 'supportsSetVariable' ):
-      # TODO add a winbar item ? add a mapping ?
-      pass
-
   def ConnectionClosed( self ):
     self.Clear()
     self._connection = None
@@ -518,6 +514,9 @@ class VariablesView( object ):
   def SetVariableValue( self, buf = None, line_num = None ):
     variable: Variable
     view: View
+
+    if not self._server_capabilities.get( 'supportsSetVariable' ):
+      return
 
     variable, view = self._GetVariable( buf, line_num )
     if variable is None:

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -533,7 +533,8 @@ class VariablesView( object ):
       return
 
     new_value = utils.AskForInput( 'New Value: ',
-                                   variable.variable.get( 'value', '' ) )
+                                   variable.variable.get( 'value', '' ),
+                                   completion = 'expr' )
 
     if new_value is None:
       return

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -557,6 +557,9 @@ class VariablesView( object ):
       variable.Update( new_variable )
       view.draw()
 
+    def failure_handler( reason, message ):
+      utils.UserMessage( f'Cannot set value: { reason }', error = True )
+
     self._connection.DoRequest( handler, {
       'command': 'setVariable',
       'arguments': {
@@ -564,7 +567,7 @@ class VariablesView( object ):
         'name': variable.variable[ 'name' ],
         'value': new_value
       },
-    } )
+    }, failure_handler = failure_handler )
 
 
 

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -19,7 +19,7 @@ import logging
 from functools import partial
 import typing
 
-from vimspector import utils
+from vimspector import utils, settings
 
 
 class Expandable:
@@ -165,13 +165,16 @@ class VariablesView( object ):
     self._variable_eval: Scope = None
     self._variable_eval_view: View = None
 
+    mappings = settings.Dict( 'mappings' )[ 'variables' ]
+
     def AddExpandMappings():
-      vim.command( 'nnoremap <silent> <buffer> <CR> '
-                   ':<C-u>call vimspector#ExpandVariable()<CR>' )
-      vim.command( 'nnoremap <silent> <buffer> <2-LeftMouse> '
-                   ':<C-u>call vimspector#ExpandVariable()<CR>' )
-      vim.command( 'nnoremap <silent> <buffer> <C-CR> '
-                   ':<C-u>call vimspector#SetVariableValue()<CR>' )
+      for mapping in utils.GetVimList( mappings, 'expand_collapse' ):
+        vim.command( f'nnoremap <silent> <buffer> { mapping } '
+                     ':<C-u>call vimspector#ExpandVariable()<CR>' )
+
+      for mapping in utils.GetVimList( mappings, 'set_value' ):
+        vim.command( f'nnoremap <silent> <buffer> { mapping } '
+                     ':<C-u>call vimspector#SetVariableValue()<CR>' )
 
     # Set up the "Variables" buffer in the variables_win
     self._scopes: typing.List[ Scope ] = []
@@ -194,8 +197,9 @@ class VariablesView( object ):
                              'vimspector#OmniFuncWatch' )
     with utils.LetCurrentWindow( watches_win ):
       AddExpandMappings()
-      vim.command(
-        'nnoremap <buffer> <DEL> :call vimspector#DeleteWatch()<CR>' )
+      for mapping in utils.GetVimList( mappings, 'delete' ):
+        vim.command(
+          f'nnoremap <buffer> { mapping } :call vimspector#DeleteWatch()<CR>' )
 
       if utils.UseWinBar():
         vim.command( 'nnoremenu <silent> 1.1 WinBar.New '

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -515,11 +515,11 @@ class VariablesView( object ):
       },
     } )
 
-  def SetVariableValue( self ):
+  def SetVariableValue( self, buf = None, line_num = None ):
     variable: Variable
     view: View
 
-    variable, view = self._GetVariable( buf = None, line_num = None )
+    variable, view = self._GetVariable( buf, line_num )
     if variable is None:
       return
 

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -198,11 +198,11 @@ class VariablesView( object ):
         'nnoremap <buffer> <DEL> :call vimspector#DeleteWatch()<CR>' )
 
       if utils.UseWinBar():
-        vim.command( 'nnoremenu 1.1 WinBar.New '
+        vim.command( 'nnoremenu <silent> 1.1 WinBar.New '
                      ':call vimspector#AddWatch()<CR>' )
-        vim.command( 'nnoremenu 1.2 WinBar.Expand/Collapse '
+        vim.command( 'nnoremenu <silent> 1.2 WinBar.Expand/Collapse '
                      ':call vimspector#ExpandVariable()<CR>' )
-        vim.command( 'nnoremenu 1.3 WinBar.Delete '
+        vim.command( 'nnoremenu <silent> 1.3 WinBar.Delete '
                      ':call vimspector#DeleteWatch()<CR>' )
         vim.command( 'nnoremenu <silent> 1.1 WinBar.Set '
                      ':call vimspector#SetVariableValue()<CR>' )

--- a/support/custom_ui_vimrc
+++ b/support/custom_ui_vimrc
@@ -105,7 +105,10 @@ function! s:OnJumpToFrame() abort
   nmap <silent> <buffer> <LocalLeader>di <Plug>VimspectorBalloonEval
   xmap <silent> <buffer> <LocalLeader>di <Plug>VimspectorBalloonEval
 
-  let s:mapped[ string( bufnr() ) ] = 1
+  let s:mapped[ string( bufnr() ) ] = { 'modifiable': &modifiable }
+
+  setlocal nomodifiable
+
 endfunction
 
 function! s:OnDebugEnd() abort
@@ -124,6 +127,8 @@ function! s:OnDebugEnd() abort
         silent! nunmap <buffer> <LocalLeader>dc
         silent! nunmap <buffer> <LocalLeader>di
         silent! xunmap <buffer> <LocalLeader>di
+
+        let &l:modifiable = s:mapped[ bufnr ][ 'modifiable' ]
       endtry
     endfor
   finally
@@ -148,7 +153,7 @@ let g:vimspector_mappings = {
       \   'stack_trace': {},
       \   'variables': {
       \    'set_value': [ '<Tab>', '<C-CR>' ],
-      \   },
+      \   }
       \ }
 
 " }}}

--- a/support/custom_ui_vimrc
+++ b/support/custom_ui_vimrc
@@ -142,4 +142,15 @@ augroup END
 
 " }}}
 
+" Custom mappings for special buffers {{{
+
+let g:vimspector_mappings = {
+      \   'stack_trace': {},
+      \   'variables': {
+      \    'set_value': [ '<Tab>', '<C-CR>' ],
+      \   },
+      \ }
+
+" }}}
+
 " vim: foldmethod=marker

--- a/support/custom_ui_vimrc
+++ b/support/custom_ui_vimrc
@@ -152,7 +152,7 @@ augroup END
 let g:vimspector_mappings = {
       \   'stack_trace': {},
       \   'variables': {
-      \    'set_value': [ '<Tab>', '<C-CR>' ],
+      \    'set_value': [ '<Tab>', '<C-CR>', 'C' ],
       \   }
       \ }
 


### PR DESCRIPTION
Use ctrl-enter on a variable to set its value.

Unfortunately ctrl-enter only works if you have working `modifyOtherKeys` set up (and afaict doesn't work in neovim).

So we add a surreptitious way to modify the mappings through configuration. This is currently undocumented however, as I'm not sure how far we want to expose it. There are some serious issues with it (like the popup filter having to kinda try to parse the mapping spec to see if the current "key" matches it...).

But the functionality is pretty sweet, and includes command-line completion for expression (even though I'm not sure that it's actually an expression in DAP)

I should really write some tests...