### PR TITLE
Adhoc Launc Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,6 +800,30 @@ See [our YouCompleteMe integration guide](#usage-with-youcompleteme) for
 another example where it can be used to specify the port to connect the [java
 debugger](#java---partially-supported)
 
+To launch with an ad-hoc config you can use:
+
+* `call vimspector#LaunchWithConfigurations( dict )`
+
+The argument is a `dict` wich is the `configurations` section of a .vimspector file
+Pass one configuration in and that will be selected as the one to run.
+For example:
+
+```viml
+   let pid = <some_exression>
+   call vimspector#LaunchWithConfigurations({
+               \  "attach": {
+               \    "adapter": "netcoredbg",
+               \    "configuration": {
+               \      "request": "attach",
+               \      "processId": proc_id
+               \    }
+               \  }
+               \})
+```
+
+This would launch the debugger and attach to the specified process without the need
+to have a local .vimspector file on disk.
+
 ### Debug configuration selection
 
 Vimspector uses the following logic to choose a configuration to launch:

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -51,6 +51,13 @@ function! vimspector#Launch( ... ) abort
   py3 _vimspector_session.Start( *vim.eval( 'a:000' ) )
 endfunction
 
+function! vimspector#LaunchWithConfigurations( configurations ) abort
+  if !s:Enabled()
+    return
+  endif
+  py3 _vimspector_session.Start( configs = vim.eval( 'a:configurations' ) )
+endfunction
+
 function! vimspector#LaunchWithSettings( settings ) abort
   if !s:Enabled()
     return

--- a/doc/vimspector.txt
+++ b/doc/vimspector.txt
@@ -998,6 +998,27 @@ things.
 See our YouCompleteMe integration guide for another example where it can be
 used to specify the port to connect the java debugger
 
+To launch with an ad-hoc config you can use:
+
+- 'call vimspector#LaunchWithConfigurations( dict )'
+
+The argument is a `dict` wich is the `configurations` section of a .vimspector file
+Pass one configuration in and that will be selected as the one to run.
+For example:
+
+   vimspector#LaunchWithConfigurations({
+           \  "attach": {
+           \    "adapter": "netcoredbg",
+           \    "configuration": {
+           \      "request": "attach",
+           \      "processId": proc_id
+           \    }
+           \  }
+           \})
+
+This would launch the debugger and attach to the specified process without the need
+to have a local .vimspector file on disk.
+
 -------------------------------------------------------------------------------
                                      *vimspector-debug-configuration-selection*
 Debug configuration selection ~

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -101,7 +101,7 @@ class DebugSession( object ):
 
     return launch_config_file, configurations
 
-  def Start( self, force_choose=False, launch_variables = None ):
+  def Start( self, force_choose=False, launch_variables = None, configs = None ):
     # We mutate launch_variables, so don't mutate the default argument.
     # https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments
     if launch_variables is None:
@@ -115,7 +115,13 @@ class DebugSession( object ):
 
     current_file = utils.GetBufferFilepath( vim.current.buffer )
     adapters = {}
-    launch_config_file, configurations = self.GetConfigurations( adapters )
+
+    launch_config_file = None
+    configurations = None
+    if configs:
+      configurations = configs
+    else:
+      launch_config_file, configurations = self.GetConfigurations( adapters )
 
     if not configurations:
       utils.UserMessage( 'Unable to find any debug configurations. '

--- a/tests/language_csharp.test.vim
+++ b/tests/language_csharp.test.vim
@@ -10,6 +10,40 @@ function! SetUp_Test_Go_Simple()
   let g:vimspector_enable_mappings = 'HUMAN'
 endfunction
 
+function! Test_CSharp_Simple_Adhoc_Config()
+  let fn='Program.cs'
+  lcd ../support/test/csharp
+  exe 'edit ' . fn
+
+  call vimspector#SetLineBreakpoint( fn, 31 )
+  call vimspector#LaunchWithConfigurations( {
+    \ "launch - netcoredbg": {
+    \   "adapter": "netcoredbg",
+    \   "configuration": {
+    \     "request": "launch",
+    \     "program": "${workspaceRoot}/bin/Debug/netcoreapp3.1/csharp.dll",
+    \     "args": [],
+    \     "stopAtEntry": v:false
+    \   }
+    \ }
+  \ } )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 31, 7 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 31 )
+        \ } )
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 32, 12 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 32 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction
+
 function! Test_CSharp_Simple()
   let fn='Program.cs'
   lcd ../support/test/csharp

--- a/tests/language_go.test.vim
+++ b/tests/language_go.test.vim
@@ -46,6 +46,55 @@ function! Test_Go_Simple()
   %bwipeout!
 endfunction
 
