### PR TITLE
Add basic session save/restore functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ For detailed explanation of the `.vimspector.json` format, see the
        * [Exception breakpoints](#exception-breakpoints)
        * [Clear breakpoints](#clear-breakpoints)
        * [Run to Cursor](#run-to-cursor)
+       * [Save and restore](#save-and-restore)
     * [Stepping](#stepping)
     * [Variables and scopes](#variables-and-scopes)
     * [Variable or selection hover evaluation](#variable-or-selection-hover-evaluation)
@@ -93,7 +94,7 @@ For detailed explanation of the `.vimspector.json` format, see the
     * [Example](#example)
  * [FAQ](#faq)
 
-<!-- Added by: ben, at: Tue 21 Sep 2021 11:51:03 BST -->
+<!-- Added by: ben, at: Tue 28 Sep 2021 20:51:39 BST -->
 
 <!--te-->
 
@@ -839,6 +840,8 @@ breakpoints. This section describes the full API in vimscript functions.
 * Use `vimspector#ClearLineBreakpoint( file_name, line_num )` to
   remove a breakpoint at a specific file/line
 * Use `vimspector#ClearBreakpoints()` to clear all breakpoints
+* Use `:VimspectorMkSession` and `:VimspectorLoadSession` to save and restore
+  breakpoints
 
 Examples:
 
@@ -854,6 +857,10 @@ Examples:
 * `call vimspector#ClearLineBreakpoint( 'some_file.py', 10 )` - delete the
   breakpoint at `some_file.py:10`
 * `call vimspector#ClearBreakpoints()` - clear all breakpoints
+* `VimspectorMkSession` - create `.vimspector.session`
+* `VimspectorLoadSession` - read `.vimspector.session`
+* `VimspectorMkSession my_session_file` - create `my_session_file`
+* `VimspectorLoadSession my_session_file` - read `my_session_file`
 
 ### Line breakpoints
 
@@ -915,6 +922,29 @@ to clear all breakpoints including the memory of exception breakpoint choices.
 Use `vimspector#RunToCursor` or `<leader><F8>`: this creates a temporary
 breakpoint on the current line, then continues execution, clearing the
 breakpoint when it is hit.
+
+### Save and restore
+
+Vimspector can save and restore breakpoints (and some other stuff) to a session
+file. The following commands exist for htat:
+
+* `VimspectorMkSession [file name]` - save the current set of line breakpoints,
+  logpoints, conditional breakpoints, function breakpoints and exception
+  breakpoint filters to the session file.
+* `VimspectorLoadSession [file name]` - read breakpoints from the session file
+  and replace any currently set breakpoints. Prior to loading, all current
+  breakpoints are cleared (as if `vimspector#ClearLineBreakpoints()` was
+  called).
+
+In both cases, the file name argument is optional. By default, the file is named
+`.vimspector.session`, but this can be changed globally by setting
+`g:vimspector_session_file_name` to something else, or by manually specifying a
+path when calling the command.
+
+Advanced users may wish to automate the process of loading and saving, for
+example by adding `VimEnter` and `VimLeave` autocommands. It's recommented in
+that case to use `silent!` to avoid annoying errors if the file can't be read or
+writtten.
 
 ## Stepping
 

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -557,7 +557,7 @@ function! vimspector#OnBufferCreated( file_name ) abort
     return
   endif
 
-  py3 _vimspector_session.RefreshSigns( vim.eval( 'a:file_name' ) )
+  py3 _vimspector_session.RefreshSigns()
 endfunction
 
 function! vimspector#ShowEvalBalloon( is_visual ) abort
@@ -584,6 +584,21 @@ function! vimspector#PrintDebugInfo() abort
   py3 _vimspector_session.PrintDebugInfo()
 endfunction
 
+function! vimspector#ReadSessionFile( file_name ) abort
+  if !s:Enabled()
+    return
+  endif
+
+  py3 _vimspector_session.ReadSessionFile( vim.eval( 'a:file_name' ) )
+endfunction
+
+function! vimspector#WriteSessionFile( file_name ) abort
+  if !s:Enabled()
+    return
+  endif
+
+  py3 _vimspector_session.WriteSessionFile( vim.eval( 'a:file_name' ) )
+endfunction
 
 " Boilerplate {{{
 let &cpoptions=s:save_cpo

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -584,20 +584,32 @@ function! vimspector#PrintDebugInfo() abort
   py3 _vimspector_session.PrintDebugInfo()
 endfunction
 
-function! vimspector#ReadSessionFile( file_name ) abort
+function! vimspector#ReadSessionFile( ... ) abort
   if !s:Enabled()
     return
   endif
 
-  py3 _vimspector_session.ReadSessionFile( vim.eval( 'a:file_name' ) )
+  if a:0 == 0
+    let file_name = '.vimspector.session'
+  else
+    let file_name = a:1
+  endif
+
+  py3 _vimspector_session.ReadSessionFile( vim.eval( 'file_name' ) )
 endfunction
 
-function! vimspector#WriteSessionFile( file_name ) abort
+function! vimspector#WriteSessionFile( ... ) abort
   if !s:Enabled()
     return
   endif
 
-  py3 _vimspector_session.WriteSessionFile( vim.eval( 'a:file_name' ) )
+  if a:0 == 0
+    let file_name = '.vimspector.session'
+  else
+    let file_name = a:1
+  endif
+
+  py3 _vimspector_session.WriteSessionFile( vim.eval( 'file_name' ) )
 endfunction
 
 " Boilerplate {{{

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -589,13 +589,7 @@ function! vimspector#ReadSessionFile( ... ) abort
     return
   endif
 
-  if a:0 == 0
-    let file_name = '.vimspector.session'
-  else
-    let file_name = a:1
-  endif
-
-  py3 _vimspector_session.ReadSessionFile( vim.eval( 'file_name' ) )
+  py3 _vimspector_session.ReadSessionFile( *vim.eval( 'a:000' ) )
 endfunction
 
 function! vimspector#WriteSessionFile( ... ) abort
@@ -603,13 +597,7 @@ function! vimspector#WriteSessionFile( ... ) abort
     return
   endif
 
-  if a:0 == 0
-    let file_name = '.vimspector.session'
-  else
-    let file_name = a:1
-  endif
-
-  py3 _vimspector_session.WriteSessionFile( vim.eval( 'file_name' ) )
+  py3 _vimspector_session.WriteSessionFile( *vim.eval( 'a:000' ) )
 endfunction
 
 " Boilerplate {{{

--- a/doc/vimspector-ref.txt
+++ b/doc/vimspector-ref.txt
@@ -311,7 +311,7 @@ If the user accepts the default, the resulting string '"true"' is coerced to a
 JSON value 'true', and the suffix is stripped fom the key, resulting in the
 following:
 >
-  "stopOnEntry#json": true
+  "stopOnEntry": true
 <
 Which is what we need.
 
@@ -761,7 +761,7 @@ Vimspector then orchestrates the various tools to set you up.
         "variables": {
           // Just an example of how to specify a variable manually rather than
           // vimspector asking for input from the user
-          "ServiceName": "${fileBasenameNoExtention}"
+          "ServiceName": "${fileBasenameNoExtension}"
         },
   
         "adapter": "python-remote",

--- a/doc/vimspector.txt
+++ b/doc/vimspector.txt
@@ -39,10 +39,11 @@ Contents ~
   2. Breakpoints                                       |vimspector-breakpoints|
    1. Summary                                              |vimspector-summary|
    2. Line breakpoints                            |vimspector-line-breakpoints|
-   3. Conditional breakpoints              |vimspector-conditional-breakpoints|
+   3. Conditional breakpoints and logpoints |vimspector-conditional-breakpoints-logpoints|
    4. Exception breakpoints                  |vimspector-exception-breakpoints|
    5. Clear breakpoints                          |vimspector-clear-breakpoints|
    6. Run to Cursor                                  |vimspector-run-to-cursor|
+   7. Save and restore                                |vimspector-save-restore|
   3. Stepping                                             |vimspector-stepping|
   4. Variables and scopes                         |vimspector-variables-scopes|
   5. Variable or selection hover evaluation |vimspector-variable-or-selection-hover-evaluation|
@@ -57,13 +58,13 @@ Contents ~
   10. Terminate debuggee                        |vimspector-terminate-debuggee|
  7. Debug profile configuration        |vimspector-debug-profile-configuration|
   1. C, C++, Rust, etc.                              |vimspector-c-c-rust-etc.|
-   1. C++ Remote debugging                      |vimspector-c-remote-debugging|
-   2. C++ Remote launch and attach          |vimspector-c-remote-launch-attach|
+   1. Data visualization / pretty printing |vimspector-data-visualization-pretty-printing|
+   2. C++ Remote debugging                      |vimspector-c-remote-debugging|
+   3. C++ Remote launch and attach          |vimspector-c-remote-launch-attach|
   2. Rust                                                     |vimspector-rust|
   3. Python                                                 |vimspector-python|
    1. Python Remote Debugging              |vimspector-python-remote-debugging|
    2. Python Remote launch and attach  |vimspector-python-remote-launch-attach|
-   3. Legacy: vscode-python                   |vimspector-legacy-vscode-python|
   4. TCL                                                       |vimspector-tcl|
   5. C♯                                                          |vimspector-c|
   6. Go                                                         |vimspector-go|
@@ -72,8 +73,9 @@ Contents ~
    2. Debug cli application                  |vimspector-debug-cli-application|
   8. JavaScript, TypeScript, etc.       |vimspector-javascript-typescript-etc.|
   9. Java                                                     |vimspector-java|
-   1. Usage with YouCompleteMe            |vimspector-usage-with-youcompleteme|
-   2. Other LSP clients                          |vimspector-other-lsp-clients|
+   1. Hot code replace                            |vimspector-hot-code-replace|
+   2. Usage with YouCompleteMe            |vimspector-usage-with-youcompleteme|
+   3. Other LSP clients                          |vimspector-other-lsp-clients|
   10. Lua                                                      |vimspector-lua|
   11. Other servers                                  |vimspector-other-servers|
  8. Customisation                                    |vimspector-customisation|
@@ -94,7 +96,7 @@ Introduction ~
 
 For a tutorial and usage overview, take a look at the Vimspector website [1].
 
-For detailed explanatin of the '.vimspector.json' format, see the reference
+For detailed explanation of the '.vimspector.json' format, see the reference
 guide [2].
 
 Image: Build (see reference [3]) Image: Gitter [4]
@@ -143,10 +145,11 @@ Image: Build (see reference [3]) Image: Gitter [4]
   - Breakpoints
   - Summary
   - Line breakpoints
-  - Conditional breakpoints
+  - Conditional breakpoints and logpoints
   - Exception breakpoints
   - Clear breakpoints
   - Run to Cursor
+  - Save and restore
   - Stepping
   - Variables and scopes
   - Variable or selection hover evaluation
@@ -158,17 +161,18 @@ Image: Build (see reference [3]) Image: Gitter [4]
   - Console autocompletion
   - Log View
   - Closing debugger
+  - Terminate debuggee
 
 - Debug profile configuration
 
-  - C, C , Rust, etc.
-  - C Remote debugging
-  - C Remote launch and attach
+  - C, C++, Rust, etc.
+  - Data visualization / pretty printing
+  - C++ Remote debugging
+  - C++ Remote launch and attach
   - Rust
   - Python
   - Python Remote Debugging
   - Python Remote launch and attach
-  - Legacy: vscode-python
   - TCL
   - C♯
   - Go
@@ -177,6 +181,7 @@ Image: Build (see reference [3]) Image: Gitter [4]
   - Debug cli application
   - JavaScript, TypeScript, etc.
   - Java
+  - Hot code replace
   - Usage with YouCompleteMe
   - Other LSP clients
   - Lua
@@ -200,7 +205,7 @@ Image: Build (see reference [3]) Image: Gitter [4]
 Features and Usage ~
 
 The plugin is a capable Vim graphical debugger for multiple languages. It's
-mostly tested for c++, python and TCL, but in theory supports any language that
+mostly tested for C++, Python and TCL, but in theory supports any language that
 Visual Studio Code supports (but see caveats).
 
 The Vimspector website [1] has an overview of the UI, along with basic
@@ -250,38 +255,41 @@ runtime dependencies). They are categorised by their level of support:
 - 'Supported' : Fully supported, frequently used and manually tested
 - 'Experimental': Working, but not frequently used and rarely tested
 - 'Legacy': No longer supported, please migrate your config
+- 'Retired': No longer included or supported.
 
-========================================================================================================================================================
-|     _Language_     |   _Status_   | _Switch (for 'install_gadget.py')_ | _Adapter (for ':VimspectorInstall')_ |            _Dependencies_            |
-========================================================================================================================================================
-| C, C++, Rust etc.  | Tested       | '--all' or '--enable-c' (or cpp)   | vscode-cpptools                      | mono-core                            |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| Rust, C, C++, etc. | Supported    | '--force-enable-rust'              | CodeLLDB                             | Python 3                             |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| Python             | Tested       | '--all' or '--enable-python'       | debugpy                              | Python 2.7 or Python 3               |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| Go                 | Tested       | '--enable-go'                      | vscode-go                            | Go, Delve [11]                       |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| TCL                | Supported    | '--all' or '--enable-tcl'          | tclpro                               | TCL 8.5                              |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| Bourne Shell       | Supported    | '--all' or '--enable-bash'         | vscode-bash-debug                    | Bash v??                             |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| Lua                | Supported    | '--all' or '--enable-lua'          | local-lua-debugger-vscode            | Node >=12.13.0, Npm, Lua interpreter |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| Node.js            | Supported    | '--force-enable-node'              | vscode-node-debug2                   | 6 < Node < 12, Npm                   |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| Javascript         | Supported    | '--force-enable-chrome'            | debugger-for-chrome                  | Chrome                               |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| Java               | Supported    | '--force-enable-java'              | vscode-java-debug                    | Compatible LSP plugin (see later)    |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| C# (dotnet core)   | Experimental | '--force-enable-csharp'            | netcoredbg                           | DotNet core                          |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| C# (mono)          | Experimental | '--force-enable-csharp'            | vscode-mono-debug                    | Mono                                 |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| F#, VB, etc.       | Experimental | '--force-enable-fsharp' (or vbnet) | netcoredbg                           | DotNet core                          |
---------------------------------------------------------------------------------------------------------------------------------------------------------
-| Python.legacy      | Legacy       | '--force-enable-python.legacy'     | vscode-python                        | Node 10, Python 2.7 or Python 3      |
---------------------------------------------------------------------------------------------------------------------------------------------------------
+=====================================================================================================================================================
+|     _Language_     |  _Status_ | _Switch (for 'install_gadget.py')_ | _Adapter (for ':VimspectorInstall')_ |            _Dependencies_            |
+=====================================================================================================================================================
+| C, C++, Rust etc.  | Tested    | '--all' or '--enable-c' (or cpp)   | vscode-cpptools                      | mono-core                            |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| Rust, C, C++, etc. | Supported | '--force-enable-rust'              | CodeLLDB                             | Python 3                             |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| Python             | Tested    | '--all' or '--enable-python'       | debugpy                              | Python 2.7 or Python 3               |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| Go                 | Tested    | '--enable-go'                      | vscode-go                            | Node, Go, Delve [11]                 |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| TCL                | Supported | '--all' or '--enable-tcl'          | tclpro                               | TCL 8.5                              |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| Bourne Shell       | Supported | '--all' or '--enable-bash'         | vscode-bash-debug                    | Bash v??                             |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| Lua                | Supported | '--all' or '--enable-lua'          | local-lua-debugger-vscode            | Node >=12.13.0, Npm, Lua interpreter |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| Node.js            | Supported | '--force-enable-node'              | vscode-node-debug2                   | 6 < Node < 12, Npm                   |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| Javascript         | Supported | '--force-enable-chrome'            | debugger-for-chrome                  | Chrome                               |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| Javascript         | Supported | '--force-enable-firefox'           | vscode-firefox-debug                 | Firefox                              |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| Java               | Supported | '--force-enable-java'              | vscode-java-debug                    | Compatible LSP plugin (see later)    |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| C# (dotnet core)   | Tested    | '--force-enable-csharp'            | netcoredbg                           | DotNet core                          |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| F#, VB, etc.       | Supported | '--force-enable-[fsharp,vbnet]'    | ','--force-enable-vbnet`             | netcoredbg                           |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| C# (mono)          | _Retired_ | N/A                                | N/A                                  | N/A                                  |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+| Python.legacy      | _Retired_ | N/A                                | N/A                                  | N/A                                  |
+-----------------------------------------------------------------------------------------------------------------------------------------------------
 
 
 -------------------------------------------------------------------------------
@@ -419,9 +427,10 @@ If you just want to try out vimspector without changing your vim config, there
 are example projects for a number of languages in 'support/test', including:
 
 - Python ('support/test/python/simple_python')
-- Go ('support/test/go/hello_world')
+- Go ('support/test/go/hello_world' and
+  'support/test/go/name-starts-with-vowel')
 - Nodejs ('support/test/node/simple')
-- Chrome ('support/test/chrome/')
+- Chrome/Firefox ('support/test/web/')
 - etc.
 
 To test one of these out, cd to the directory and run:
@@ -664,13 +673,6 @@ Example:
           "${gadgetDir}/vscode-cpptools/debugAdapters/OpenDebugAD7"
         ],
         "name": "cppdbg"
-      },
-      "vscode-python": {
-        "command": [
-          "node",
-          "${gadgetDir}/vscode-python/out/client/debugger/debugAdapter/main.js"
-        ],
-        "name": "vscode-python"
       }
     }
   }
@@ -815,37 +817,37 @@ personal and so you should work out what you like and use vim's powerful
 mapping features to set your own mappings. To that end, Vimspector defines the
 following '<Plug>' mappings:
 
-=================================================================================================================================================================================
-|                   _Mapping_                   |                         _Function_                        |                               _API_                               |
-=================================================================================================================================================================================
-| '<Plug>VimspectorContinue'                    | When debugging, continue. Otherwise start debugging.      | 'vimspector#Continue()'                                           |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorStop'                        | Stop debugging.                                           | 'vimspector#Stop()'                                               |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimpectorRestart'                      | Restart debugging with the same configuration.            | 'vimspector#Restart()'                                            |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorPause'                       | Pause debuggee.                                           | 'vimspector#Pause()'                                              |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorToggleBreakpoint'            | Toggle line breakpoint on the current line.               | 'vimspector#ToggleBreakpoint()'                                   |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorToggleConditionalBreakpoint' | Toggle conditional line breakpoint on the current line.   | 'vimspector#ToggleBreakpoint( { trigger expr, hit count expr } )' |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorAddFunctionBreakpoint'       | Add a function breakpoint for the expression under cursor | "vimspector#AddFunctionBreakpoint( '<cexpr>' )"                   |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorRunToCursor'                 | Run to Cursor                                             | 'vimspector#RunToCursor()'                                        |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorStepOver'                    | Step Over                                                 | 'vimspector#StepOver()'                                           |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorStepInto'                    | Step Into                                                 | 'vimspector#StepInto()'                                           |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorStepOut'                     | Step out of current function scope                        | 'vimspector#StepOut()'                                            |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorUpFrame'                     | Move up a frame in the current call stack                 | 'vimspector#UpFrame()'                                            |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorDownFrame'                   | Move down a frame in the current call stack               | 'vimspector#DownFrame()'                                          |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| '<Plug>VimspectorBalloonEval'                 | Evaluate expression under cursor (or visual) in popup     | _internal_                                                        |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+===========================================================================================================================================================================================
+|                   _Mapping_                   |                              _Function_                             |                               _API_                               |
+===========================================================================================================================================================================================
+| '<Plug>VimspectorContinue'                    | When debugging, continue. Otherwise start debugging.                | 'vimspector#Continue()'                                           |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorStop'                        | Stop debugging.                                                     | 'vimspector#Stop()'                                               |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimpectorRestart'                      | Restart debugging with the same configuration.                      | 'vimspector#Restart()'                                            |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorPause'                       | Pause debuggee.                                                     | 'vimspector#Pause()'                                              |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorToggleBreakpoint'            | Toggle line breakpoint on the current line.                         | 'vimspector#ToggleBreakpoint()'                                   |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorToggleConditionalBreakpoint' | Toggle conditional line breakpoint or logpoint on the current line. | 'vimspector#ToggleBreakpoint( { trigger expr, hit count expr } )' |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorAddFunctionBreakpoint'       | Add a function breakpoint for the expression under cursor           | "vimspector#AddFunctionBreakpoint( '<cexpr>' )"                   |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorRunToCursor'                 | Run to Cursor                                                       | 'vimspector#RunToCursor()'                                        |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorStepOver'                    | Step Over                                                           | 'vimspector#StepOver()'                                           |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorStepInto'                    | Step Into                                                           | 'vimspector#StepInto()'                                           |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorStepOut'                     | Step out of current function scope                                  | 'vimspector#StepOut()'                                            |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorUpFrame'                     | Move up a frame in the current call stack                           | 'vimspector#UpFrame()'                                            |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorDownFrame'                   | Move down a frame in the current call stack                         | 'vimspector#DownFrame()'                                          |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| '<Plug>VimspectorBalloonEval'                 | Evaluate expression under cursor (or visual) in popup               | _internal_                                                        |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 
 These map roughly 1-1 with the API functions below.
@@ -908,31 +910,31 @@ variables) are unfixable, try the following mappings, by adding the following
 >
   let g:vimspector_enable_mappings = 'HUMAN'
 <
-============================================================================================================================
-|    _Key_     |                   _Mapping_                   |                         _Function_                        |
-============================================================================================================================
-| 'F5'         | '<Plug>VimspectorContinue'                    | When debugging, continue. Otherwise start debugging.      |
-----------------------------------------------------------------------------------------------------------------------------
-| 'F3'         | '<Plug>VimspectorStop'                        | Stop debugging.                                           |
-----------------------------------------------------------------------------------------------------------------------------
-| 'F4'         | '<Plug>VimspectorRestart'                     | Restart debugging with the same configuration.            |
-----------------------------------------------------------------------------------------------------------------------------
-| 'F6'         | '<Plug>VimspectorPause'                       | Pause debuggee.                                           |
-----------------------------------------------------------------------------------------------------------------------------
-| 'F9'         | '<Plug>VimspectorToggleBreakpoint'            | Toggle line breakpoint on the current line.               |
-----------------------------------------------------------------------------------------------------------------------------
-| '<leader>F9' | '<Plug>VimspectorToggleConditionalBreakpoint' | Toggle conditional line breakpoint on the current line.   |
-----------------------------------------------------------------------------------------------------------------------------
-| 'F8'         | '<Plug>VimspectorAddFunctionBreakpoint'       | Add a function breakpoint for the expression under cursor |
-----------------------------------------------------------------------------------------------------------------------------
-| '<leader>F8' | '<Plug>VimspectorRunToCursor'                 | Run to Cursor                                             |
-----------------------------------------------------------------------------------------------------------------------------
-| 'F10'        | '<Plug>VimspectorStepOver'                    | Step Over                                                 |
-----------------------------------------------------------------------------------------------------------------------------
-| 'F11'        | '<Plug>VimspectorStepInto'                    | Step Into                                                 |
-----------------------------------------------------------------------------------------------------------------------------
-| 'F12'        | '<Plug>VimspectorStepOut'                     | Step out of current function scope                        |
-----------------------------------------------------------------------------------------------------------------------------
+======================================================================================================================================
+|    _Key_     |                   _Mapping_                   |                              _Function_                             |
+======================================================================================================================================
+| 'F5'         | '<Plug>VimspectorContinue'                    | When debugging, continue. Otherwise start debugging.                |
+--------------------------------------------------------------------------------------------------------------------------------------
+| 'F3'         | '<Plug>VimspectorStop'                        | Stop debugging.                                                     |
+--------------------------------------------------------------------------------------------------------------------------------------
+| 'F4'         | '<Plug>VimspectorRestart'                     | Restart debugging with the same configuration.                      |
+--------------------------------------------------------------------------------------------------------------------------------------
+| 'F6'         | '<Plug>VimspectorPause'                       | Pause debuggee.                                                     |
+--------------------------------------------------------------------------------------------------------------------------------------
+| 'F9'         | '<Plug>VimspectorToggleBreakpoint'            | Toggle line breakpoint on the current line.                         |
+--------------------------------------------------------------------------------------------------------------------------------------
+| '<leader>F9' | '<Plug>VimspectorToggleConditionalBreakpoint' | Toggle conditional line breakpoint or logpoint on the current line. |
+--------------------------------------------------------------------------------------------------------------------------------------
+| 'F8'         | '<Plug>VimspectorAddFunctionBreakpoint'       | Add a function breakpoint for the expression under cursor           |
+--------------------------------------------------------------------------------------------------------------------------------------
+| '<leader>F8' | '<Plug>VimspectorRunToCursor'                 | Run to Cursor                                                       |
+--------------------------------------------------------------------------------------------------------------------------------------
+| 'F10'        | '<Plug>VimspectorStepOver'                    | Step Over                                                           |
+--------------------------------------------------------------------------------------------------------------------------------------
+| 'F11'        | '<Plug>VimspectorStepInto'                    | Step Into                                                           |
+--------------------------------------------------------------------------------------------------------------------------------------
+| 'F12'        | '<Plug>VimspectorStepOut'                     | Step out of current function scope                                  |
+--------------------------------------------------------------------------------------------------------------------------------------
 
 
 In addition, I recommend adding a mapping to '<Plug>VimspectorBalloonEval', in
@@ -1051,6 +1053,9 @@ Summary ~
 
 - Use 'vimspector#ClearBreakpoints()' to clear all breakpoints
 
+- Use ':VimspectorMkSession' and ':VimspectorLoadSession' to save and restore
+  breakpoints
+
 Examples:
 
 - 'call vimspector#ToggleBreakpoint()' - toggle breakpoint on current line
@@ -1073,6 +1078,14 @@ Examples:
 
 - 'call vimspector#ClearBreakpoints()' - clear all breakpoints
 
+- 'VimspectorMkSession' - create '.vimspector.session'
+
+- 'VimspectorLoadSession' - read '.vimspector.session'
+
+- 'VimspectorMkSession my_session_file' - create 'my_session_file'
+
+- 'VimspectorLoadSession my_session_file' - read 'my_session_file'
+
 -------------------------------------------------------------------------------
                                                   *vimspector-line-breakpoints*
 Line breakpoints ~
@@ -1084,8 +1097,8 @@ For most debugging scenarios, users will just hit '<F9>' to create a line
 breakpoint on the current line and '<F5>' to launch the application.
 
 -------------------------------------------------------------------------------
-                                           *vimspector-conditional-breakpoints*
-Conditional breakpoints ~
+                                 *vimspector-conditional-breakpoints-logpoints*
+Conditional breakpoints and logpoints ~
 
 Some debug adapters support conditional breakpoints. Note that vimspector does
 not tell you if the debugger doesn't support conditional breakpoints (yet). A
@@ -1105,7 +1118,12 @@ dictionary of options. The dictionary can have the following keys:
   combination with 'condition'. Not supported by all debug adapters. For
   example, to break on the 3rd time hitting this line, enter '3'.
 
-In both cases, the expression is evaluated by the debugger, so should be in
+- 'logMessage': An optional string to make this breakpoint a "logpoint"
+  instead. When triggered, this message is printed to the console rather than
+  interrupting execution. You can embed expressions in braces '{like this}',
+  for example '#{ logMessage: "Iteration {i} or {num_entries / 2}" }'
+
+In each case expressions are evaluated by the debugger, so should be in
 whatever dialect the debugger understands when evaluating expressions.
 
 When using the '<leader><F9>' mapping, the user is prompted to enter these
@@ -1141,6 +1159,32 @@ Run to Cursor ~
 Use 'vimspector#RunToCursor' or '<leader><F8>': this creates a temporary
 breakpoint on the current line, then continues execution, clearing the
 breakpoint when it is hit.
+
+-------------------------------------------------------------------------------
+                                                      *vimspector-save-restore*
+Save and restore ~
+
+Vimspector can save and restore breakpoints (and some other stuff) to a session
+file. The following commands exist for htat:
+
+- 'VimspectorMkSession [file name]' - save the current set of line
+  breakpoints, logpoints, conditional breakpoints, function breakpoints and
+  exception breakpoint filters to the session file.
+
+- 'VimspectorLoadSession [file name]' - read breakpoints from the session
+  file and replace any currently set breakpoints. Prior to loading, all
+  current breakpoints are cleared (as if 'vimspector#ClearLineBreakpoints()'
+  was called).
+
+In both cases, the file name argument is optional. By default, the file is
+named '.vimspector.session', but this can be changed globally by setting
+'g:vimspector_session_file_name' to something else, or by manually specifying a
+path when calling the command.
+
+Advanced users may wish to automate the process of loading and saving, for
+example by adding 'VimEnter' and 'VimLeave' autocommands. It's recommented in
+that case to use 'silent!' to avoid annoying errors if the file can't be read
+or writtten.
 
 -------------------------------------------------------------------------------
                                                           *vimspector-stepping*
@@ -1263,6 +1307,9 @@ be changed manually to "switch to" that thread.
   focussed thread to the thread of that frame and jump to that frame in the
   code window.
 
+- The current frame when a breakpoint is hit or if manuall jumping is also
+  highlighted.
+
   Image: stack trace (see reference [28])
 
 The stack trace is represented by the buffer 'vimspector.StackTrace'.
@@ -1328,6 +1375,8 @@ information when something goes wrong that's not a Vim traceback.
 
 If you just want to see the Vimspector log file, use ':VimspectorToggleLog',
 which will tail it in a little window (doesn't work on Windows).
+
+You can see some debugging info with ':VimspectorDebugInfo'
 
 -------------------------------------------------------------------------------
                                                   *vimspector-closing-debugger*
@@ -1437,6 +1486,39 @@ licensing.
   }
 <
 -------------------------------------------------------------------------------
+                                *vimspector-data-visualization-pretty-printing*
+Data visualization / pretty printing ~
+
+Depending on the backend you need to enable pretty printing of complex types
+manually.
+
+- LLDB: Pretty printing is enabled by default
+
+- GDB: To enable gdb pretty printers, consider the snippet below. It is not
+  enough to have 'set print pretty on' in your .gdbinit!
+>
+  {
+    "configurations": {
+      "Launch": {
+        "adapter": "vscode-cpptools",
+        "configuration": {
+          "request": "launch",
+          "program": "<path to binary>",
+          ...
+          "MIMode": "gdb"
+          "setupCommands": [
+            {
+              "description": "Enable pretty-printing for gdb",
+              "text": "-enable-pretty-printing",
+              "ignoreFailures": true
+            }
+          ],
+        }
+      }
+    }
+  }
+<
+-------------------------------------------------------------------------------
                                                 *vimspector-c-remote-debugging*
 C++ Remote debugging ~
 
@@ -1525,9 +1607,6 @@ Python ~
 
 - Full options:
   https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings
-
-**Migrating from 'vscode-python'**: change '"adapter": "vscode-python"' to
-'"adapter": "debugpy"'.
 >
   {
     "configurations": {
@@ -1592,40 +1671,12 @@ If you're feeling fancy, checkout the reference guide [31] for an example of
 getting Vimspector to remotely launch and attach.
 
 -------------------------------------------------------------------------------
-                                              *vimspector-legacy-vscode-python*
-Legacy: vscode-python ~
-
-- No longer installed by default - please pass '--force-enable-python.legacy'
-  if you just want to continue using your working setup.
-- vscode-python [37]
-- NOTE: You must be running 'node' 10. See this issue [38]
->
-  {
-    "configurations": {
-      "<name>: Launch": {
-        "adapter": "vscode-python",
-        "configuration": {
-          "name": "<name>: Launch",
-          "type": "python",
-          "request": "launch",
-          "cwd": "<working directory>",
-          "stopOnEntry": true,
-          "console": "externalTerminal",
-          "debugOptions": [],
-          "program": "<path to main python file>"
-        }
-      }
-      ...
-    }
-  }
-<
--------------------------------------------------------------------------------
                                                                *vimspector-tcl*
 TCL ~
 
 - TCL (TclProDebug)
 
-See my fork of TclProDebug [39] for instructions.
+See my fork of TclProDebug [37] for instructions.
 
 -------------------------------------------------------------------------------
                                                                  *vimspector-c*
@@ -1645,33 +1696,8 @@ netcoredbg'
           "program": "${workspaceRoot}/bin/Debug/netcoreapp2.2/csharp.dll",
           "args": [],
           "stopAtEntry": true,
-          "cwd": "${workspaceRoot}"
-        }
-      }
-    }
-  }
-<
-- C# - mono
-
-Install with 'install_gadget.py --force-enable-csharp' or ':VimspectorInstall
-vscode-mono-debug'.
-
-**_Known not to work._**
->
-  {
-    "configurations": {
-      "launch - mono": {
-        "adapter": "vscode-mono-debug",
-        "configuration": {
-          "request": "launch",
-          "program": "${workspaceRoot}/bin/Debug/netcoreapp2.2/csharp.dll",
-          "args": [],
           "cwd": "${workspaceRoot}",
-          "runtimeExecutable": "mono",
-          "runtimeArgs": [],
-          "env": [],
-          "externalConsole": false,
-          "console": "integratedTerminal"
+          "env": {}
         }
       }
     }
@@ -1686,8 +1712,12 @@ Go ~
 Requires:
 
 - 'install_gadget.py --enable-go' or ':VimspectorInstall vscode-go'
-- Delve [40] installed, e.g. 'go get -u github.com/go-delve/delve/cmd/dlv'
+- Delve [38] installed, e.g. 'go get -u github.com/go-delve/delve/cmd/dlv'
 - Delve to be in your PATH, or specify the 'dlvToolPath' launch option
+
+NOTE: Vimspector uses the "legacy" vscode-go debug adapter [39] rather than the
+"built-in" DAP support in Delve. You can track
+https://github.com/puremourning/vimspector/issues/186 for that.
 >
   {
     "configurations": {
@@ -1703,7 +1733,7 @@ Requires:
     }
   }
 <
-See the vscode-go docs for troubleshooting information [41]
+See the vscode-go docs for troubleshooting information [40]
 
 -------------------------------------------------------------------------------
                                                                *vimspector-php*
@@ -1822,25 +1852,40 @@ Requires:
     }
   }
 <
