### PR TITLE
Update netcoredbg to 1.2.0-738 to support async/await

### DIFF
--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -233,7 +233,7 @@ GADGETS = {
       'format': 'tar',
     },
     'all': {
-      'version': '1.2.0-635'
+      'version': '1.2.0-738'
     },
     'macos': {
       'file_name': 'netcoredbg-osx.tar.gz',

--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -237,7 +237,7 @@ GADGETS = {
     },
     'macos': {
       'file_name': 'netcoredbg-osx.tar.gz',
-      'version': '1.2.0-536',
+      'version': '1.2.0-635',
       'checksum':
         '71c773e34d358950f25119bade7e3081c4c2f9d71847bd49027ca5792e918beb',
     },

--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -237,11 +237,12 @@ GADGETS = {
     },
     'macos': {
       'file_name': 'netcoredbg-osx.tar.gz',
+      'version': '1.2.0-536',
       'checksum':
         '71c773e34d358950f25119bade7e3081c4c2f9d71847bd49027ca5792e918beb',
     },
     'linux': {
-      'file_name': 'netcoredbg-linux-bionic.tar.gz',
+      'file_name': 'netcoredbg-linux-bionic-amd64.tar.gz',
       'checksum': '',
     },
     'windows': {


### PR DESCRIPTION
Simple pull to update netcoredbg to 1.2.0-738. 

**There is currently no new binary for macos, so I was hoping that setting 'version' on the macos settings would override the 'all' settings.** Please advise if that is not the case. I do not have a mac to test on.

I have tested on arch linux with kernel 5.11.4-arch1-1 and Windows 10.