+function! Test_Go_Simple_Adhoc_Config()
+  let fn='hello-world.go'
+  lcd ../support/test/go/hello_world
+  exe 'edit ' . fn
+  call setpos( '.', [ 0, 4, 1 ] )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 4, 1 )
+  call vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorBP', 4 )
+
+  " Add the breakpoint
+  call feedkeys( "\<F9>", 'xt' )
+  call vimspector#test#signs#AssertSignGroupSingletonAtLine( 'VimspectorBP',
+                                                           \ 4,
+                                                           \ 'vimspectorBP',
+                                                           \ 9 )
+
+  call setpos( '.', [ 0, 1, 1 ] )
+
+  " Here we go. Start Debugging
+  call vimspector#LaunchWithConfigurations({
+  \  "run": {
+  \    "adapter": "vscode-go",
+  \    "default": v:true,
+  \    "configuration": {
+  \      "request": "launch",
+  \      "program": "${workspaceRoot}/hello-world.go",
+  \      "mode": "debug",
+  \      "dlvToolPath": "$HOME/go/bin/dlv",
+  \      "trace": v:true,
+  \      "env": { "GO111MODULE": "off" }
+  \    }
+  \  },
+  \ })
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 4, 1 )
+
+  " Step
+  call feedkeys( "\<F10>", 'xt' )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 5, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 5 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction
+
 
 function! Test_Run_To_Cursor()
   let fn='hello-world.go'

--- a/tests/language_lua.test.vim
+++ b/tests/language_lua.test.vim
@@ -35,6 +35,52 @@ function! BaseTest( configuration )
   %bwipeout!
 endfunction
 
+function! BaseTest_Adhoc_Config( configuration )
+  let fn='simple.lua'
+  lcd ../support/test/lua/simple
+  exe 'edit ' . fn
+
+  call vimspector#SetLineBreakpoint( fn, 5 )
+  call vimspector#LaunchWithConfigurations( {
+  \  "lua": {
+  \    "adapter": "lua-local",
+  \    "configuration": {
+  \      "request": "launch",
+  \      "type": "lua-local",
+  \      "cwd": "${workspaceFolder}",
+  \      "program": {
+  \        "lua": "lua",
+  \        "file": "simple.lua",
+  \        "stopOnEntry": false
+  \      }
+  \    }
+  \  },
+  \ } )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 5, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 5 )
+        \ } )
+
+  " Step
+  call feedkeys( "\<F10>", 'xt' )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 6, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 6 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction
+
+
+function! Test_Lua_Simple_Adhoc_Config()
+  call BaseTest_Adhoc_Config( 'lua' )
+endfunction
+
 
 function! Test_Lua_Simple()
   call BaseTest( 'lua' )

--- a/tests/language_python.test.vim
+++ b/tests/language_python.test.vim
@@ -46,6 +46,63 @@ function! Test_Python_Simple()
   %bwipeout!
 endfunction
 
+function! Test_Python_Simple_Adhoc_Config()
+  let fn='main.py'
+  lcd ../support/test/python/simple_python
+  exe 'edit ' . fn
+  call setpos( '.', [ 0, 6, 1 ] )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 6, 1 )
+  call vimspector#test#signs#AssertSignGroupEmptyAtLine( 'VimspectorBP', 6 )
+
+  " Add the breakpoint
+  call feedkeys( "\<F9>", 'xt' )
+  call vimspector#test#signs#AssertSignGroupSingletonAtLine( 'VimspectorBP',
+                                                           \ 6,
+                                                           \ 'vimspectorBP',
+                                                           \ 9 )
+
+  call setpos( '.', [ 0, 1, 1 ] )
+
+  " Here we go. Start Debugging
+  " call vimspector#LaunchWithSettings( { 'configuration': 'run' } )
+  call vimspector#LaunchWithConfigurations({
+  \  "run": {
+  \    "adapter": "debugpy",
+  \    "configuration": {
+  \      "request": "launch",
+  \      "type": "python",
+  \      "cwd": "${workspaceRoot}",
+  \      "program": "${file}",
+  \      "stopOnEntry": v:false,
+  \      "console": "integratedTerminal"
+  \    },
+  \    "breakpoints": {
+  \      "exception": {
+  \        "raised": "N",
+  \        "uncaught": "",
+  \        "userUnhandled": ""
+  \      }
+  \    }
+  \  }
+  \ })
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 6, 1 )
+
+  " Step
+  call feedkeys( "\<F10>", 'xt' )
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 7, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 7 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction
+
 function! SetUp_Test_Python_Remote_Attach()
   let g:vimspector_enable_mappings = 'HUMAN'
 endfunction


### PR DESCRIPTION
The thought here is to add the option to be able to launch with an ad-hoc config passed when you call the launch function.

The use case here is integrating debugging for unit tests in C# in the Omnisharp-Vim plugin.

I made a nominal effort to get the tests updated, but I was missing some go binaries and lua stuff, so hopefully those work in the CI runs. If not I will look at those.

Please let me know if you'd like me to do anything differently.