-- Chrome
+- Chrome/Firefox
 
-This uses the chrome debugger, see https://marketplace.visualstudio.com/items?i
-temName=msjsdiag.debugger-for-chrome.
+This uses the chrome/firefox debugger (they are very similar), see https://mark
+etplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome and https:
+//marketplace.visualstudio.com/items?itemName=firefox-devtools.vscode-firefox-d
+ebug, respectively.
 
 It allows you to debug scripts running inside chrome from within Vim.
 
 - './install_gadget.py --force-enable-chrome' or ':VimspectorInstall
   debugger-for-chrome'
-- Example: 'support/test/chrome'
+
+- './install_gadget.py --force-enable-firefox' or ':VimspectorInstall
+  debugger-for-firefox'
+
+- Example: 'support/test/web'
 >
   {
     "configurations": {
-      "launch": {
+      "chrome": {
         "adapter": "chrome",
         "configuration": {
           "request": "launch",
           "url": "http://localhost:1234/",
           "webRoot": "${workspaceRoot}/www"
+        }
+      },
+      "firefox": {
+        "adapter": "firefox",
+        "configuration": {
+          "request": "launch",
+          "url": "http://localhost:1234/",
+          "webRoot": "${workspaceRoot}/www",
+          "reAttach": true
         }
       }
     }
@@ -1850,20 +1895,35 @@ It allows you to debug scripts running inside chrome from within Vim.
                                                               *vimspector-java*
 Java ~
 
-Vimspector works well with the java debug server [42], which runs as a jdt.ls
+Vimspector works well with the java debug server [41], which runs as a jdt.ls
 (Java Language Server) plugin, rather than a standalone debug adapter.
 
 Vimspector is not in the business of running language servers, only debug
 adapters, so this means that you need a compatible Language Server Protocol
-editor plugin to use Java. I recommend YouCompleteMe [43], which has full
+editor plugin to use Java. I recommend YouCompleteMe [42], which has full
 support for jdt.ls, and most importantly a trivial way to load the debug
 adapter and to use it with Vimspector.
+
+-------------------------------------------------------------------------------
+                                                  *vimspector-hot-code-replace*
+Hot code replace ~
+
+When using the java debug server [41], Vimspector supports the hot code replace
+custom feature. By default, when the underlying class files change, vimspector
+asks the user if they wish to reload these classes at runtime.
+
+This behaviour can be customised:
+
+- "let g:ycm_java_hotcodereplace_mode = 'ask'" - the default, ask the user
+  for each reload.
+- "let g:ycm_java_hotcodereplace_mode = 'always'" - don't ask, always reload
+- "let g:ycm_java_hotcodereplace_mode = 'never'" - don't ask, never reload
 
 -------------------------------------------------------------------------------
                                           *vimspector-usage-with-youcompleteme*
 Usage with YouCompleteMe ~
 
-- Set up YCM for java [43].
+- Set up YCM for java [42].
 
 - Get Vimspector to download the java debug plugin: 'install_gadget.py
   --force-enable-java <other options...>' or ':VimspectorInstall
@@ -1927,24 +1987,24 @@ If you see "Unable to get DAP port - is JDT.LS initialized?", try running
 ':YcmCompleter ExecuteCommand vscode.java.startDebugSession' and note the
 output. If you see an error like 'ResponseFailedException: Request failed:
 -32601: No delegateCommandHandler for vscode.java.startDebugSession', make sure
-that: _Your YCM jdt.ls is actually working, see the YCM docs [44] for
+that: _Your YCM jdt.ls is actually working, see the YCM docs [43] for
 troubleshooting_ The YCM jdt.ls has had time to initialize before you start the
 debugger * That 'g:ycm_java_jdtls_extension_path' is set in '.vimrc' or prior
 to YCM starting
 
-For the launch arguments, see the vscode document [45].
+For the launch arguments, see the vscode document [44].
 
 -------------------------------------------------------------------------------
                                                  *vimspector-other-lsp-clients*
 Other LSP clients ~
 
-See this issue [46] for more background.
+See this issue [45] for more background.
 
 -------------------------------------------------------------------------------
                                                                *vimspector-lua*
 Lua ~
 
-Lua is supported through local-lua-debugger-vscode [47]. This debugger uses
+Lua is supported through local-lua-debugger-vscode [46]. This debugger uses
 stdio to communicate with the running process, so calls to 'io.read' will cause
 problems.
 
@@ -1999,7 +2059,7 @@ problems.
 Other servers ~
 
 - Java - vscode-javac. This works, but is not as functional as Java Debug
-  Server. Take a look at this comment [48] for instructions.
+  Server. Take a look at this comment [47] for instructions.
 
 ===============================================================================
                                                      *vimspector-customisation*
@@ -2015,38 +2075,50 @@ Vimsector uses the following signs internally. If they are defined before
 Vimsector uses them, they will not be replaced. So to customise the signs,
 define them in your 'vimrc'.
 
-=============================================================================
-|         _Sign_         |            _Description_            | _Priority_ |
-=============================================================================
-| 'vimspectorBP'         | Line breakpoint                     | 9          |
------------------------------------------------------------------------------
-| 'vimspectorBPCond'     | Conditional line breakpoint         | 9          |
------------------------------------------------------------------------------
-| 'vimspectorBPDisabled' | Disabled breakpoint                 | 9          |
------------------------------------------------------------------------------
-| 'vimspectorPC'         | Program counter (i.e. current line) | 200        |
------------------------------------------------------------------------------
-| 'vimspectorPCBP'       | Program counter and breakpoint      | 200        |
------------------------------------------------------------------------------
+====================================================================================
+|           _Sign_          |              _Description_              | _Priority_ |
+====================================================================================
+| 'vimspectorBP'            | Line breakpoint                         | 9          |
+------------------------------------------------------------------------------------
+| 'vimspectorBPCond'        | Conditional line breakpoint             | 9          |
+------------------------------------------------------------------------------------
+| 'vimspectorBPLog'         | Logpoint                                | 9          |
+------------------------------------------------------------------------------------
+| 'vimspectorBPDisabled'    | Disabled breakpoint                     | 9          |
+------------------------------------------------------------------------------------
+| 'vimspectorPC'            | Program counter (i.e. current line)     | 200        |
+------------------------------------------------------------------------------------
+| 'vimspectorPCBP'          | Program counter and breakpoint          | 200        |
+------------------------------------------------------------------------------------
+| 'vimspectorCurrentThread' | Focussed thread in stack trace view     | 200        |
+------------------------------------------------------------------------------------
+| 'vimspectorCurrentFrame'  | Current stack frame in stack trace view | 200        |
+------------------------------------------------------------------------------------
 
 
 The default symbols are the equivalent of something like the following:
 >
-  sign define vimspectorBP         text=\ ● texthl=WarningMsg
-  sign define vimspectorBPCond     text=\ ◆ texthl=WarningMsg
-  sign define vimspectorBPDisabled text=\ ● texthl=LineNr
-  sign define vimspectorPC         text=\ ▶ texthl=MatchParen linehl=CursorLine
-  sign define vimspectorPCBP       text=●▶  texthl=MatchParen linehl=CursorLine
+  sign define vimspectorBP            text=\ ● texthl=WarningMsg
+  sign define vimspectorBPCond        text=\ ◆ texthl=WarningMsg
+  sign define vimspectorBPLog         text=\ ◆ texthl=SpellRare
+  sign define vimspectorBPDisabled    text=\ ● texthl=LineNr
+  sign define vimspectorPC            text=\ ▶ texthl=MatchParen linehl=CursorLine
+  sign define vimspectorPCBP          text=●▶  texthl=MatchParen linehl=CursorLine
+  sign define vimspectorCurrentThread text=▶   texthl=MatchParen linehl=CursorLine
+  sign define vimspectorCurrentFrame  text=▶   texthl=Special    linehl=CursorLine
 <
 If the signs don't display properly, your font probably doesn't contain these
 glyphs. You can easily change them by defining the sign in your vimrc. For
 example, you could put this in your 'vimrc' to use some simple ASCII symbols:
 >
-  sign define vimspectorBP text=o          texthl=WarningMsg
-  sign define vimspectorBPCond text=o?     texthl=WarningMsg
-  sign define vimspectorBPDisabled text=o! texthl=LineNr
-  sign define vimspectorPC text=\ >        texthl=MatchParen
-  sign define vimspectorPCBP text=o>       texthl=MatchParen
+  sign define vimspectorBP text=o             texthl=WarningMsg
+  sign define vimspectorBPCond text=o?        texthl=WarningMsg
+  sign define vimspectorBPLog text=!!         texthl=SpellRare
+  sign define vimspectorBPDisabled text=o!    texthl=LineNr
+  sign define vimspectorPC text=\ >           texthl=MatchParen
+  sign define vimspectorPCBP text=o>          texthl=MatchParen
+  sign define vimspectorCurrentThread text=>  texthl=MatchParen
+  sign define vimspectorCurrentFrame text=>   texthl=Special
 <
 -------------------------------------------------------------------------------
                                                      *vimspector-sign-priority*
@@ -2068,6 +2140,7 @@ For example:
   let g:vimspector_sign_priority = {
     \    'vimspectorBP':         3,
     \    'vimspectorBPCond':     2,
+    \    'vimspectorBPLog':      2,
     \    'vimspectorBPDisabled': 1,
     \    'vimspectorPC':         999,
     \ }
@@ -2302,7 +2375,7 @@ FAQ ~
    require very-specific unique handling.
 
 3. How do I stop it starting a new Terminal.app on macOS? See this comment
-   [49]
+   [48]
 
 4. Can I specify answers to the annoying questions about exception
    breakpoints in my '.vimspector.json' ? Yes, see here [23].
@@ -2336,6 +2409,12 @@ FAQ ~
    clients. Vimspector simply displays this information in the output
    window. It _does not_ and _will not ever_ collect, use, forward or
    otherwise share any data with any third parties.
+
+4. Do I _have_ to put a '.vimspector.json' in the root of every project? No,
+   you can put all of your adapter and debug configs in a single directory
+   [49] if you want to, but note the caveat that '${workspaceRoot}' won't be
+   calculated correctly in that case. The vimsepctor author uses this a lot
+   [50].
 
 ===============================================================================
                                                         *vimspector-references*
@@ -2377,18 +2456,19 @@ References ~
 [34] https://github.com/microsoft/debugpy#debugpy-cli-usage
 [35] https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings
 [36] https://github.com/microsoft/debugpy/wiki/Debugging-over-SSH
-[37] https://github.com/Microsoft/vscode-python
-[38] https://github.com/puremourning/vimspector/issues/105
-[39] https://github.com/puremourning/TclProDebug
-[40] https://github.com/go-delve/delve/tree/master/Documentation/installation
-[41] https://github.com/golang/vscode-go/blob/master/docs/debugging.md#troubleshooting
-[42] https://github.com/Microsoft/java-debug
-[43] https://github.com/ycm-core/YouCompleteMe#java-semantic-completion
-[44] https://github.com/ycm-core/YouCompleteMe#troubleshooting
-[45] https://code.visualstudio.com/docs/java/java-debugging
-[46] https://github.com/puremourning/vimspector/issues/3
-[47] https://github.com/tomblind/local-lua-debugger-vscode
-[48] https://github.com/puremourning/vimspector/issues/3#issuecomment-576916076
-[49] https://github.com/puremourning/vimspector/issues/90#issuecomment-577857322
+[37] https://github.com/puremourning/TclProDebug
+[38] https://github.com/go-delve/delve/tree/master/Documentation/installation
+[39] https://github.com/golang/vscode-go/blob/master/docs/debugging-legacy.md
+[40] https://github.com/golang/vscode-go/blob/master/docs/debugging-legacy.md#troubleshooting
+[41] https://github.com/Microsoft/java-debug
+[42] https://github.com/ycm-core/YouCompleteMe#java-semantic-completion
+[43] https://github.com/ycm-core/YouCompleteMe#troubleshooting
+[44] https://code.visualstudio.com/docs/java/java-debugging
+[45] https://github.com/puremourning/vimspector/issues/3
+[46] https://github.com/tomblind/local-lua-debugger-vscode
+[47] https://github.com/puremourning/vimspector/issues/3#issuecomment-576916076
+[48] https://github.com/puremourning/vimspector/issues/90#issuecomment-577857322
+[49] https://puremourning.github.io/vimspector/configuration.html#debug-configurations
+[50] https://github.com/puremourning/.vim-mac/tree/master/vimspector-conf
 
 vim: ft=help

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -133,6 +133,13 @@ command! -bar -nargs=0
       \ VimspectorAbortInstall
       \ call vimspector#AbortInstall()
 
+" Session files
+command! -bar -nargs=? -complete=file
+      \ VimspectorLoadSession
+      \ call vimspector#ReadSessionFile( <f-args> )
+command! -bar -nargs=? -complete=file
+      \ VimspectorMkSession
+      \ call vimspector#WriteSessionFile( <f-args> )
 
 
 " Dummy autocommands so that we can call this whenever

--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -474,9 +474,32 @@ class ProjectBreakpoints( object ):
         self._exception_breakpoints[ 'exceptionOptions' ] = []
 
 
-  def Refresh( self, file_name ):
-    # TODO: Just this file ?
+  def Refresh( self ):
     self._ShowBreakpoints()
+
+
+  def Save( self ):
+    # Need to copy line breakpoitns, because we have to remove the 'sign_id'
+    # property. Otherwsie we might end up loading junk sign_ids
+    line = {}
+    for file_name, breakpoints in self._line_breakpoints.items():
+      bps = [ dict( bp ) for bp in breakpoints ]
+      for bp in bps:
+        bp.pop( 'sign_id', None )
+      line[ file_name ] = bps
+
+    return {
+      'line': line,
+      'function': self._func_breakpoints,
+      'exception': self._exception_breakpoints
+    }
+
+
+  def Load( self, save_data ):
+    self.ClearBreakpoints()
+    self._line_breakpoints = save_data.get( 'line', {} )
+    self._func_breakpoints = save_data.get( 'function' , [] )
+    self._exception_breakpoints = save_data.get( 'exception', None )
 
 
   def _ShowBreakpoints( self ):

--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -147,8 +147,9 @@ class ProjectBreakpoints( object ):
 
     self.UpdateUI()
 
+
   def _FindLineBreakpoint( self, file_name, line ):
-    file_name = os.path.abspath( file_name )
+    file_name = _NormaliseFileName( file_name )
     for index, bp in enumerate( self._line_breakpoints[ file_name ] ):
       self._SignToLine( file_name, bp )
       if bp[ 'line' ] == line:
@@ -158,7 +159,7 @@ class ProjectBreakpoints( object ):
 
 
   def _PutLineBreakpoint( self, file_name, line, options ):
-    self._line_breakpoints[ os.path.abspath( file_name ) ].append( {
+    self._line_breakpoints[ _NormaliseFileName( file_name ) ].append( {
       'state': 'ENABLED',
       'line': line,
       'options': options,
@@ -174,7 +175,7 @@ class ProjectBreakpoints( object ):
   def _DeleteLineBreakpoint( self, bp, file_name, index ):
     if 'sign_id' in bp:
       signs.UnplaceSign( bp[ 'sign_id' ], 'VimspectorBP' )
-    del self._line_breakpoints[ os.path.abspath( file_name ) ][ index ]
+    del self._line_breakpoints[ _NormaliseFileName( file_name ) ][ index ]
 
 
   def ToggleBreakpoint( self, options ):
@@ -545,3 +546,8 @@ class ProjectBreakpoints( object ):
       bp[ 'line' ] = int( signs[ 0 ][ 'signs' ][ 0 ][ 'lnum' ] )
 
     return bp[ 'line' ]
+
+
+def _NormaliseFileName( file_name ):
+  absoluate_path = os.path.abspath( file_name )
+  return absoluate_path if os.path.isfile( absoluate_path ) else file_name

--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -501,6 +501,8 @@ class ProjectBreakpoints( object ):
     self._func_breakpoints = save_data.get( 'function' , [] )
     self._exception_breakpoints = save_data.get( 'exception', None )
 
+    self.UpdateUI()
+
 
   def _ShowBreakpoints( self ):
     for file_name, line_breakpoints in self._line_breakpoints.items():

--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -224,7 +224,7 @@ class CodeView( object ):
         return
 
 
-  def Refresh( self, file_name ):
+  def Refresh( self ):
     # TODO: jsut the file ?
     self.ShowBreakpoints()
 

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -460,7 +460,9 @@ class DebugSession( object ):
       return True
     except OSError:
       self._logger.exception( f"Invalid session file { session_file }" )
-      utils.UserMessage( "Session file not found", persist=True, error=True )
+      utils.UserMessage( f"Session file { session_file } not found",
+                         persist=True,
+                         error=True )
       return False
     except json.JSONDecodeError:
       self._logger.exception( f"Invalid session file { session_file }" )

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -60,6 +60,7 @@ class DebugSession( object ):
     self._logView = None
     self._stackTraceView = None
     self._variablesView = None
+    self._saved_variables_data = None
     self._outputView = None
     self._breakpoints = breakpoints.ProjectBreakpoints()
     self._splash_screen = None
@@ -306,6 +307,13 @@ class DebugSession( object ):
 
       self._stackTraceView.ConnectionUp( self._connection )
       self._variablesView.ConnectionUp( self._connection )
+
+      if self._saved_variables_data:
+        self._variablesView.Load( self._saved_variables_data )
+        # TODO: clear it ?
+        # TODO: store this stuff in module scope in variables.py ?
+        # TODO: hmmm...
+
       self._outputView.ConnectionUp( self._connection )
       self._breakpoints.ConnectionUp( self._connection )
 
@@ -429,6 +437,57 @@ class DebugSession( object ):
 
     # make sure that we're displaying signs in any still-open buffers
     self._breakpoints.UpdateUI()
+
+  def ReadSessionFile( self, session_file ):
+    try:
+      with open( session_file, 'r' ) as f:
+        session_data = json.load( f )
+
+      USER_CHOICES.update(
+        session_data.get( 'session', {} ).get( 'user_choices', {} ) )
+
+      self._breakpoints.Load( session_data.get( 'breakpoints' ) )
+
+      # We might not _have_ a self._variablesView yet so we need a
+      # mechanism where we save this for later and reload when it's ready
+      variables_data = session_data.get( 'variables', {} )
+      if self._variablesView:
+        self._variablesView.Load( variables_data )
+      else:
+        self._saved_variables_data = variables_data
+
+      self.RefreshSigns()
+      return True
+    except OSError:
+      self._logger.exception( f"Invalid session file { session_file }" )
+      utils.UserMessage( "Session file not found", persist=True, error=True )
+      return False
+    except json.JSONDecodeError:
+      self._logger.exception( f"Invalid session file { session_file }" )
+      utils.UserMessage( "The session file could not be read",
+                         persist = True,
+                         error = True )
+      return False
+
+
+  def WriteSessionFile( self, session_file ):
+    try:
+      with open( session_file, 'w' ) as f:
+        f.write( json.dumps( {
+          'breakpoints': self._breakpoints.Save(),
+          'session': {
+            'user_choices': USER_CHOICES,
+          },
+          'variables': self._variablesView.Save() if self._variablesView else {}
+        } ) )
+
+      return True
+    except OSError:
+      self._logger.exception( f"Unable to write session file { session_file }" )
+      utils.UserMessage( "The session file could not be read",
+                         persist = True,
+                         error = True )
+      return False
 
   @IfConnected()
   def StepOver( self ):
@@ -658,11 +717,11 @@ class DebugSession( object ):
 
     return items
 
-  def RefreshSigns( self, file_name ):
+  def RefreshSigns( self ):
     if self._connection:
-      self._codeView.Refresh( file_name )
+      self._codeView.Refresh()
     else:
-      self._breakpoints.Refresh( file_name )
+      self._breakpoints.Refresh()
 
 
   def _SetUpUI( self ):

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -927,10 +927,11 @@ class DebugSession( object ):
 
     # the codeView.SetCurrentFrame already checked the frame was valid and
     # countained a valid source
+    assert frame
     self._variablesView.SetSyntax( self._codeView.current_syntax )
     self._stackTraceView.SetSyntax( self._codeView.current_syntax )
     self._variablesView.LoadScopes( frame )
-    self._variablesView.EvaluateWatches()
+    self._variablesView.EvaluateWatches( frame )
 
     if reason == 'stopped':
       self._breakpoints.ClearTemporaryBreakpoint( frame[ 'source' ][ 'path' ],

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -455,8 +455,6 @@ class DebugSession( object ):
         self._variablesView.Load( variables_data )
       else:
         self._saved_variables_data = variables_data
-
-      self.RefreshSigns()
       return True
     except OSError:
       self._logger.exception( f"Invalid session file { session_file }" )

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -35,6 +35,9 @@ DEFAULTS = {
   'terminal_maxheight': 15,
   'terminal_minheight': 5,
 
+  # Session files
+  'session_file_name': '.vimspector.session',
+
   # Signs
   'sign_priority': {
     'vimspectorPC':            200,

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -293,6 +293,10 @@ def TemporaryVimOption( opt, value ):
     vim.options[ opt ] = old_value
 
 
+def DirectoryOfCurrentFile():
+  return os.path.dirname( os.path.abspath( vim.current.buffer.name ) )
+
+
 def PathToConfigFile( file_name, from_directory = None ):
   if not from_directory:
     p = os.getcwd()

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -268,6 +268,17 @@ class VariablesView( object ):
     utils.CleanUpHiddenBuffer( self._watch.buf )
     self.ClearTooltip()
 
+  def Save( self ):
+    return {
+      'watches': [
+        watch.expression[ 'expression' ] for watch in self._watches
+      ]
+    }
+
+  def Load( self, save_data ):
+    for expression in save_data.get( 'watches', [] ):
+      # It's not really possible to save the frameId, so we just supply None
+      self._watches.append( Watch.New( None, expression, 'watch' ) )
 
   def LoadScopes( self, frame ):
     def scopes_consumer( message ):

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -114,12 +114,33 @@ class Variable( Expandable ):
 
 class Watch:
   """Holds a user watch expression (DAP request) and the result (WatchResult)"""
-  def __init__( self, expression: dict ):
+  def __init__( self, expression: dict, tied_to_frame: bool ):
     self.result: WatchResult
     self.line = None
 
     self.expression = expression
+    self.tied_to_frame = tied_to_frame
     self.result = None
+
+  def SetCurrentFrame( self, frame ):
+    # OK this is a bit hacky. In Vimspector we have elected to associatet a
+    # frameId with a watch so that expressions that might match different things
+    # in different (current) stack frames always resolve unambiguously to the
+    # frame the user added the watch in. For exam,ple consider a stack like:
+    #
+    # TOP      int i = 0;
+    # MIDDLE   int i = 100;
+    # BOTTOM   int i = -1;
+    #
+    # When adding a watch for 'i' in MIDDLE, we should see '100', even if the
+    # 'current frame' is BOTTOM.
+    #
+    # However, if we _saved_ the watch to the file, we _don't know_ what the
+    # frameid should be!. Se, we just bung the current frame on it and it
+    # shimmers between frames as we step/move.
+
+    if not self.tied_to_frame:
+      self.expression[ 'frameId' ] = frame[ 'id' ]
 
   @staticmethod
   def New( frame, expression, context ):
@@ -130,7 +151,7 @@ class Watch:
     if frame:
       watch[ 'frameId' ] = frame[ 'id' ]
 
-    return Watch( watch )
+    return Watch( watch, bool( frame ) )
 
 
 class View:
@@ -421,7 +442,7 @@ class VariablesView( object ):
 
   def AddWatch( self, frame, expression ):
     self._watches.append( Watch.New( frame, expression, 'watch' ) )
-    self.EvaluateWatches()
+    self.EvaluateWatches( frame )
 
   def DeleteWatch( self ):
     if vim.current.buffer != self._watch.buf:
@@ -445,8 +466,9 @@ class VariablesView( object ):
 
     utils.UserMessage( 'No watch found' )
 
-  def EvaluateWatches( self ):
+  def EvaluateWatches( self, current_frame: dict ):
     for watch in self._watches:
+      watch.SetCurrentFrame( current_frame )
       self._connection.DoRequest(
         partial( self._UpdateWatchExpression, watch ),
         {

--- a/tests/session.test.vim
+++ b/tests/session.test.vim
@@ -1,0 +1,240 @@
+function! SetUp()
+  call vimspector#test#setup#SetUpWithMappings( 'HUMAN' )
+endfunction
+
+function! ClearDown()
+  call vimspector#test#setup#ClearDown()
+endfunction
+
+function! Test_Save_Session_Specify_Path_Not_Running_Breakpoints()
+  let moo = 'moo.py'
+  let cow = 'cow.py'
+  lcd ../support/test/python/multiple_files
+
+  call vimspector#SetLineBreakpoint( moo, 6 )
+  call vimspector#SetLineBreakpoint( moo, 9, { 'logMessage': 'test' } )
+  call vimspector#SetLineBreakpoint( cow, 15, { 'condition': '1==2' } )
+
+  execute 'edit' moo
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorBP',
+          \ 6,
+          \ 'vimspectorBP',
+          \ 9 ) } )
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorBP',
+          \ 9,
+          \ 'vimspectorBPLog',
+          \ 9 ) } )
+
+  execute 'edit' cow
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorBP',
+          \ 15,
+          \ 'vimspectorBPCond',
+          \ 9 ) } )
+
+  let save_file = tempname()
+  execute 'VimspectorMkSession' save_file
+  call assert_true( filereadable( save_file ) )
+  " check it looks valid ?
+  call json_decode( join( readfile( save_file ), '\n' ) )
+  call vimspector#ClearBreakpoints()
+
+  execute 'edit' moo
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupEmptyAtLine(
+          \ 'VimspectorBP',
+          \ 6 ) } )
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupEmptyAtLine(
+          \ 'VimspectorBP',
+          \ 9 ) } )
+
+  execute 'edit' cow
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupEmptyAtLine(
+          \ 'VimspectorBP',
+          \ 15 ) } )
+
+  execute 'VimspectorLoadSession' save_file
+
+  execute 'edit' moo
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorBP',
+          \ 6,
+          \ 'vimspectorBP',
+          \ 9 ) } )
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorBP',
+          \ 9,
+          \ 'vimspectorBPLog',
+          \ 9 ) } )
+
+  execute 'edit' cow
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorBP',
+          \ 15,
+          \ 'vimspectorBPCond',
+          \ 9 ) } )
+
+  call vimspector#test#setup#Reset()
+  lcd -
+  silent! call delete( save_file )
+  %bwipeout!
+endfunction
+
+function! Test_Save_Session_Specify_Path_While_Running_Breakpoints()
+  let moo = 'moo.py'
+  let cow = 'cow.py'
+  lcd ../support/test/python/multiple_files
+
+  call vimspector#SetLineBreakpoint( moo, 6 )
+  call vimspector#SetLineBreakpoint( moo, 9, { 'logMessage': 'test' } )
+  call vimspector#SetLineBreakpoint( cow, 15, { 'condition': '1==2' } )
+
+  execute 'edit' moo
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorBP',
+          \ 6,
+          \ 'vimspectorBP',
+          \ 9 ) } )
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorBP',
+          \ 9,
+          \ 'vimspectorBPLog',
+          \ 9 ) } )
+
+  execute 'edit' cow
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorBP',
+          \ 15,
+          \ 'vimspectorBPCond',
+          \ 9 ) } )
+
+  let save_file = tempname()
+  call vimspector#WriteSessionFile( save_file )
+  call vimspector#ClearBreakpoints()
+
+  call vimspector#Launch()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( moo, 1, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( moo, 1 )
+
+  call vimspector#ReadSessionFile( save_file )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( moo, 1, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( moo, 1 )
+
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorCode',
+          \ 6,
+          \ 'vimspectorBP',
+          \ 9 ) } )
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorCode',
+          \ 9,
+          \ 'vimspectorBP',
+          \ 9 ) } )
+
+  execute 'edit' cow
+  call WaitForAssert( {->
+        \vimspector#test#signs#AssertSignGroupSingletonAtLine(
+          \ 'VimspectorCode',
+          \ 15,
+          \ 'vimspectorBP',
+          \ 9 ) } )
+
+  call vimspector#Continue()
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( moo, 6, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( moo, 6 )
+
+  call vimspector#test#setup#Reset()
+  lcd -
+  silent! call delete( save_file )
+  %bwipeout!
+endfunction
+
+function! SetUp_Test_Save_Session_Specify_Path_While_Running_Watches()
+  let g:vimspector_session_file_name = tempname()
+endfunction
+
+function! TearDown_Test_Save_Session_Specify_Path_While_Running_Watches()
+  unlet g:vimspector_session_file_name
+endfunction
+
+function! Test_Save_Session_Specify_Path_While_Running_Watches()
+  let moo = 'moo.py'
+  let cow = 'cow.py'
+  lcd ../support/test/python/multiple_files
+  call vimspector#Launch()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( moo, 1, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( moo, 1 )
+
+  call cursor( [ 6, 1 ] )
+  call vimspector#RunToCursor()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( moo, 6, 1 )
+  call WaitForAssert( { ->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( moo, 6 )  } )
+
+  call vimspector#AddWatch( 'i' )
+  call WaitForAssert( {->
+        \   assert_equal(
+        \     [
+        \         'Watches: ----',
+        \         'Expression: i',
+        \         ' *- Result: 1',
+        \     ],
+        \     getbufline( winbufnr( g:vimspector_session_windows.watches ),
+        \                 1,
+        \                 '$' )
+        \   )
+        \ } )
+
+  VimspectorMkSession
+  call vimspector#test#setup#Reset()
+
+  VimspectorLoadSession
+  call vimspector#Launch()
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( moo, 1, 1 )
+  call vimspector#test#signs#AssertPCIsAtLineInBuffer( moo, 1 )
+  call cursor( [ 6, 1 ] )
+  call vimspector#RunToCursor()
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( moo, 6, 1 )
+  call WaitForAssert( { ->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( moo, 6 ) } )
+
+  " FIXME: Fails here, i think because we add the watch with the 'wrong'
+  " frame ID, so this just gets NameError" name 'i' is not defined.
+  call WaitForAssert( {->
+        \   assert_equal(
+        \     [
+        \         'Watches: ----',
+        \         'Expression: i',
+        \         ' *- Result: 1',
+        \     ],
+        \     getbufline( winbufnr( g:vimspector_session_windows.watches ),
+        \                 1,
+        \                 '$' )
+        \   )
+        \ } )
+
+
+  silent! call delete( g:vimspector_session_file_name )
+  call vimspector#test#setup#Reset()
+  lcd -
+  %bwipeout!
+endfunction

--- a/tests/session.test.vim
+++ b/tests/session.test.vim
@@ -6,10 +6,10 @@ function! ClearDown()
   call vimspector#test#setup#ClearDown()
 endfunction
 
-function! Test_Save_Session_Specify_Path_Not_Running_Breakpoints()
-  let moo = 'moo.py'
-  let cow = 'cow.py'
+function! Test_Save_Session_Specify_Path_Not_Running_LineBreakpoints()
   lcd ../support/test/python/multiple_files
+  let moo = getcwd() . '/moo.py'
+  let cow = getcwd() . '/cow.py'
 
   call vimspector#SetLineBreakpoint( moo, 6 )
   call vimspector#SetLineBreakpoint( moo, 9, { 'logMessage': 'test' } )
@@ -60,6 +60,10 @@ function! Test_Save_Session_Specify_Path_Not_Running_Breakpoints()
           \ 'VimspectorBP',
           \ 15 ) } )
 
