### PR TITLE
Reset when closing the tab

### DIFF
--- a/autoload/vimspector/internal/balloon.vim
+++ b/autoload/vimspector/internal/balloon.vim
@@ -198,7 +198,7 @@ function! vimspector#internal#balloon#Close() abort
     call nvim_win_close( s:nvim_border_win_id, v:true )
 
     call vimspector#internal#balloon#CloseCallback()
-  else
+  elseif !empty( popup_getoptions( s:popup_win_id ) )
     call popup_close(s:popup_win_id)
   endif
 endfunction

--- a/compiler/vimspector_test.vim
+++ b/compiler/vimspector_test.vim
@@ -155,7 +155,9 @@ if ! has( 'gui_running' )
   " å is the right-option+q
   nnoremap <buffer> å :cfirst<CR>
   " å is the right-option+a
-  nnoremap <buffer> œ :FuncLine<CR>
+  nnoremap <buffer> œ :cnext<CR>
+  " å is the right-option+f
+  nnoremap <buffer> ƒ :FuncLine<CR>
   " Ω is the right-option+z
   nnoremap <buffer> Ω :cprevious<CR>
 endif

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -152,9 +152,14 @@ augroup VimspectorUserAutoCmds
 augroup END
 
 " FIXME: Only register this _while_ debugging is active
+let g:vimspector_resetting = 0
 augroup Vimspector
   autocmd!
   autocmd BufNew * call vimspector#OnBufferCreated( expand( '<afile>' ) )
+  autocmd TabClosed *
+        \   if !g:vimspector_resetting
+        \ |   call vimspector#internal#state#TabClosed( expand( '<afile>' ) )
+        \ | endif
 augroup END
 
 " boilerplate {{{

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -117,6 +117,9 @@ def CleanUpCommand( name, api_prefix ):
 
 
 def CleanUpHiddenBuffer( buf ):
+  if not buf.valid:
+    return
+
   try:
     vim.command( 'bdelete! {}'.format( buf.number ) )
   except vim.error as e:

--- a/tests/tabpage.test.vim
+++ b/tests/tabpage.test.vim
@@ -6,6 +6,16 @@ function! ClearDown()
   call vimspector#test#setup#ClearDown()
 endfunction
 
+let s:fn='../support/test/python/simple_python/main.py'
+
+function! s:StartDebugging()
+  exe 'edit ' . s:fn
+  call vimspector#SetLineBreakpoint( s:fn, 23 )
+  call vimspector#LaunchWithSettings( { 'configuration': 'run' } )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 23, 1 )
+endfunction
+
+
 function! Test_Step_With_Different_Tabpage()
   lcd testdata/cpp/simple
   edit simple.cpp
@@ -152,5 +162,35 @@ function! Test_All_Buffers_Deleted_Installer()
   call vimspector#test#setup#Reset()
   set hidden&
   au! Test_All_Buffers_Deleted_Installer
+  %bwipe!
+endfunction
+
+function! Test_Close_Tab_No_Vimspector()
+  tabnew
+  q
+  %bwipe!
+endfunction
+
+function! Test_Close_Tab_With_Vimspector()
+  call s:StartDebugging()
+  call vimspector#test#setup#WaitForReset()
+  call s:StartDebugging()
+  tabclose!
+  %bwipe!
+endfunction
+
+function! Test_Close_Tab_With_Vimspector()
+  call s:StartDebugging()
+  tabedit newfile
+  tabclose
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 25, 1 )
+
+  tabclose!
+  call vimspector#test#setup#WaitForReset()
+
+  call s:StartDebugging()
+  call vimspector#test#setup#Reset()
   %bwipe!
 endfunction


### PR DESCRIPTION
You can now kill vimspector sesssion by closing the vimspector session
tab, rather than this causing an ugly backtrace

Fixes #454