### PR TITLE
Fix default variable values having substitutions from the calculus

### DIFF
--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -494,7 +494,6 @@ def _Substitute( template, mapping ):
     if mo.group( 'braceddefault' ) is not None:
       named = mo.group( 'defname' )
       if named not in mapping:
-        ''
         raise MissingSubstitution(
           named,
           mo.group( 'default' ).replace( '\\}', '}' ) )
@@ -536,8 +535,11 @@ def ExpandReferencesInString( orig_s,
         if default_value is None and e.default_value is not None:
           try:
             default_value = _Substitute( e.default_value, mapping )
-          except MissingSubstitution:
-            default_value = e.default_value
+          except MissingSubstitution as e2:
+            if e2.name in calculus:
+              default_value = calculus[ e2.name ]()
+            else:
+              default_value = e.default_value
 
         mapping[ key ] = AskForInput( 'Enter value for {}: '.format( key ),
                                       default_value )

--- a/tests/python/Test_ExpandReferencesInDict.py
+++ b/tests/python/Test_ExpandReferencesInDict.py
@@ -35,6 +35,7 @@ class TestExpandReferencesInDict( unittest.TestCase ):
       'one': '${one}',
       'two': '${one} and ${two}',
       'three': '${three}',
+      'three_with_default': '${three_with_default:${three\\}}', # uses calculus
       'four': '${four}',
       'five': '${five}',
       'list': [ '*${words}' ],
@@ -58,6 +59,7 @@ class TestExpandReferencesInDict( unittest.TestCase ):
       'one': 'one',
       'two': 'one and TWO',
       'three': '3',
+      'three_with_default': '3',
       'four': 'typed text',
       'five': '5ive!',
       'list': [ 'these', 'are', 'some', 'words' ],


### PR DESCRIPTION
Previously it would default to the `${whatever}`; I think this was broken when the calculus was introduced.