### PR TITLE
FIx typo in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -722,7 +722,7 @@ Vimspector then orchestrates the various tools to set you up.
       "variables": {
         // Just an example of how to specify a variable manually rather than
         // vimspector asking for input from the user
-        "ServiceName": "${fileBasenameNoExtention}"
+        "ServiceName": "${fileBasenameNoExtension}"
       },
 
       "adapter": "python-remote",


### PR DESCRIPTION
A small typo that wastes time for people that copy and modify the config file