### PR TITLE
Not able to set breakpoint in java libraries

### DIFF
--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -152,7 +152,9 @@ class ProjectBreakpoints( object ):
 
 
   def _PutLineBreakpoint( self, file_name, line, options ):
-    self._line_breakpoints[ os.path.abspath( file_name ) ].append( {
+    abs_name = os.path.abspath( file_name )
+    path = abs_name if os.path.isfile( abs_name ) else file_name
+    self._line_breakpoints[ path ].append( {
       'state': 'ENABLED',
       'line': line,
       'options': options,


### PR DESCRIPTION
For some lsp services, like java, the compiler can open the source files from various libraries. For java, if I have the source code, the code will be opened by go to definition in a virtual buffer, which does not exists locally (jdt://contents/<library-name>). 

Setting the break point then in library will fail silently. 

This PR fixes this issue. First, I did a check if the file exists physically, in which case, the key remains the same. However, if the file does not exists physically, then the key will be the exact file name.