### PR TITLE
Narrow UI mode

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,12 +17,12 @@ assignees: ''
 
 > Please answer the following questions
 
-* Does your issue reproduce using `vim -Nu /path/to/vimspector/support/minimal_vimrc` ? \[Yes/No]
+* Does your issue reproduce using `vim --clean -Nu /path/to/vimspector/support/minimal_vimrc` ? \[Yes/No]
 * If you are using Neovim, does your issue reproduce using Vim? \[Yes/No]
 
 > List of steps to reproduce:
 
-> 1. Run `vim -Nu /path/to/vimspector/support/minimal_vimrc`
+> 1. Run `vim ---clean Nu /path/to/vimspector/support/minimal_vimrc`
 > 2. Open _this project_...
 > 3. Press _this sequence of keys_
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ in the issue report.
 The minimal vimrc is in `support/test/minimal_vimrc` and can be used as follows:
 
 ```
-vim -Nu /path/to/vimspector/support/minimal_vimrc
+vim --clean -Nu /path/to/vimspector/support/minimal_vimrc
 ```
 
 ## Pull Requests

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -655,6 +655,37 @@ class DebugSession( object ):
     vim.command( 'tab split' )
     self._uiTab = vim.current.tabpage
 
+    mode = settings.Get( 'ui_mode' )
+
+    self._logger.debug( 'ui_mode = %s', mode )
+
+    if mode == 'auto':
+      # Go vertical if there isn't enough horizontal space for at least:
+      #  the left bar width
+      #  + the code min width
+      #  + the terminal min width
+      #  + enough space for a sign column and number column?
+      min_width = ( settings.Int( 'sidebar_width' )
+                    + 1 + 2 + 3
+                    + settings.Int( 'code_minwidth' )
+                    + 1 + settings.Int( 'terminal_minwidth' ) )
+
+      mode = ( 'vertical'
+               if vim.options[ 'columns' ] < min_width
+               else 'horizontal' )
+
+      self._logger.debug( 'min_width: %s, actual: %s - result: %s',
+                          min_width,
+                          vim.options[ 'columns' ],
+                          mode )
+
+    if mode == 'vertical':
+      self._SetUpUIVertical()
+    else:
+      self._SetUpUIHorizontal()
+
+
+  def _SetUpUIHorizontal( self ):
     # Code window
     code_window = vim.current.window
     self._codeView = code.CodeView( code_window, self._api_prefix )
@@ -695,6 +726,66 @@ class DebugSession( object ):
     # TODO: If/when we support multiple sessions, we'll need some way to
     # indicate which tab was created and store all the tabs
     vim.vars[ 'vimspector_session_windows' ] = {
+      'mode': 'horizontal',
+      'tabpage': self._uiTab.number,
+      'code': utils.WindowID( code_window, self._uiTab ),
+      'stack_trace': utils.WindowID( stack_trace_window, self._uiTab ),
+      'variables': utils.WindowID( vars_window, self._uiTab ),
+      'watches': utils.WindowID( watch_window, self._uiTab ),
+      'output': utils.WindowID( output_window, self._uiTab ),
+      'eval': None # this is going to be updated every time eval popup is opened
+    }
+    with utils.RestoreCursorPosition():
+      with utils.RestoreCurrentWindow():
+        with utils.RestoreCurrentBuffer( vim.current.window ):
+          vim.command( 'doautocmd User VimspectorUICreated' )
+
+
+  def _SetUpUIVertical( self ):
+    # Code window
+    code_window = vim.current.window
+    self._codeView = code.CodeView( code_window, self._api_prefix )
+
+    # Call stack
+    vim.command(
+      f'topleft { settings.Int( "topbar_height" ) }new' )
+    stack_trace_window = vim.current.window
+    one_third = int( vim.eval( 'winwidth( 0 )' ) ) / 3
+    self._stackTraceView = stack_trace.StackTraceView( self,
+                                                       stack_trace_window )
+
+
+    # Watches
+    vim.command( 'leftabove vertical new' )
+    watch_window = vim.current.window
+
+    # Variables
+    vim.command( 'leftabove vertical new' )
+    vars_window = vim.current.window
+
+
+    with utils.LetCurrentWindow( vars_window ):
+      vim.command( f'{ one_third }wincmd |' )
+    with utils.LetCurrentWindow( watch_window ):
+      vim.command( f'{ one_third }wincmd |' )
+    with utils.LetCurrentWindow( stack_trace_window ):
+      vim.command( f'{ one_third }wincmd |' )
+
+    self._variablesView = variables.VariablesView( vars_window,
+                                                   watch_window )
+
+
+    # Output/logging
+    vim.current.window = code_window
+    vim.command( f'rightbelow { settings.Int( "bottombar_height" ) }new' )
+    output_window = vim.current.window
+    self._outputView = output.DAPOutputView( output_window,
+                                             self._api_prefix )
+
+    # TODO: If/when we support multiple sessions, we'll need some way to
+    # indicate which tab was created and store all the tabs
+    vim.vars[ 'vimspector_session_windows' ] = {
+      'mode': 'vertical',
       'tabpage': self._uiTab.number,
       'code': utils.WindowID( code_window, self._uiTab ),
       'stack_trace': utils.WindowID( stack_trace_window, self._uiTab ),

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -657,8 +657,6 @@ class DebugSession( object ):
 
     mode = settings.Get( 'ui_mode' )
 
-    self._logger.debug( 'ui_mode = %s', mode )
-
     if mode == 'auto':
       # Go vertical if there isn't enough horizontal space for at least:
       #  the left bar width
@@ -670,13 +668,23 @@ class DebugSession( object ):
                     + settings.Int( 'code_minwidth' )
                     + 1 + settings.Int( 'terminal_minwidth' ) )
 