+  " change directory then load, ensure that we find the right file for the
+  " breakpoint
+  lcd ../
+  %bwipeout!
   execute 'VimspectorLoadSession' save_file
 
   execute 'edit' moo
@@ -88,6 +92,14 @@ function! Test_Save_Session_Specify_Path_Not_Running_Breakpoints()
   lcd -
   silent! call delete( save_file )
   %bwipeout!
+endfunction
+
+function! Test_Save_Session_Funtion_Breakpoints()
+  " TODO
+endfunction
+
+function! Test_Save_Session_Exception_Breakpoints()
+  " TODO
 endfunction
 
 function! Test_Save_Session_Specify_Path_While_Running_Breakpoints()
@@ -166,15 +178,15 @@ function! Test_Save_Session_Specify_Path_While_Running_Breakpoints()
   %bwipeout!
 endfunction
 
-function! SetUp_Test_Save_Session_Specify_Path_While_Running_Watches()
+function! SetUp_Test_Save_Session_NoSpecify_Path_While_Running_Watches()
   let g:vimspector_session_file_name = tempname()
 endfunction
 
-function! TearDown_Test_Save_Session_Specify_Path_While_Running_Watches()
+function! TearDown_Test_Save_NoSession_Specify_Path_While_Running_Watches()
   unlet g:vimspector_session_file_name
 endfunction
 
