### PR TITLE
Filter configurations by filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,7 +842,8 @@ See [the reference guide][vimspector-ref-config-selection] for details.
 
 ### Get configurations
 
-* Use `vimspector#GetConfigurations()` to get a list of configurations
+* Use `vimspector#GetConfigurations()` to get a list of configurations for
+  filetype of the current buffer
 
 For example, to get an array of configurations and fuzzy matching on the result
 ```viml
@@ -1208,6 +1209,7 @@ For `lldb-vscode` replace the name of the adapter with `lldb-vscode`:
   "configurations": {
     "Launch": {
       "adapter": "vscode-cpptools",
+      "filetypes": [ "cpp", "c", "objc", "rust" ], // optional
       "configuration": {
         "request": "launch",
         "program": "<path to binary>",
@@ -1220,6 +1222,7 @@ For `lldb-vscode` replace the name of the adapter with `lldb-vscode`:
     },
     "Attach": {
       "adapter": "vscode-cpptools",
+      "filetypes": [ "cpp", "c", "objc", "rust" ], // optional
       "configuration": {
         "request": "attach",
         "program": "<path to binary>",
@@ -1242,6 +1245,7 @@ licensing.
   "configurations": {
     "Launch": {
       "adapter": "vscode-cpptools",
+      "filetypes": [ "cpp", "c", "objc", "rust" ], // optional
       "configuration": {
         "request": "launch",
         "program": "<path to binary>",
@@ -1254,7 +1258,8 @@ licensing.
 
 ### Data visualization / pretty printing
 
-Depending on the backend you need to enable pretty printing of complex types manually.
+Depending on the backend you need to enable pretty printing of complex types
+manually.
 
 * LLDB: Pretty printing is enabled by default
 
@@ -1266,6 +1271,7 @@ Depending on the backend you need to enable pretty printing of complex types man
   "configurations": {
     "Launch": {
       "adapter": "vscode-cpptools",
+      "filetypes": [ "cpp", "c", "objc", "rust" ], // optional
       "configuration": {
         "request": "launch",
         "program": "<path to binary>",
@@ -1348,6 +1354,7 @@ Rust is supported with any gdb/lldb-based debugger. So it works fine with
   "configurations": {
     "launch": {
       "adapter": "CodeLLDB",
+      "filetypes": [ "rust" ],
       "configuration": {
         "request": "launch",
         "program": "${workspaceRoot}/target/debug/vimspector_test"
@@ -1374,6 +1381,7 @@ Rust is supported with any gdb/lldb-based debugger. So it works fine with
   "configurations": {
     "<name>: Launch": {
       "adapter": "debugpy",
+      "filetypes": [ "pythyon" ],
       "configuration": {
         "name": "<name>: Launch",
         "type": "python",
@@ -1411,6 +1419,7 @@ to:
   "configurations": {
     "Python Attach": {
       "adapter": "multi-session",
+      "filetypes": [ "python" ], // optional
       "configuration": {
         "request": "attach",
         "pathMappings": [
@@ -1453,6 +1462,7 @@ netcoredbg`
   "configurations": {
     "launch - netcoredbg": {
       "adapter": "netcoredbg",
+      "filetypes": [ "csharp", "fsharp", "vbnet" ], // optional
       "configuration": {
         "request": "launch",
         "program": "${workspaceRoot}/bin/Debug/netcoreapp2.2/csharp.dll",
@@ -1483,6 +1493,7 @@ NOTE: Vimspector uses the ["legacy" vscode-go debug adapter](https://github.com/
   "configurations": {
     "run": {
       "adapter": "vscode-go",
+      "filetypes": [ "go" ], // optional
       "configuration": {
         "request": "launch",
         "program": "${fileDirname}",
@@ -1532,6 +1543,7 @@ xdebug.remote_port=9000
   "configurations": {
     "Listen for XDebug": {
       "adapter": "vscode-php-debug",
+      "filetypes": [ "php" ], // optional
       "configuration": {
         "name": "Listen for XDebug",
         "type": "php",
@@ -1545,6 +1557,7 @@ xdebug.remote_port=9000
     },
     "Launch currently open script": {
       "adapter": "vscode-php-debug",
+      "filetypes": [ "php" ], // optional
       "configuration": {
         "name": "Launch currently open script",
         "type": "php",
@@ -1590,6 +1603,7 @@ Requires:
   "configurations": {
     "run": {
       "adapter": "vscode-node",
+      "filetypes": [ "javascript", "typescript" ], // optional
       "configuration": {
         "request": "launch",
         "protocol": "auto",
@@ -1680,6 +1694,7 @@ This behaviour can be customised:
   "configurations": {
     "Java Attach": {
       "adapter": "vscode-java",
+      "filetypes": [ "java" ],
       "configuration": {
         "request": "attach",
         "hostName": "${host}",
@@ -1769,6 +1784,7 @@ This debugger uses stdio to communicate with the running process, so calls to
   "configurations": {
     "lua": {
       "adapter": "lua-local",
+      "filetypes": [ "lua" ],
       "configuration": {
         "request": "launch",
         "type": "lua-local",
@@ -1781,6 +1797,7 @@ This debugger uses stdio to communicate with the running process, so calls to
     },
     "luajit": {
       "adapter": "lua-local",
+      "filetypes": [ "lua" ],
       "configuration": {
         "request": "launch",
         "type": "lua-local",
@@ -1793,6 +1810,7 @@ This debugger uses stdio to communicate with the running process, so calls to
     },
     "love": {
       "adapter": "lua-local",
+      "filetypes": [ "love" ],
       "configuration": {
         "request": "launch",
         "type": "lua-local",
@@ -1813,6 +1831,8 @@ This debugger uses stdio to communicate with the running process, so calls to
   Server. Take a look at [this
   comment](https://github.com/puremourning/vimspector/issues/3#issuecomment-576916076)
   for instructions.
+- See also [the wiki](https://github.com/puremourning/vimspector/wiki/languages)
+  which has community-contributed plugin files for some languages.
 
 
 # Customisation

--- a/docs/schema/vimspector.schema.json
+++ b/docs/schema/vimspector.schema.json
@@ -248,6 +248,18 @@
                 "type": [ "string", "array" ],
                 "description": "Defines the value of the special token %CMD% in remote-launch 'runCommand(s)'. The value is inserted into the command line where an entry matching '%CMD%' is found in 'runCommand(s)' command array."
               },
+              "default": {
+                "type": "boolean",
+                "description": "When true, this configuration is picked by default"
+              },
+              "autoselect": {
+                "type": "boolean",
+                "description": "When false, this configuration is _never_ picked by default"
+              },
+              "filetypes": {
+                "type": "array",
+                "description": "List of Vim filetypes that this configuration applies to. The configuraiton is only used if one of the current filetypes appears in this list, or if this list is not supplied,"
+              },
               "configuration": {
                 "type": "object",
                 "required": [ "request" ],
@@ -264,12 +276,6 @@
               "breakpoints": {
                 "type": "object",
                 "properties": {
-                  "line": {
-                    "$comment": "TBA: Not supported yet"
-                  },
-                  "function": {
-                    "$comment": "TBA: Not supported yet"
-                  },
                   "exception": {
                     "type": "object",
                     "description": "Exception breakpoints configuration, mapping the server's exception filter to enabled/disable/default flag",

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -100,6 +100,15 @@ class DebugSession( object ):
         configurations.update( database.get( 'configurations' ) or {} )
         adapters.update( database.get( 'adapters' ) or {} )
 
+    if filetypes:
+      # filter out any configurations that have a 'filetypes' list set and it
+      # doesn't contain one of the current filetypes
+      configurations = {
+        k: c for k, c in configurations.items() if 'filetypes' not in c or any(
+          ft in c[ 'filetypes' ] for ft in filetypes
+        )
+      }
+
     return launch_config_file, configurations
 
   def Start( self,

--- a/run_tests
+++ b/run_tests
@@ -92,7 +92,8 @@ if [ "$INSTALL" = "1" ] || [ "$INSTALL" = "script" ]; then
                --basedir ${BASEDIR} \
                ${INSTALLER_ARGS} \
                --all \
-               --force-enable-csharp; then
+               --force-enable-csharp \
+               --force-enable-node; then
     echo "Script installation reported errors" >&2
     exit 1
   fi
@@ -103,7 +104,7 @@ if [ "$INSTALL" = "1" ] || [ "$INSTALL" = "vim" ]; then
                --cmd "${BASEDIR_CMD}" \
                -c 'autocmd User VimspectorInstallSuccess qa!' \
                -c 'autocmd User VimspectorInstallFailed cquit!' \
-               -c "VimspectorInstall --all netcoredbg"; then
+               -c "VimspectorInstall --all netcoredbg vscode-node-debug2"; then
     echo "Vim installation reported errors" >&2
     exit 1
   fi

--- a/support/test/multiple_filetypes/.vimspector.json
+++ b/support/test/multiple_filetypes/.vimspector.json
@@ -1,0 +1,41 @@
+{
+  "configurations": {
+    "Node": {
+      "adapter": "vscode-node",
+      "filetypes": [ "javascript" ],
+      "default": true,
+      "configuration": {
+        "request": "launch",
+        "protocol": "auto",
+        "stopOnEntry": true,
+        "console": "integratedTerminal",
+        "program": "${workspaceRoot}/test.js",
+        "cwd": "${workspaceRoot}"
+      },
+      "breakpoints": {
+        "exception": {
+          "all": "",
+          "uncaught": ""
+        }
+      }
+    },
+    "Python": {
+      "adapter": "debugpy",
+      "filetypes": [ "python" ],
+      "default": true,
+      "configuration": {
+        "request": "launch",
+        "program": "${workspaceRoot}/test.py",
+        "stopOnEntry": true,
+        "cwd": "${workspaceRoot}"
+      },
+      "breakpoints": {
+        "exception": {
+          "all": "",
+          "raised": "",
+          "uncaught": ""
+        }
+      }
+    }
+  }
+}

--- a/support/test/multiple_filetypes/test.js
+++ b/support/test/multiple_filetypes/test.js
@@ -1,0 +1,3 @@
+console.log( "Hello" );
+console.log( "From" );
+console.log( "JavaScript" );

--- a/support/test/multiple_filetypes/test.py
+++ b/support/test/multiple_filetypes/test.py
@@ -1,0 +1,7 @@
+def Main():
+  print( "Hello" )
+  print( "From" )
+  print( "Python" )
+
+
+Main()

--- a/tests/get_configurations.test.vim
+++ b/tests/get_configurations.test.vim
@@ -20,3 +20,34 @@ function Test_Get_Configurations()
   %bwipe!
 endfunction
 
+function! Test_Get_Configurations_FilteredFiletypes()
+  edit ../support/test/multiple_filetypes/test.js
+  call assert_equal( [ 'Node' ], vimspector#GetConfigurations() )
+  edit ../support/test/multiple_filetypes/test.py
+  call assert_equal( [ 'Python' ], vimspector#GetConfigurations() )
+  edit ../support/test/multiple_filetypes/.vimspector.json
+  call assert_equal( [], vimspector#GetConfigurations() )
+  %bwipe!
+endfunction
+
+function! Test_PickConfiguration_FilteredFiletypes()
+  let fn = '../support/test/multiple_filetypes/test.js'
+  exe 'edit ' . fn
+  normal! G
+  call vimspector#Launch()
+  call WaitForAssert( { ->
+        \ vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 1, 1  )
+        \ } )
+  call vimspector#test#setup#Reset()
+
+  let fn = '../support/test/multiple_filetypes/test.py'
+  exe 'edit ' . fn
+  normal! G
+  call vimspector#Launch()
+  call WaitForAssert( { ->
+        \ vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 1, 1  )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction


### PR DESCRIPTION
You can now specify `filetypes` in the `configuration` block as a list of vim filetypes the configuration applies to. When the list is specified for a configuration and no current buffer filetype is in the list, then the configuration is ignored.

This allows for better workflow when you have multiple types of file in your project. You can combine this with the 'default' and 'autoselect' entries to make default configurations for specific filetypes within your project.

Suggestion by @SUPERustam