### PR TITLE
Add support for logpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,7 +863,7 @@ is paused when the specified line is executed.
 For most debugging scenarios, users will just hit `<F9>` to create a line
 breakpoint on the current line and `<F5>` to launch the application.
 
-### Conditional breakpoints
+### Conditional breakpoints and logpoints
 
 Some debug adapters support conditional breakpoints. Note that vimspector does
 not tell you if the debugger doesn't support conditional breakpoints (yet). A
@@ -880,8 +880,12 @@ dictionary of options. The dictionary can have the following keys:
   times the breakpoint should be ignored. Should (probably?) not be used in
   combination with `condition`. Not supported by all debug adapters. For
   example, to break on the 3rd time hitting this line, enter `3`.
+* `logMessage`: An optional string to make this breakpoint a "logpoint" instead.
+  When triggered, this message is printed to the console rather than
+  interrupting execution. You can embed expressions in braces `{like this}`, for
+  example `#{ logMessage: "Iteration {i} or {num_entries / 2}" }`
 
-In both cases, the expression is evaluated by the debugger, so should be in
+In each case expressions are evaluated by the debugger, so should be in
 whatever dialect the debugger understands when evaluating expressions.
 
 When using the `<leader><F9>` mapping, the user is prompted to enter these

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -84,6 +84,25 @@ function! vimspector#ClearBreakpoints() abort
   py3 _vimspector_session.ClearBreakpoints()
 endfunction
 
+let s:extended_breakpoint_properties = [
+      \ { 'prop': 'condition', 'msg': 'Enter condition expression' },
+      \ { 'prop': 'hitCondition', 'msg': 'Enter hit count expression' },
+      \ { 'prop': 'logMessage',
+      \   'msg': 'Enter log expression (to make log point)' },
+    \ ]
+
+function! vimspector#ToggleAdvancedBreakpoint() abort
+  let options = {}
+  for spec in s:extended_breakpoint_properties
+    let response = input( spec.msg . ': ' )
+    if response !=# ''
+      let options[ spec.prop ] = response
+    endif
+  endfor
+
+  call vimspector#ToggleBreakpoint( options )
+endfunction
+
 function! vimspector#ToggleBreakpoint( ... ) abort
   if !s:Enabled()
     return

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -53,10 +53,7 @@ nnoremap <silent> <Plug>VimspectorPause
 nnoremap <silent> <Plug>VimspectorToggleBreakpoint
       \ :<c-u>call vimspector#ToggleBreakpoint()<CR>
 nnoremap <silent> <Plug>VimspectorToggleConditionalBreakpoint
-      \ :<c-u>call vimspector#ToggleBreakpoint(
-                    \ { 'condition': input( 'Enter condition expression: ' ),
-                    \   'hitCondition': input( 'Enter hit count expression: ' ) }
-                    \ )<CR>
+      \ :<c-u>call vimspector#ToggleAdvancedBreakpoint()<CR>
 nnoremap <silent> <Plug>VimspectorAddFunctionBreakpoint
       \ :<c-u>call vimspector#AddFunctionBreakpoint( expand( '<cexpr>' ) )<CR>
 nnoremap <silent> <Plug>VimspectorStepOver

--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -484,7 +484,9 @@ class ProjectBreakpoints( object ):
           self._next_sign_id += 1
 
         sign = ( 'vimspectorBPDisabled' if bp[ 'state' ] != 'ENABLED'
-                 else 'vimspectorBPCond' if 'condition' in bp[ 'options' ]
+                 else 'vimspectorBPCond'
+                   if 'condition' in bp[ 'options' ]
+                   or 'hitCondition' in bp[ 'options' ]
                  else 'vimspectorBP' )
 
         if utils.BufferExists( file_name ):

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -1294,7 +1294,10 @@ class DebugSession( object ):
       f"Workspace Root: { self._workspace_root }",
       "Launch Config: " ] + Pretty( self._launch_config ) + [
       "Server Capabilities: " ] + Pretty( self._server_capabilities ) + [
-    ]
+      "Line Breakpoints: " ] + Pretty( self._breakpoints._line_breakpoints ) + [
+      "Server Breakpoints: " ] + Pretty( self._codeView._breakpoints ) + [
+      "Func Breakpoints: " ] + Pretty( self._breakpoints._func_breakpoints ) + [
+      "Ex Breakpoints: " ] + Pretty( self._breakpoints._exception_breakpoints )
 
     self._outputView.ClearCategory( 'DebugInfo' )
     self._outputView.Print( "DebugInfo", debugInfo )