-function! Test_Save_Session_Specify_Path_While_Running_Watches()
+function! Test_Save_Session_NoSpecify_Path_While_Running_Watches()
   let moo = 'moo.py'
   let cow = 'cow.py'
   lcd ../support/test/python/multiple_files
@@ -235,4 +247,8 @@ function! Test_Save_Session_Specify_Path_While_Running_Watches()
   call vimspector#test#setup#Reset()
   lcd -
   %bwipeout!
+endfunction
+
+function! Test_Save_User_Choices()
+  " TODO
 endfunction

--- a/tests/session.test.vim
+++ b/tests/session.test.vim
@@ -217,8 +217,6 @@ function! Test_Save_Session_Specify_Path_While_Running_Watches()
   call WaitForAssert( { ->
         \ vimspector#test#signs#AssertPCIsAtLineInBuffer( moo, 6 ) } )
 
-  " FIXME: Fails here, i think because we add the watch with the 'wrong'
-  " frame ID, so this just gets NameError" name 'i' is not defined.
   call WaitForAssert( {->
         \   assert_equal(
         \     [

--- a/update-vim-docs
+++ b/update-vim-docs
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "$1" ] || [ ! -d "$1" ]; then
+  echo "Usage: $(basename $0) <path to vim-tools>"
+  exit 1
+fi
+
+pushd $(dirname $0)
+  python3 $1/html2vimdoc.py -f vimspector README.md > doc/vimspector.txt
+  python3 $1/html2vimdoc.py -f vimspector-ref \
+                               docs/configuration.md > doc/vimspector-ref.txt
+popd


### PR DESCRIPTION
Manual load/store of:
 - breakpoins
 - saved "entered data" in the debug session
 - watches

We wanted to automate this store/load but it's just really hard to know
when to do it. So we make it a manual operation for save/load specifying
a file name. We can still add something automatic if we can work out the
best way to do that.

Also add VimspectorMkSession and VimspectorLoadSession commands
    
By default, we use .vimspector.session. Commands complete file name  which is only optional argument.

Closes #453 