+      min_height = ( settings.Int( 'code_minheight' ) + 1 +
+                     settings.Int( 'topbar_height' ) + 1 +
+                     settings.Int( 'bottombar_height' ) + 1 +
+                     2 )
+
       mode = ( 'vertical'
                if vim.options[ 'columns' ] < min_width
                else 'horizontal' )
 
-      self._logger.debug( 'min_width: %s, actual: %s - result: %s',
+      if vim.options[ 'lines' ] < min_height:
+        mode = 'horizontal'
+
+      self._logger.debug( 'min_width/height: %s/%s, actual: %s/%s - result: %s',
                           min_width,
+                          min_height,
                           vim.options[ 'columns' ],
+                          vim.options[ 'lines' ],
                           mode )
 
     if mode == 'vertical':

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -20,11 +20,20 @@ from vimspector import utils
 
 DEFAULTS = {
   # UI
-  'bottombar_height':  10,
-  'sidebar_width':     50,
-  'code_minwidth':     82,
-  'terminal_maxwidth': 80,
-  'terminal_minwidth': 10,
+  'ui_mode':            'auto',
+  'bottombar_height':   10,
+
+  # For ui_mode = 'horizontal':
+  'sidebar_width':      50,
+  'code_minwidth':      82,
+  'terminal_maxwidth':  80,
+  'terminal_minwidth':  10,
+
+  # For ui_mode = 'vertical':
+  'topbar_height':      15,
+  'code_minheight':     20,
+  'terminal_maxheight': 15,
+  'terminal_minheight': 5,
 
   # Signs
   'sign_priority': {

--- a/python3/vimspector/terminal.py
+++ b/python3/vimspector/terminal.py
@@ -23,11 +23,52 @@ def LaunchTerminal( api_prefix,
   env = params.get( 'env' ) or {}
 
   term_options = {
-    'vertical': 1,
     'norestore': 1,
     'cwd': cwd,
     'env': env,
   }
+
+  if settings.Get( 'ui_mode' ) == 'horizontal':
+    # force-horizontal
+    term_options[ 'vertical' ] = 1
+  elif utils.GetVimValue( vim.vars[ 'vimspector_session_windows' ],
+                          'mode' ) == 'horizontal':
+    # horizontal, which means that we should have enough space for:
+    #  - sidebar
+    #  - code min
+    #  - term min width
+    #  - + 2 vertical spaders
+    #  - + 3 columns for signs
+    term_options[ 'vertical' ] = 1
+
+    # if we don't have enough space for terminal_maxwidth, then see if we have
+    # enough vertically for terminal_maxheight, in which case,
+    # that seems a better fit
+    term_horiz_max = ( settings.Int( 'sidebar_width' ) +
+                       1 + 2 + 3 +
+                       settings.Int( 'code_minwidth' ) +
+                       1 + settings.Int( 'terminal_maxwidth' ) )
+    term_vert_max = ( settings.Int( 'bottombar_height' ) + 1 +
+                      settings.Int( 'code_minheight' ) + 1 +
+                      settings.Int( 'terminal_minheight' ) )
+
+    if ( vim.options[ 'columns' ] < term_horiz_max and
+         vim.options[ 'lines' ] >= term_vert_max ):
+      # Looks like it, let's try that layout
+      term_options[ 'vertical' ] = 0
+
+
+  else:
+    # vertical - we need enough space horizontally for the code+terminal, but we
+    # may fit better with code above terminal
+    term_options[ 'vertical' ] = 0
+
+    term_horiz_max = ( settings.Int( 'code_minwidth' ) + 3 +
+                       settings.Int( 'terminal_maxwidth' ) + 1 )
+
+    if vim.options[ 'columns' ] > term_horiz_max:
+      term_options[ 'vertical' ] = 1
+
 
   if not window_for_start or not window_for_start.valid:
     # TOOD: Where? Maybe we should just use botright vertical ...
@@ -50,13 +91,23 @@ def LaunchTerminal( api_prefix,
     # If we're making a vertical split from the code window, make it no more
     # than 80 columns and no fewer than 10. Also try and keep the code window
     # at least 82 columns
-    if term_options[ 'vertical' ] and not term_options.get( 'curwin', 0 ):
+    if term_options.get( 'curwin', 0 ):
+      pass
+    elif term_options[ 'vertical' ]:
       term_options[ 'term_cols' ] = max(
         min ( int( vim.eval( 'winwidth( 0 )' ) )
                    - settings.Int( 'code_minwidth' ),
               settings.Int( 'terminal_maxwidth' ) ),
         settings.Int( 'terminal_minwidth' )
       )
+    else:
+      term_options[ 'term_rows' ] = max(
+        min ( int( vim.eval( 'winheight( 0 )' ) )
+                   - settings.Int( 'code_minheight' ),
+              settings.Int( 'terminal_maxheight' ) ),
+        settings.Int( 'terminal_minheight' )
+      )
+
 
     buffer_number = int(
       utils.Call(

--- a/tests/ui.test.vim
+++ b/tests/ui.test.vim
@@ -256,7 +256,7 @@ function! SetUp_Test_AutoLayoutTerminalVertVert()
   " Not wide enough to go horizontal, but wide enough to put the terminal and
   " code vertically split
   call vimspector#test#setup#PushOption( 'columns', 80 )
-  call vimspector#test#setup#PushOption( 'lines', 30 )
+  call vimspector#test#setup#PushOption( 'lines', 50 )
 endfunction
 
 function! Test_AutoLayoutTerminalVertVert()

--- a/tests/ui.test.vim
+++ b/tests/ui.test.vim
@@ -1,6 +1,7 @@
 let s:fn='../support/test/python/simple_python/main.py'
 
 function! SetUp()
+  let g:vimspector_ui_mode = get( s:, 'vimspector_ui_mode', 'horizontal' )
   call vimspector#test#setup#SetUpWithMappings( 'HUMAN' )
 endfunction
 
@@ -16,12 +17,17 @@ function! s:StartDebugging()
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 23, 1 )
 endfunction
 
+function! SetUp_Test_StandardLayout()
+  call vimspector#test#setup#PushOption( 'columns', 200 )
+endfunction
+
 function! Test_StandardLayout()
   call s:StartDebugging()
 
   call vimspector#StepOver()
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 25, 1 )
 
+  call assert_equal( 'horizontal', g:vimspector_session_windows.mode )
   call assert_equal(
         \ [ 'row', [
         \   [ 'col', [
@@ -42,6 +48,247 @@ function! Test_StandardLayout()
   call vimspector#test#setup#Reset()
   %bwipe!
 endfunction
+
+function! TearDown_Test_StandardLayout()
+  call vimspector#test#setup#PopOption( 'columns' )
+endfunction
+
+function! SetUp_Test_NarrowLayout()
+  call vimspector#test#setup#PushOption( 'columns', 100 )
+  let s:vimspector_ui_mode = 'vertical'
+endfunction
+
+function! Test_NarrowLayout()
+  call s:StartDebugging()
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 25, 1 )
+
+  call assert_equal( 'vertical', g:vimspector_session_windows.mode )
+  call assert_equal(
+        \ [ 'col', [
+        \   [ 'row', [
+        \     [ 'leaf', g:vimspector_session_windows.variables ],
+        \     [ 'leaf', g:vimspector_session_windows.watches ],
+        \     [ 'leaf', g:vimspector_session_windows.stack_trace ],
+        \   ] ],
+        \   [ 'leaf', g:vimspector_session_windows.code ],
+        \   [ 'leaf', g:vimspector_session_windows.terminal ],
+        \   [ 'leaf', g:vimspector_session_windows.output ],
+        \ ] ],
+        \ winlayout( g:vimspector_session_windows.tabpage ) )
+
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+function! TearDown_Test_NarrowLayout()
+  unlet s:vimspector_ui_mode
+  call vimspector#test#setup#PopOption( 'columns' )
+endfunction
+
+function! SetUp_Test_AutoLayoutTerminalVert()
+  let s:vimspector_ui_mode = 'auto'
+  call vimspector#test#setup#PushOption( 'columns', 250 )
+  call vimspector#test#setup#PushOption( 'lines', 30 )
+endfunction
+
+function! Test_AutoLayoutTerminalVert()
+  call s:StartDebugging()
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 25, 1 )
+
+  call assert_equal( 'horizontal', g:vimspector_session_windows.mode )
+  call assert_equal(
+        \ [ 'row', [
+        \   [ 'col', [
+        \     [ 'leaf', g:vimspector_session_windows.variables ],
+        \     [ 'leaf', g:vimspector_session_windows.watches ],
+        \     [ 'leaf', g:vimspector_session_windows.stack_trace ],
+        \   ] ],
+        \   [ 'col', [
+        \     [ 'row', [
+        \       [ 'leaf', g:vimspector_session_windows.code ],
+        \       [ 'leaf', g:vimspector_session_windows.terminal ],
+        \     ] ],
+        \     [ 'leaf', g:vimspector_session_windows.output ],
+        \   ] ]
+        \ ] ],
+        \ winlayout( g:vimspector_session_windows.tabpage ) )
+
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+function! TearDown_Test_AutoLayoutTerminalVert()
+  unlet s:vimspector_ui_mode
+  call vimspector#test#setup#PopOption( 'lines' )
+  call vimspector#test#setup#PopOption( 'columns' )
+endfunction
+
+function! SetUp_Test_AutoLayoutTerminalHorizVert()
+  let s:vimspector_ui_mode = 'auto'
+  " Wide enough to be horizontal layout, but not wide enough to fully fit the
+  " terminal, with enough rows to fit the max terminal below
+  call vimspector#test#setup#PushOption( 'columns',
+        \ 50 + 82 + 3 + 2 + 12 )
+  call vimspector#test#setup#PushOption( 'lines', 50 )
+endfunction
+
+function! Test_AutoLayoutTerminalHorizVert()
+  call s:StartDebugging()
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 25, 1 )
+
+  call assert_equal( 'horizontal', g:vimspector_session_windows.mode )
+  call assert_equal(
+        \ [ 'row', [
+        \   [ 'col', [
+        \     [ 'leaf', g:vimspector_session_windows.variables ],
+        \     [ 'leaf', g:vimspector_session_windows.watches ],
+        \     [ 'leaf', g:vimspector_session_windows.stack_trace ],
+        \   ] ],
+        \   [ 'col', [
+        \     [ 'leaf', g:vimspector_session_windows.code ],
+        \     [ 'leaf', g:vimspector_session_windows.terminal ],
+        \     [ 'leaf', g:vimspector_session_windows.output ],
+        \   ] ]
+        \ ] ],
+        \ winlayout( g:vimspector_session_windows.tabpage ) )
+
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+function! TearDown_Test_AutoLayoutTerminalHorizVert()
+  unlet s:vimspector_ui_mode
+  call vimspector#test#setup#PopOption( 'lines' )
+  call vimspector#test#setup#PopOption( 'columns' )
+endfunction
+
+function! SetUp_Test_AutoLayoutTerminalHorizVertButNotEnoughLines()
+  let s:vimspector_ui_mode = 'auto'
+  " Wide enough to be horizontal layout, but not wide enough to fully fit the
+  " terminal, with enough rows to fit the max terminal below, but there are not
+  " enough lines to do this
+  call vimspector#test#setup#PushOption( 'columns',
+        \ 50 + 82 + 3 + 2 + 12 )
+  call vimspector#test#setup#PushOption( 'lines', 20 )
+endfunction
+
+function! Test_AutoLayoutTerminalHorizVertButNotEnoughLines()
+  call s:StartDebugging()
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 25, 1 )
+
+  call assert_equal( 'horizontal', g:vimspector_session_windows.mode )
+  call assert_equal(
+        \ [ 'row', [
+        \   [ 'col', [
+        \     [ 'leaf', g:vimspector_session_windows.variables ],
+        \     [ 'leaf', g:vimspector_session_windows.watches ],
+        \     [ 'leaf', g:vimspector_session_windows.stack_trace ],
+        \   ] ],
+        \   [ 'col', [
+        \     [ 'row', [
+        \       [ 'leaf', g:vimspector_session_windows.code ],
+        \       [ 'leaf', g:vimspector_session_windows.terminal ],
+        \     ] ],
+        \     [ 'leaf', g:vimspector_session_windows.output ],
+        \   ] ],
+        \ ] ],
+        \ winlayout( g:vimspector_session_windows.tabpage ) )
+
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+function! TearDown_Test_AutoLayoutTerminalHorizVertButNotEnoughLines()
+  unlet s:vimspector_ui_mode
+  call vimspector#test#setup#PopOption( 'lines' )
+  call vimspector#test#setup#PopOption( 'columns' )
+endfunction
+
+function! SetUp_Test_AutoLayoutTerminalHoriz()
+  let s:vimspector_ui_mode = 'vertical'
+  " Vertical layout, but we split the terminal horizonally
+  call vimspector#test#setup#PushOption( 'columns', 200 )
+  call vimspector#test#setup#PushOption( 'lines', 50 )
+endfunction
+
+function! Test_AutoLayoutTerminalHoriz()
+  call s:StartDebugging()
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 25, 1 )
+
+  call assert_equal( 'vertical', g:vimspector_session_windows.mode )
+  call assert_equal(
+        \ [ 'col', [
+        \   [ 'row', [
+        \     [ 'leaf', g:vimspector_session_windows.variables ],
+        \     [ 'leaf', g:vimspector_session_windows.watches ],
+        \     [ 'leaf', g:vimspector_session_windows.stack_trace ],
+        \   ] ],
+        \   [ 'row', [
+        \     [ 'leaf', g:vimspector_session_windows.code ],
+        \     [ 'leaf', g:vimspector_session_windows.terminal ],
+        \   ] ],
+        \   [ 'leaf', g:vimspector_session_windows.output ],
+        \ ] ],
+        \ winlayout( g:vimspector_session_windows.tabpage ) )
+
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+function! TearDown_Test_AutoLayoutTerminalHoriz()
+  unlet s:vimspector_ui_mode
+  call vimspector#test#setup#PopOption( 'lines' )
+  call vimspector#test#setup#PopOption( 'columns' )
+endfunction
+
+function! SetUp_Test_AutoLayoutTerminalVertVert()
+  let s:vimspector_ui_mode = 'auto'
+  " Not wide enough to go horizontal, but wide enough to put the terminal and
+  " code vertically split
+  call vimspector#test#setup#PushOption( 'columns', 80 )
+  call vimspector#test#setup#PushOption( 'lines', 30 )
+endfunction
+
+function! Test_AutoLayoutTerminalVertVert()
+  call s:StartDebugging()
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 25, 1 )
+
+  call assert_equal( 'vertical', g:vimspector_session_windows.mode )
+  call assert_equal(
+        \ [ 'col', [
+        \   [ 'row', [
+        \     [ 'leaf', g:vimspector_session_windows.variables ],
+        \     [ 'leaf', g:vimspector_session_windows.watches ],
+        \     [ 'leaf', g:vimspector_session_windows.stack_trace ],
+        \   ] ],
+        \   [ 'leaf', g:vimspector_session_windows.code ],
+        \   [ 'leaf', g:vimspector_session_windows.terminal ],
+        \   [ 'leaf', g:vimspector_session_windows.output ],
+        \ ] ],
+        \ winlayout( g:vimspector_session_windows.tabpage ) )
+
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+function! TearDown_Test_AutoLayoutTerminalVertVert()
+  unlet s:vimspector_ui_mode
+  call vimspector#test#setup#PopOption( 'lines' )
+  call vimspector#test#setup#PopOption( 'columns' )
+endfunction
+
 
 function! Test_CloseVariables()
   call s:StartDebugging()


### PR DESCRIPTION
The vimspector UI is "optimised" for wider screens with the utility windows on the left and the code on the right with a vertical split for the terminal.

however, if the window is narrow, this isn't ideal.

    Add vertical (i.e. narrow) layout

    This puts the 3 utility windows at the top, horizontally split, with the
    code view below.  The terminal window is drawn either vertically split
    (if there's room) or horizontally split otherwise.  The output window
    remains at tht bottom.

    We add equivalent sizing options too, setting some defauts that roughly
    work on my macbook pro.

    By default we switch to the narrow layout if there are fewer than 160
    columns, but this can be overridden by setting g:vimspector_ui_mode.

Auto mode tries to guess the best layout, but can also be controlled with options.