--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -421,12 +421,12 @@ GADGETS = {
              '${version}/${file_name}',
     },
     'all': {
-      'version': 'v1.6.5',
+      'version': 'v1.6.7',
     },
     'macos': {
       'file_name': 'codelldb-x86_64-darwin.vsix',
       'checksum':
-        'e7d9f4f8ec3c3774af6d1dbf11f0568db1417c4d51038927228cd07028725594',
+        'b652fc18f100f93ed1732a131f3dc519cbaf5ae688e9a91decf795203206497d',
       'make_executable': [
         'adapter/codelldb',
         'lldb/bin/debugserver',
@@ -437,7 +437,7 @@ GADGETS = {
     'linux': {
       'file_name': 'codelldb-x86_64-linux.vsix',
       'checksum':
-        'eda2cd9b3089dcc0524c273e91ffb5875fe08c930bf643739a2cd1846e1f98d6',
+        'ca95479f9f6c9563aefb043e3bbacd7cc641b5915412df480ef9438b224d71ff',
       'make_executable': [
         'adapter/codelldb',
         'lldb/bin/lldb',
@@ -448,7 +448,7 @@ GADGETS = {
     'windows': {
       'file_name': 'codelldb-x86_64-windows.vsix',
       'checksum':
-        '8ddebe8381a3d22dc3d95139c3797fda06b5cc34aadf300e13b1c516b9da95fe',
+        '0ae2559b4de4db592fb0eb44a2300e080cf802d3ea9970fe30835d4a63b5adc9',
       'make_executable': []
     },
     'adapters': {

--- a/support/test/cpp/simple_c_program/.vimspector.json
+++ b/support/test/cpp/simple_c_program/.vimspector.json
@@ -2,6 +2,11 @@
   "configurations": {
     "CodeLLDB": {
       "adapter": "CodeLLDB",
+      "variables": {
+        "BUILDME": {
+          "shell": "g++ -o ${workspaceRoot}/test -g -std=c++17 ${workspaceRoot}/test_c.cpp"
+        }
+      },
       "configuration": {
         "request": "launch",
         "program": "${workspaceRoot}/test",
@@ -10,6 +15,11 @@
     },
     "lldb-vscode": {
       "adapter": "lldb-vscode",
+      "variables": {
+        "BUILDME": {
+          "shell": "g++ -o ${workspaceRoot}/test -g -std=c++17 ${workspaceRoot}/test_c.cpp"
+        }
+      },
       "configuration": {
         "request": "launch",
         "program": "${workspaceRoot}/test",
@@ -18,6 +28,11 @@
     },
     "cpptools": {
       "adapter": "vscode-cpptools",
+      "variables": {
+        "BUILDME": {
+          "shell": "g++ -o ${workspaceRoot}/test -g -std=c++17 ${workspaceRoot}/test_c.cpp"
+        }
+      },
       "configuration": {
         "request": "launch",
         "program": "${workspaceRoot}/test",

--- a/support/test/cpp/simple_c_program/test_c.cpp
+++ b/support/test/cpp/simple_c_program/test_c.cpp
@@ -38,5 +38,9 @@ int main ( int argc, char ** argv )
   printf( "HOME: %s\n", getenv( "HOME" ) );
 
   Test::TestStruct t{ true, {99} };
-  foo( t );
+  foo( t ); // ADL!
+
+  for ( int i = 0; i < 100 ; ++i ) {
+    Test::foo( { true, {i} } );
+  }
 }

--- a/tests/breakpoints_doublewidth.test.vim
+++ b/tests/breakpoints_doublewidth.test.vim
@@ -294,7 +294,7 @@ function! Test_Conditional_Line_Breakpoint()
   call vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorBP', 16 )
 
   " Add the conditional breakpoint (, is mapleader)
-  call feedkeys( ",\<F9>argc==0\<CR>\<CR>", 'xt' )
+  call feedkeys( ",\<F9>argc==0\<CR>\<CR>\<CR>", 'xt' )
   call vimspector#test#signs#AssertSignGroupSingletonAtLine( 'VimspectorBP',
                                                            \ 16,
                                                            \ 'vimspectorBPCond',
@@ -371,7 +371,7 @@ function! Test_Conditional_Line_Breakpoint_Hit()
   call setpos( '.', [ 0, 14, 1 ] )
 
   " Add the conditional breakpoint (3 times) (, is mapleader)
-  call feedkeys( ",\<F9>\<CR>3\<CR>", 'xt' )
+  call feedkeys( ",\<F9>\<CR>3\<CR>\<CR>", 'xt' )
   call vimspector#test#signs#AssertSignGroupSingletonAtLine(
         \ 'VimspectorBP',
         \ 14,
@@ -519,6 +519,7 @@ function! Test_ListBreakpoints()
 endfunction
 
 function! Test_Custom_Breakpoint_Priority()
+  call ThisTestIsFlaky()
   let g:vimspector_sign_priority = {
         \ 'vimspectorPC': 1,
         \ 'vimspectorPCBP': 1,

--- a/tests/testdata/cpp/simple/.vimspector.json
+++ b/tests/testdata/cpp/simple/.vimspector.json
@@ -107,7 +107,19 @@
         "request": "launch",
         "program": "${workspaceRoot}/${fileBasenameNoExtension}",
         "cwd": "${workspaceRoot}",
-        "expressions": "native"
+        "expressions": "native",
+        "args": [
+          "A", "eh",
+          "B", "bee",
+          "C", "Sea",
+          "D", "Ceedy"
+        ]
+      },
+      "breakpoints": {
+        "exception": {
+          "cpp_throw": "",
+          "cpp_catch": ""
+        }
       }
     }
   },

--- a/tests/ui.test.vim
+++ b/tests/ui.test.vim
@@ -709,3 +709,24 @@ function! Test_VimspectorJumpedToFrame()
   lcd -
   %bwipe!
 endfunction
+
+function! Test_DebugInfo_NotConnected()
+  redir => debug_message
+  VimspectorDebugInfo
+  redir END
+
+  call assert_equal( 'Vimspector not connected, start a debug session first',
+        \ trim( debug_message ) )
+
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+function! Test_DebugInfo_Connected()
+  call s:StartDebugging()
+
+  " Just make sure there are no errors for now
+  VimspectorDebugInfo
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction


### PR DESCRIPTION
Log points are added when `logMessage` is in the extra breakpoints options.

These work in codelldb, but in vscode-cpptools it seems that you have to only add them _after_ starting debugging (don't seem to work if added beforehand). So we use codelldb in the tests, which is a good thing to be doing anyway.