### PR TITLE
fixing unescaped double quotes

### DIFF
--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -572,7 +572,7 @@ function! vimspector#ShowEvalBalloon( is_visual ) abort
 
   return py3eval( '_vimspector_session.ShowEvalBalloon('
                 \ . ' int( vim.eval( "winnr()" ) ), "'
-                \ . expr
+                \ . substitute(expr, '"', '\\"', 'g')
                 \ . '", 0 )' )
 endfunction
 

--- a/tests/testdata/cpp/simple/simple.cpp
+++ b/tests/testdata/cpp/simple/simple.cpp
@@ -14,7 +14,5 @@ int main( int argc, char ** )
 {
   printf( "this is a test %d\n", argc );
   foo( argc );
-  char c = 'a';
-  char arr[4] = "abc";
   return 0;
 }

--- a/tests/testdata/cpp/simple/simple.cpp
+++ b/tests/testdata/cpp/simple/simple.cpp
@@ -14,5 +14,7 @@ int main( int argc, char ** )
 {
   printf( "this is a test %d\n", argc );
   foo( argc );
+  char c = 'a';
+  char arr[4] = "abc";
   return 0;
 }

--- a/tests/testdata/cpp/simple/variables.cpp
+++ b/tests/testdata/cpp/simple/variables.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 
 int main() {
     std::cout << "Hello world!" << std::endl;
@@ -7,5 +8,8 @@ int main() {
     int& b = a;
     ++a;
     std::cout << "a: " << a << " b: " << b << std::endl;
+    char c = 'a';
+    std::string str = "abc";
+    std::cout << "str: " << str << " c: " << c << std::endl;
     return 0;
 }

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -755,12 +755,12 @@ function! Test_VariableEval()
 endfunction
 
 function! Test_VariableEvalStrings()
-  let fn =  'testdata/cpp/simple/simple.cpp'
-  call s:StartDebugging( #{ fn: fn, line: 17, col: 1, launch: #{
+  let fn =  'testdata/cpp/simple/variables.cpp'
+  call s:StartDebugging( #{ fn: fn, line: 11, col: 1, launch: #{
         \   configuration: 'run-to-breakpoint'
         \ } } )
 
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 17, 1 )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 11, 1 )
 
   " leader is ,
   xmap <buffer> <Leader>d <Plug>VimspectorBalloonEval
@@ -792,7 +792,7 @@ function! Test_VariableEvalStrings()
 
 
   call vimspector#StepOver()
-  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 18, 1 )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 12, 1 )
 
   " select string \"abc\"
   call feedkeys( 'f"vf",d', 'xt' )


### PR DESCRIPTION
Problem arises from unescaped `"` during evaluation e.g. `"some text"` in c++.
I kind of knew about this, but forgot to fix. Sorry... 
Anyway, here is the fix and the test, too.
Fixes #460 