### PR TITLE
Open debugger in same tab

### DIFF
--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -418,7 +418,6 @@ class DebugSession( object ):
       self._variablesView.Reset()
       self._outputView.Reset()
       self._codeView.Reset()
-      vim.command( 'tabclose!' )
       vim.command( 'doautocmd <nomodeline> User VimspectorDebugEnded' )
       self._stackTraceView = None
       self._variablesView = None
@@ -666,7 +665,6 @@ class DebugSession( object ):
 
 
   def _SetUpUI( self ):
-    vim.command( 'tab split' )
     self._uiTab = vim.current.tabpage
 
     mode = settings.Get( 'ui_mode' )


### PR DESCRIPTION
It seems not necessary to start debugger in separate tab. A better approach to me seems to be just using the same tab