### PR TITLE
Add the ${lineNumber} predefined variable

### DIFF
--- a/doc/vimspector-ref.txt
+++ b/doc/vimspector-ref.txt
@@ -615,6 +615,7 @@ The following variables are provided:
 - '${fileDirname}' - the current opened file's 'dirname'
 - '${fileExtname}' - the current opened file's extension
 - '${cwd}' - the current working directory of the active window on launch
+- '${lineNumber}' - the current selected line number in the active file
 - '${unusedLocalPort}' - an unused local TCP port
 
 ===============================================================================

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -578,6 +578,7 @@ The following variables are provided:
 * `${fileDirname}` - the current opened file's `dirname`
 * `${fileExtname}` - the current opened file's extension
 * `${cwd}` - the current working directory of the active window on launch
+* `${lineNumber}` - the current selected line number in the active file
 * `${unusedLocalPort}` - an unused local TCP port
 
 ## Remote Debugging Support

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -113,6 +113,7 @@ class DebugSession( object ):
     self._launch_config = None
 
     current_file = utils.GetBufferFilepath( vim.current.buffer )
+    current_line_number = vim.current.window.cursor[0]
     adapters = {}
     launch_config_file, configurations = self.GetConfigurations( adapters )
 
@@ -231,6 +232,7 @@ class DebugSession( object ):
       'workspaceFolder': self._workspace_root,
       'gadgetDir': install.GetGadgetDir( VIMSPECTOR_HOME ),
       'file': current_file,
+      'lineNumber': current_line_number,
     }
 
     calculus = {


### PR DESCRIPTION
When writing a debug profile configuration, it's useful to be able to
access the exact line in the source from which debugging is launched.
For example, this can be used to find the test function to debug.

VSCode already supports a ${lineNumber} predefined variable. Add support
for this variable in Vimspector.

Fixes puremourning/vimspector#404