### PR TITLE
Allow zero or one args for :VimspectorEval (like :VimspectorWatch)

### DIFF
--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -249,23 +249,12 @@ function! vimspector#AddWatchPrompt( expr ) abort
   call vimspector#AddWatch( a:expr )
 endfunction
 
-function! vimspector#Evaluate( ... ) abort
+function! vimspector#Evaluate( expr ) abort
   if !s:Enabled()
     return
   endif
-
-  if a:0 == 0
-    let l:expr = input( 'Enter eval expression: ' , '', 'custom,vimspector#CompleteExpr' )
-  else
-    let l:expr = a:1
-  endif
-
-  if l:expr ==# ''
-    return
-  endif
-
   py3 _vimspector_session.ShowOutput( 'Console' )
-  py3 _vimspector_session.EvaluateConsole( vim.eval( 'l:expr' ), True )
+  py3 _vimspector_session.EvaluateConsole( vim.eval( 'a:expr' ), True )
 endfunction
 
 function! vimspector#EvaluateConsole( expr ) abort

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -255,9 +255,13 @@ function! vimspector#Evaluate( ... ) abort
   endif
 
   if a:0 == 0
-    let l:expr = input( 'Enter eval expression: ' )
+    let l:expr = input( 'Enter eval expression: ' , '', 'custom,vimspector#CompleteExpr' )
   else
     let l:expr = a:1
+  endif
+
+  if l:expr ==# ''
+    return
   endif
 
   py3 _vimspector_session.ShowOutput( 'Console' )

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -239,12 +239,19 @@ function! vimspector#AddWatchPrompt( expr ) abort
   call vimspector#AddWatch( a:expr )
 endfunction
 
-function! vimspector#Evaluate( expr ) abort
+function! vimspector#Evaluate( ... ) abort
   if !s:Enabled()
     return
   endif
+
+  if a:0 == 0
+    let l:expr = input( 'Enter eval expression: ' )
+  else
+    let l:expr = a:1
+  endif
+
   py3 _vimspector_session.ShowOutput( 'Console' )
-  py3 _vimspector_session.EvaluateConsole( vim.eval( 'a:expr' ), True )
+  py3 _vimspector_session.EvaluateConsole( vim.eval( 'l:expr' ), True )
 endfunction
 
 function! vimspector#EvaluateConsole( expr ) abort

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -100,7 +100,7 @@ command! -bar -nargs=? -complete=custom,vimspector#CompleteOutput
 command! -bar
       \ VimspectorToggleLog
       \ call vimspector#ToggleLog()
-command! -bar -nargs=1 -complete=custom,vimspector#CompleteExpr
+command! -bar -nargs=? -complete=custom,vimspector#CompleteExpr
       \ VimspectorEval
       \ call vimspector#Evaluate( <f-args> )
 command! -bar

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -100,7 +100,7 @@ command! -bar -nargs=? -complete=custom,vimspector#CompleteOutput
 command! -bar
       \ VimspectorToggleLog
       \ call vimspector#ToggleLog()
-command! -bar -nargs=? -complete=custom,vimspector#CompleteExpr
+command! -nargs=1 -complete=custom,vimspector#CompleteExpr
       \ VimspectorEval
       \ call vimspector#Evaluate( <f-args> )
 command! -bar

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -508,6 +508,33 @@ function Test_EvaluateConsole()
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer(
         \ 'vimspector.Console', len, v:null )
 
+  VimspectorEval
+  call feedkeys( 't.c\<CR>', 'xt' )
+
+  call assert_equal( bufnr( 'vimspector.Console' ),
+                   \ winbufnr( g:vimspector_session_windows.output ) )
+
+  call WaitForAssert( {->
+        \   assert_equal(
+        \     [
+        \       "99 'c'"
+        \     ],
+        \     getbufline( bufnr( 'vimspector.Console' ), '$', '$' )
+        \   )
+        \ } )
+
+  let len = getbufinfo( 'vimspector.Console' )[ 0 ].linecount
+
+  call WaitForAssert( {->
+        \   assert_equal(
+        \     [
+        \       'Evaluating: t.c',
+        \       "99 'c'"
+        \     ],
+        \     getbufline( bufnr( 'vimspector.Console' ), len-1, '$' )
+        \   )
+        \ } )
+
   call vimspector#test#setup#Reset()
   %bwipe!
 endfunction

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -508,15 +508,31 @@ function Test_EvaluateConsole()
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer(
         \ 'vimspector.Console', len, v:null )
 
-  call feedkeys( ':VimspectorEval\<CR>t.c\<CR>', 'xt' )
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+
+function Test_EvaluateConsole()
+  let fn =  'testdata/cpp/simple/struct.cpp'
+  call s:StartDebugging( #{ fn: fn, line: 24, col: 1, launch: #{
+        \   configuration: 'run-to-breakpoint'
+        \ } } )
+
+  " Make sure the Test t is initialised
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 26, 1 )
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 27, 1 )
+
+  call feedkeys( ':VimspectorEval\<CR>t.i\<CR>', 'xt' )
 
   call assert_equal( bufnr( 'vimspector.Console' ),
                    \ winbufnr( g:vimspector_session_windows.output ) )
-
   call WaitForAssert( {->
         \   assert_equal(
         \     [
-        \       "99 'c'"
+        \       '1'
         \     ],
         \     getbufline( bufnr( 'vimspector.Console' ), '$', '$' )
         \   )
@@ -527,12 +543,14 @@ function Test_EvaluateConsole()
   call WaitForAssert( {->
         \   assert_equal(
         \     [
-        \       'Evaluating: t.c',
-        \       "99 'c'"
+        \       'Evaluating: t.i',
+        \       '1'
         \     ],
         \     getbufline( bufnr( 'vimspector.Console' ), len-1, '$' )
         \   )
         \ } )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer(
+        \ 'vimspector.Console', len, v:null )
 
   call vimspector#test#setup#Reset()
   %bwipe!

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -470,7 +470,7 @@ function! Test_ExpandWatch()
 endfunction
 
 
-function Test_EvaluateConsole()
+function Test_EvaluateInput()
   let fn =  'testdata/cpp/simple/struct.cpp'
   call s:StartDebugging( #{ fn: fn, line: 24, col: 1, launch: #{
         \   configuration: 'run-to-breakpoint'

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -543,7 +543,7 @@ function Test_EvaluateInput()
   call WaitForAssert( {->
         \   assert_equal(
         \     [
-        \       '(int) $1 = 5',
+        \       'Evaluating: -exec print (int) printf("hello")',
         \     ],
         \     getbufline( bufnr( 'vimspector.Console' ), len-2, len-2 )
         \   )

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -525,14 +525,14 @@ function Test_EvaluateInput()
   call vimspector#StepOver()
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 27, 1 )
 
-  VimspectorEval -exec print printf("hello")
+  VimspectorEval -exec print (int) printf("hello")
 
   call assert_equal( bufnr( 'vimspector.Console' ),
                    \ winbufnr( g:vimspector_session_windows.output ) )
   call WaitForAssert( {->
         \   assert_equal(
         \     [
-        \       '@"hello"'
+        \       ''
         \     ],
         \     getbufline( bufnr( 'vimspector.Console' ), '$', '$' )
         \   )
@@ -543,8 +543,8 @@ function Test_EvaluateInput()
   call WaitForAssert( {->
         \   assert_equal(
         \     [
-        \       'Evaluating: -exec print printf("hello")',
-        \       '@"hello"'
+        \       '(int) $1 = 5',
+        \       ''
         \     ],
         \     getbufline( bufnr( 'vimspector.Console' ), len-1, '$' )
         \   )

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -532,7 +532,7 @@ function Test_EvaluateInput()
   call WaitForAssert( {->
         \   assert_equal(
         \     [
-        \       '@"hello\r\n"'
+        \       '@"hello"'
         \     ],
         \     getbufline( bufnr( 'vimspector.Console' ), '$', '$' )
         \   )
@@ -543,8 +543,8 @@ function Test_EvaluateInput()
   call WaitForAssert( {->
         \   assert_equal(
         \     [
-        \       'Evaluating: -exec print printf("hello\n")',
-        \       '@"hello\r\n"'
+        \       'Evaluating: -exec print printf("hello")',
+        \       '@"hello"'
         \     ],
         \     getbufline( bufnr( 'vimspector.Console' ), len-1, '$' )
         \   )

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -544,9 +544,8 @@ function Test_EvaluateInput()
         \   assert_equal(
         \     [
         \       '(int) $1 = 5',
-        \       ''
         \     ],
-        \     getbufline( bufnr( 'vimspector.Console' ), len-1, '$' )
+        \     getbufline( bufnr( 'vimspector.Console' ), len-2, len-2 )
         \   )
         \ } )
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer(

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -508,8 +508,7 @@ function Test_EvaluateConsole()
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer(
         \ 'vimspector.Console', len, v:null )
 
-  VimspectorEval
-  call feedkeys( 't.c\<CR>', 'xt' )
+  call feedkeys( ':VimspectorEval\<CR>t.c\<CR>', 'xt' )
 
   call assert_equal( bufnr( 'vimspector.Console' ),
                    \ winbufnr( g:vimspector_session_windows.output ) )

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -525,7 +525,7 @@ function Test_EvaluateInput()
   call vimspector#StepOver()
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 27, 1 )
 
-  call feedkeys( ':VimspectorEval\<CR>t.i\<CR>', 'xt' )
+  call feedkeys( ":VimspectorEval\<CR>t.i\<CR>", 'xt' )
 
   call assert_equal( bufnr( 'vimspector.Console' ),
                    \ winbufnr( g:vimspector_session_windows.output ) )

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -470,7 +470,7 @@ function! Test_ExpandWatch()
 endfunction
 
 
-function Test_EvaluateInput()
+function Test_EvaluateConsole()
   let fn =  'testdata/cpp/simple/struct.cpp'
   call s:StartDebugging( #{ fn: fn, line: 24, col: 1, launch: #{
         \   configuration: 'run-to-breakpoint'
@@ -513,7 +513,7 @@ function Test_EvaluateInput()
 endfunction
 
 
-function Test_EvaluateConsole()
+function Test_EvaluateInput()
   let fn =  'testdata/cpp/simple/struct.cpp'
   call s:StartDebugging( #{ fn: fn, line: 24, col: 1, launch: #{
         \   configuration: 'run-to-breakpoint'

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -525,14 +525,14 @@ function Test_EvaluateInput()
   call vimspector#StepOver()
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 27, 1 )
 
-  call feedkeys( ":VimspectorEval\<CR>t.i\<CR>", 'xt' )
+  VimspectorEval -exec print printf("hello")
 
   call assert_equal( bufnr( 'vimspector.Console' ),
                    \ winbufnr( g:vimspector_session_windows.output ) )
   call WaitForAssert( {->
         \   assert_equal(
         \     [
-        \       '1'
+        \       '@"hello\r\n"'
         \     ],
         \     getbufline( bufnr( 'vimspector.Console' ), '$', '$' )
         \   )
@@ -543,8 +543,8 @@ function Test_EvaluateInput()
   call WaitForAssert( {->
         \   assert_equal(
         \     [
-        \       'Evaluating: t.i',
-        \       '1'
+        \       'Evaluating: -exec print printf("hello\n")',
+        \       '@"hello\r\n"'
         \     ],
         \     getbufline( bufnr( 'vimspector.Console' ), len-1, '$' )
         \   )


### PR DESCRIPTION
I looked for a test to cargo cult, but I couldn't find any place where
`:VimspectorWatch` was called with no args and fed a string to the
`input()` call.

I also looked at the commit that added the same behavior for
VimspectorWatch (4586aa36) and it included no tests. If there's an easy
way to test this, please let me know.