### PR TITLE
Compact variables UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,7 @@ autocmd SessionLoadPost * silent! VimspectorLoadSession
 * Use `<CR>`, or double-click with left mouse to expand/collapse (+, -).
 * Set the value of the variable with `<C-CR>` (control + `<CR>`) or
   `<leader><CR>` (if `modifyOtherKeys` doesn't work for you)
+* View the type of the variable via mouse hover.
 * When changing the stack frame the locals window updates.
 * While paused, hover to see values
 
@@ -1008,11 +1009,19 @@ autocmd SessionLoadPost * silent! VimspectorLoadSession
 
 Scopes and variables are represented by the buffer `vimspector.Variables`.
 
+If you prefer a more verbose display for variables and watches, then you can
+`let g:vimspector_variables_display_mode = 'full'`. By default only the name and
+value are displayed, with other data available from hovering the mouse or
+triggering `<Plug>VimspectorBalloonEval` on the line contianing the value in the
+variables (or watches) window.
+
 ## Variable or selection hover evaluation
 
 All rules for `Variables and scopes` apply plus the following:
 
 * With mouse enabled, hover over a variable and get the value it evaluates to.
+  This applies to the variables and watches windows too, and allows you to view
+  the type of the value.
 * Use your mouse to perform a visual selection of an expression (e.g. `a + b`)
   and get its result.
 * Make a normal mode (`nmap`) and visual mode (`xmap`) mapping to
@@ -1036,6 +1045,7 @@ to add a new watch expression.
   typing the expression. Commit with `<CR>`.
 * Alternatively, use `:VimspectorWatch <expression>`. Tab-completion for
   expression is available in some debug adapters.
+* View the type of the variable via mouse hover.
 * Expand result with `<CR>`, or double-click with left mouse.
 * Set the value of the variable with `<C-CR>` (control + `<CR>`) or
   `<leader><CR>` (if `modifyOtherKeys` doesn't work for you)
@@ -1044,6 +1054,12 @@ to add a new watch expression.
 ![watch window](https://puremourning.github.io/vimspector-web/img/vimspector-watch-window.png)
 
 The watches are represented by the buffer `vimspector.StackTrace`.
+
+If you prefer a more verbose display for variables and watches, then you can
+`let g:vimspector_variables_display_mode = 'full'`. By default only the name and
+value are displayed, with other data available from hovering the mouse or
+triggering `<Plug>VimspectorBalloonEval` on the line contianing the value in the
+variables (or watches) window.
 
 ### Watch autocompletion
 

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -578,10 +578,14 @@ function! vimspector#ShowEvalBalloon( is_visual ) abort
     let expr = expand( '<cexpr>' )
   endif
 
-  return py3eval( '_vimspector_session.ShowEvalBalloon('
-                \ . ' int( vim.eval( "winnr()" ) ), "'
-                \ . expr
-                \ . '", 0 )' )
+  let line = line( '.' )
+
+  return py3eval( '_vimspector_session.HoverEvalTooltip('
+                \ . ' int( vim.eval( "winnr()" ) ), '
+                \ . ' int( vim.eval( "bufnr()" ) ), '
+                \ . ' int( vim.eval( "line" ) ), '
+                \ . '"' . expr . '", '
+                \ . '0 )' )
 endfunction
 
 function! vimspector#PrintDebugInfo() abort

--- a/autoload/vimspector/internal/balloon.vim
+++ b/autoload/vimspector/internal/balloon.vim
@@ -35,9 +35,11 @@ let s:is_neovim = has( 'nvim' )
 
 " This is used as the balloonexpr in vim to show the Tooltip at the hover
 " position
-function! vimspector#internal#balloon#HoverTooltip() abort
-  return py3eval( '_vimspector_session.ShowEvalBalloon('
+function! vimspector#internal#balloon#HoverEvalTooltip() abort
+  return py3eval( '_vimspector_session.HoverEvalTooltip('
                 \ . ' int( vim.eval( "v:beval_winnr" ) ) + 1,'
+                \ . ' int( vim.eval( "v:beval_bufnr" ) ),'
+                \ . ' int( vim.eval( "v:beval_lnum" ) ),'
                 \ . ' vim.eval( "v:beval_text"),'
                 \ . ' 1 )' )
 endfunction

--- a/doc/vimspector.txt
+++ b/doc/vimspector.txt
@@ -1239,12 +1239,19 @@ Variables and scopes ~
 - Use '<CR>', or double-click with left mouse to expand/collapse (+, -).
 - Set the value of the variable with '<C-CR>' (control + '<CR>') or
   '<leader><CR>' (if 'modifyOtherKeys' doesn't work for you)
+- View the type of the variable via mouse hover.
 - When changing the stack frame the locals window updates.
 - While paused, hover to see values
 
   Image: locals window (see reference [25])
 
 Scopes and variables are represented by the buffer 'vimspector.Variables'.
+
+If you prefer a more verbose display for variables and watches, then you can
+"let g:vimspector_variables_display_mode = 'full'". By default only the name
+and value are displayed, with other data available from hovering the mouse or
+triggering '<Plug>VimspectorBalloonEval' on the line contianing the value in
+the variables (or watches) window.
 
 -------------------------------------------------------------------------------
                             *vimspector-variable-or-selection-hover-evaluation*
@@ -1253,7 +1260,8 @@ Variable or selection hover evaluation ~
 All rules for 'Variables and scopes' apply plus the following:
 
 - With mouse enabled, hover over a variable and get the value it evaluates
-  to.
+  to. This applies to the variables and watches windows too, and allows you
+  to view the type of the value.
 
 - Use your mouse to perform a visual selection of an expression (e.g. 'a +
   b') and get its result.
@@ -1281,20 +1289,23 @@ mode to add a new watch expression.
 
 - Add watches to the variables window by entering insert mode and typing the
   expression. Commit with '<CR>'.
-
 - Alternatively, use ':VimspectorWatch <expression>'. Tab-completion for
   expression is available in some debug adapters.
-
+- View the type of the variable via mouse hover.
 - Expand result with '<CR>', or double-click with left mouse.
-
 - Set the value of the variable with '<C-CR>' (control + '<CR>') or
   '<leader><CR>' (if 'modifyOtherKeys' doesn't work for you)
-
 - Delete with '<DEL>'.
 
   Image: watch window (see reference [27])
 
 The watches are represented by the buffer 'vimspector.StackTrace'.
+
+If you prefer a more verbose display for variables and watches, then you can
+"let g:vimspector_variables_display_mode = 'full'". By default only the name
+and value are displayed, with other data available from hovering the mouse or
+triggering '<Plug>VimspectorBalloonEval' on the line contianing the value in
+the variables (or watches) window.
 
 -------------------------------------------------------------------------------
                                               *vimspector-watch-autocompletion*

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -742,7 +742,7 @@ class DebugSession( object ):
 
 
   @IfConnected()
-  def ShowEvalBalloon( self, winnr, expression, is_hover ):
+  def HoverEvalTooltip( self, winnr, bufnr, lnum, expression, is_hover ):
     frame = self._stackTraceView.GetCurrentFrame()
     # Check if RIP is in a frame
     if frame is None:
@@ -750,14 +750,13 @@ class DebugSession( object ):
       return ''
 
     # Check if cursor in code window
-    if winnr != int( self._codeView._window.number ):
-      self._logger.debug( 'Winnr %s is not the code window %s',
-                          winnr,
-                          self._codeView._window.number )
-      return ''
+    if winnr == int( self._codeView._window.number ):
+      return self._variablesView.HoverEvalTooltip( frame, expression, is_hover )
 
+    return self._variablesView.HoverVarWinTooltip( bufnr,
+                                                   lnum,
+                                                   is_hover )
     # Return variable aware function
-    return self._variablesView.VariableEval( frame, expression, is_hover )
 
 
   def CleanUpTooltip( self ):
@@ -925,8 +924,7 @@ class DebugSession( object ):
     with utils.LetCurrentWindow( stack_trace_window ):
       vim.command( f'{ one_third }wincmd _' )
 
-    self._variablesView = variables.VariablesView( vars_window,
-                                                   watch_window )
+    self._variablesView = variables.VariablesView( vars_window, watch_window )
 
     # Output/logging
     vim.current.window = code_window
@@ -983,8 +981,7 @@ class DebugSession( object ):
     with utils.LetCurrentWindow( stack_trace_window ):
       vim.command( f'{ one_third }wincmd |' )
 
-    self._variablesView = variables.VariablesView( vars_window,
-                                                   watch_window )
+    self._variablesView = variables.VariablesView( vars_window, watch_window )
 
 
     # Output/logging

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -22,6 +22,7 @@ DEFAULTS = {
   # UI
   'ui_mode':            'auto',
   'bottombar_height':   10,
+  'variables_display_mode': 'compact', # compact/full
 
   # For ui_mode = 'horizontal':
   'sidebar_width':      50,
@@ -71,7 +72,7 @@ DEFAULTS = {
 }
 
 
-def Get( option: str, default=None, cls=str ):
+def Get( option: str, cls=str ):
   return cls( utils.GetVimValue( vim.vars,
                                  f'vimspector_{ option }',
                                  DEFAULTS.get( option, cls() ) ) )

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -689,7 +689,7 @@ def ParseVariables( variables_list,
   return new_variables
 
 
-def DisplayBalloon( is_term, display, is_hover = False ):
+def CreateTooltip( is_term, display: list, is_hover = False ):
   if not is_term:
     # To enable the Windows GUI to display the balloon correctly
     # Refer https://github.com/vim/vim/issues/1512#issuecomment-492070685

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -56,6 +56,10 @@ class Expandable:
   def VariablesReference( self ):
     assert False
 
+  @abc.abstractmethod
+  def HoverText( self ):
+    return ""
+
 
 class Scope( Expandable ):
   """Holds an expandable scope (a DAP scope dict), with expand/collapse state"""
@@ -68,6 +72,9 @@ class Scope( Expandable ):
 
   def Update( self, scope ):
     self.scope = scope
+
+  def HoverText( self ):
+    return ""
 
 
 class WatchResult( Expandable ):
@@ -86,6 +93,15 @@ class WatchResult( Expandable ):
     if self.result[ 'result' ] != result[ 'result' ]:
       self.changed = True
     self.result = result
+
+  def HoverText( self ):
+    if not self.result:
+      return None
+
+    return (
+      f"Type:  { self.result.get( 'type', '<unknown>' ) }\n"
+      f"Value: { self.result.get( 'result', '<unknown>' ) }"
+    )
 
 
 class WatchFailure( WatchResult ):
@@ -110,6 +126,16 @@ class Variable( Expandable ):
     if self.variable[ 'value' ] != variable[ 'value' ]:
       self.changed = True
     self.variable = variable
+
+  def HoverText( self ):
+    if not self.variable:
+      return None
+
+    return (
+      f"Name:  { self.variable.get( 'name', '<unknown>' ) }\n"
+      f"Type:  { self.variable.get( 'type', '<unknown>' ) }\n"
+      f"Value: { self.variable.get( 'value', '<unknown>' ) }"
+    )
 
 
 class Watch:
@@ -245,8 +271,9 @@ class VariablesView( object ):
         'balloonexpr': vim.options[ 'balloonexpr' ],
         'balloondelay': vim.options[ 'balloondelay' ],
       }
-      vim.options[ 'balloonexpr' ] = ( "vimspector#internal#"
-                                       "balloon#HoverTooltip()" )
+      vim.options[ 'balloonexpr' ] = (
+        "vimspector#internal#balloon#HoverEvalTooltip()"
+      )
 
       vim.options[ 'balloondelay' ] = 250
 
@@ -379,7 +406,7 @@ class VariablesView( object ):
     self._variable_eval_view = None
     vim.vars[ 'vimspector_session_windows' ][ 'eval' ] = None
 
-  def VariableEval( self, frame, expression, is_hover ):
+  def HoverEvalTooltip( self, frame, expression, is_hover ):
     """Callback to display variable under cursor `:h ballonexpr`"""
     if not self._connection:
       return ''
@@ -392,7 +419,7 @@ class VariablesView( object ):
       else:
         watch.result.Update( message[ 'body' ] )
 
-      popup_win_id = utils.DisplayBalloon( self._is_term, [], is_hover )
+      popup_win_id = utils.CreateTooltip( self._is_term, [], is_hover )
       # record the global eval window id
       vim.vars[ 'vimspector_session_windows' ][ 'eval' ] = int( popup_win_id )
       popup_bufnr = int( vim.eval( "winbufnr({})".format( popup_win_id ) ) )
@@ -423,7 +450,7 @@ class VariablesView( object ):
 
     def failure_handler( reason, message ):
       display = [ reason ]
-      float_win_id = utils.DisplayBalloon( self._is_term, display, is_hover )
+      float_win_id = utils.CreateTooltip( self._is_term, display, is_hover )
       # record the global eval window id
       vim.vars[ 'vimspector_session_windows' ][ 'eval' ] = int( float_win_id )
 
@@ -438,6 +465,17 @@ class VariablesView( object ):
     }, failure_handler )
 
     # Return working (meanwhile)
+    return ''
+
+  def HoverVarWinTooltip( self, bufnr, lnum, is_hover ):
+    variable, view = self._GetVariable( vim.buffers[ bufnr ], lnum )
+    if variable is None:
+      return ''
+
+    hover = variable.HoverText()
+    if hover:
+      utils.CreateTooltip( self._is_term, hover.split( '\n' ), is_hover )
+
     return ''
 
   def AddWatch( self, frame, expression ):
@@ -614,36 +652,35 @@ class VariablesView( object ):
 
 
 
-  def _DrawVariables( self, view, variables, indent, is_short = False ):
-    assert indent > 0
+  def _DrawVariables( self, view, variables, indent_len, is_short = False ):
+    assert indent_len > 0
     for variable in variables:
       text = ''
-      # TODO: If 'value' is multi-line, somehow turn it into an expandable item
+      # We borrow 1 space of indent to draw the change marker
+      indent = ' ' * ( indent_len - 1 )
+      marker = '*' if variable.changed else ' '
+      icon = '+' if ( variable.IsExpandable()
+                      and not variable.IsExpanded() ) else '-'
+      name = variable.variable.get( 'name', '' )
+      kind = variable.variable.get( 'type', '' )
+      value = variable.variable.get( 'value', '<unknown>' )
+
+      # FIXME: If 'value' is multi-line, somehow turn it into an expandable item
       # where the expansion is done "internally", resolving to the multi-line
       # value
-      #
-      # TODO: switch to short mode if... something, like maybe the type is long
-      # or the value is long? But then how to get the type? Popup?
       if is_short:
-        text = '{indent}{icon} {name}: {value}'.format(
-          # We borrow 1 space of indent to draw the change marker
-          indent = ' ' * ( indent - 1 ),
-          icon = '+' if ( variable.IsExpandable()
-                          and not variable.IsExpanded() ) else '-',
-          name = variable.variable.get( 'name', '' ),
-          value = variable.variable.get( 'value', '<unknown>' )
-        )
+        value = variable.variable.get( 'value', '<unknown>' )
+        text = f'{indent}{icon} {name}: {value}'
+      elif settings.Get( 'variables_display_mode' ) == 'compact':
+        value = variable.variable.get( 'value', '<unknown>' ).splitlines()
+        if len( value ) > 0:
+          value = value[ 0 ]
+        else:
+          value = ''
+
+        text = f'{indent}{marker}{icon} {name}: {value}'
       else:
-        text = '{indent}{marker}{icon} {name} ({type_}): {value}'.format(
-          # We borrow 1 space of indent to draw the change marker
-          indent = ' ' * ( indent - 1 ),
-          marker = '*' if variable.changed else ' ',
-          icon = '+' if ( variable.IsExpandable()
-                          and not variable.IsExpanded() ) else '-',
-          name = variable.variable.get( 'name', '' ),
-          type_ = variable.variable.get( 'type', '' ),
-          value = variable.variable.get( 'value', '<unknown>' )
-        )
+        text = f'{indent}{marker}{icon} {name} ({kind}): {value}'
 
       line = utils.AppendToBuffer(
         view.buf,
@@ -653,7 +690,10 @@ class VariablesView( object ):
       view.lines[ line ] = variable
 
       if variable.ShouldDrawDrillDown():
-        self._DrawVariables( view, variable.variables, indent + 2, is_short )
+        self._DrawVariables( view,
+                             variable.variables,
+                             indent_len + 2,
+                             is_short )
 
   def _DrawScopes( self ):
     # FIXME: The drawing is dumb and draws from scratch every time. This is
@@ -696,11 +736,11 @@ class VariablesView( object ):
       indent += 2
       self._DrawVariables( self._vars, scope.variables, indent )
 
-  def _DrawWatchResult( self, view, indent, watch, is_short = False ):
+  def _DrawWatchResult( self, view, indent_len, watch, is_short = False ):
     if not watch.result:
       return
 
-    assert is_short or indent > 0
+    assert is_short or indent_len > 0
 
     if is_short:
       # The first result is always expanded in a hover (short format)
@@ -713,19 +753,27 @@ class VariablesView( object ):
       marker = '*' if watch.result.changed else ' '
       leader = ' Result: '
 
-    line =  '{indent}{marker}{icon}{leader}{result}'.format(
-      # We borrow 1 space of indent to draw the change marker
-      indent = ' ' * ( indent - 1 ),
-      marker = marker,
-      icon = icon,
-      leader = leader,
-      result = watch.result.result.get( 'result', '<unknown>' ) )
+    value = watch.result.result.get( 'result', '<unknown>' )
+    # We borrow 1 space of indent to draw the change marker
+    indent = ' ' * ( indent_len - 1 )
+
+    if settings.Get( 'variables_display_mode' ) == 'compact':
+      value = value.splitlines()
+      if len( value ) > 0:
+        value = value[ 0 ]
+      else:
+        value = ''
+
+    line = f'{indent}{marker}{icon}{leader}{value}'
 
     line = utils.AppendToBuffer( view.buf, line.split( '\n' ) )
     view.lines[ line ] = watch.result
 
     if watch.result.ShouldDrawDrillDown():
-      self._DrawVariables( view, watch.result.variables, indent + 2, is_short )
+      self._DrawVariables( view,
+                           watch.result.variables,
+                           indent_len + 2,
+                           is_short )
 
   def _ConsumeVariables( self, draw, parent, message ):
     new_variables = []

--- a/support/custom_ui_vimrc
+++ b/support/custom_ui_vimrc
@@ -35,6 +35,13 @@ function! s:CustomiseUI()
   call win_gotoid( wins.output )
   10wincmd _
   wincmd K
+
+  " Enable keyboard-hover for vars and watches
+  call win_gotoid( g:vimspector_session_windows.variables )
+  nmap <silent> <buffer> <LocalLeader>di <Plug>VimspectorBalloonEval
+
+  call win_gotoid( g:vimspector_session_windows.watches )
+  nmap <silent> <buffer> <LocalLeader>di <Plug>VimspectorBalloonEval
 endfunction
 
 function s:SetUpTerminal()

--- a/tests/variables_compact.test.vim
+++ b/tests/variables_compact.test.vim
@@ -2,7 +2,7 @@ let s:fn='../support/test/python/simple_python/main.py'
 
 function! SetUp()
   call vimspector#test#setup#SetUpWithMappings( 'HUMAN' )
-  let g:vimspector_variables_display_mode = 'full'
+  let g:vimspector_variables_display_mode = 'compact'
 endfunction
 
 function! ClearDown()
@@ -194,7 +194,7 @@ function! Test_ExpandVariables()
         \   assert_equal(
         \     [
         \       '- Scope: Locals',
-        \       ' *+ t (Test): {...}',
+        \       ' *+ t: {...}',
         \       '+ Scope: Registers',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.variables ),
@@ -216,11 +216,11 @@ function! Test_ExpandVariables()
         \   AssertMatchList(
         \     [
         \       '- Scope: Locals',
-        \       ' \*- t (Test): {...}',
-        \       '   \*- i (int): 0',
-        \       '   \*- c (char): 0 ''\\0\{1,3}''',
-        \       '   \*- fffff (float): 0',
-        \       '   \*+ another_test (AnotherTest):\( {...}\)\?',
+        \       ' \*- t: {...}',
+        \       '   \*- i: 0',
+        \       '   \*- c: 0 ''\\0\{1,3}''',
+        \       '   \*- fffff: 0',
+        \       '   \*+ another_test:\( {...}\)\?',
         \       '+ Scope: Registers',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.variables ),
@@ -235,11 +235,11 @@ function! Test_ExpandVariables()
         \   AssertMatchList(
         \     [
         \       '- Scope: Locals',
-        \       '  - t (Test): {...}',
-        \       '   \*- i (int): 1',
-        \       '    - c (char): 0 ''\\0\{1,3}''',
-        \       '    - fffff (float): 0',
-        \       '    + another_test (AnotherTest):\( {...}\)\?',
+        \       '  - t: {...}',
+        \       '   \*- i: 1',
+        \       '    - c: 0 ''\\0\{1,3}''',
+        \       '    - fffff: 0',
+        \       '    + another_test:\( {...}\)\?',
         \       '+ Scope: Registers',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.variables ),
@@ -256,7 +256,7 @@ function! Test_ExpandVariables()
         \   assert_equal(
         \     [
         \       '- Scope: Locals',
-        \       '  + t (Test): {...}',
+        \       '  + t: {...}',
         \       '+ Scope: Registers',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.variables ),
@@ -271,7 +271,7 @@ function! Test_ExpandVariables()
         \   assert_equal(
         \     [
         \       '- Scope: Locals',
-        \       '  + t (Test): {...}',
+        \       '  + t: {...}',
         \       '+ Scope: Registers',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.variables ),
@@ -287,11 +287,11 @@ function! Test_ExpandVariables()
         \   AssertMatchList(
         \     [
         \       '- Scope: Locals',
-        \       '  - t (Test): {...}',
-        \       '   \*- i (int): 1',
-        \       '   \*- c (char): 99 ''c''',
-        \       '   \*- fffff (float): 0',
-        \       '   \*+ another_test (AnotherTest):\( {...}\)\?',
+        \       '  - t: {...}',
+        \       '   \*- i: 1',
+        \       '   \*- c: 99 ''c''',
+        \       '   \*- fffff: 0',
+        \       '   \*+ another_test:\( {...}\)\?',
         \       '+ Scope: Registers',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.variables ),
@@ -393,10 +393,10 @@ function! Test_ExpandWatch()
         \       'Watches: ----',
         \       'Expression: t',
         \       ' \*- Result: {...}',
-        \       '   \*- i (int): 0',
-        \       '   \*- c (char): 0 ''\\0\{1,3}''',
-        \       '   \*- fffff (float): 0',
-        \       '   \*+ another_test (AnotherTest):\( {...}\)\?',
+        \       '   \*- i: 0',
+        \       '   \*- c: 0 ''\\0\{1,3}''',
+        \       '   \*- fffff: 0',
+        \       '   \*+ another_test:\( {...}\)\?',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.watches ),
         \                 1,
@@ -412,10 +412,10 @@ function! Test_ExpandWatch()
         \       'Watches: ----',
         \       'Expression: t',
         \       '  - Result: {...}',
-        \       '   \*- i (int): 1',
-        \       '    - c (char): 0 ''\\0\{1,3}''',
-        \       '    - fffff (float): 0',
-        \       '    + another_test (AnotherTest):\( {...}\)\?',
+        \       '   \*- i: 1',
+        \       '    - c: 0 ''\\0\{1,3}''',
+        \       '    - fffff: 0',
+        \       '    + another_test:\( {...}\)\?',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.watches ),
         \                 1,
@@ -464,10 +464,10 @@ function! Test_ExpandWatch()
         \       'Watches: ----',
         \       'Expression: t',
         \       '  - Result: {...}',
-        \       '    - i (int): 1',
-        \       '    - c (char): 99 ''c''',
-        \       '    - fffff (float): 0',
-        \       '    + another_test (AnotherTest):\( {...}\)\?',
+        \       '    - i: 1',
+        \       '    - c: 99 ''c''',
+        \       '    - fffff: 0',
+        \       '    + another_test:\( {...}\)\?',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.watches ),
         \                 1,
@@ -855,7 +855,7 @@ function! Test_SetVariableValue_Local()
         \   assert_equal(
         \     [
         \       '- Scope: Locals',
-        \       ' *+ t (Test): {...}',
+        \       ' *+ t: {...}',
         \       '+ Scope: Registers',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.variables ),
@@ -877,11 +877,11 @@ function! Test_SetVariableValue_Local()
         \   AssertMatchList(
         \     [
         \       '- Scope: Locals',
-        \       ' \*- t (Test): {...}',
-        \       '   \*- i (int): 0',
-        \       '   \*- c (char): 0 ''\\0\{1,3}''',
-        \       '   \*- fffff (float): 0',
-        \       '   \*+ another_test (AnotherTest):\( {...}\)\?',
+        \       ' \*- t: {...}',
+        \       '   \*- i: 0',
+        \       '   \*- c: 0 ''\\0\{1,3}''',
+        \       '   \*- fffff: 0',
+        \       '   \*+ another_test:\( {...}\)\?',
         \       '+ Scope: Registers',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.variables ),
@@ -904,11 +904,11 @@ EOF
         \   AssertMatchList(
         \     [
         \       '- Scope: Locals',
-        \       ' \*- t (Test): {...}',
-        \       '   \*- i (int): 100',
-        \       '   \*- c (char): 0 ''\\0\{1,3}''',
-        \       '   \*- fffff (float): 0',
-        \       '   \*+ another_test (AnotherTest):\( {...}\)\?',
+        \       ' \*- t: {...}',
+        \       '   \*- i: 100',
+        \       '   \*- c: 0 ''\\0\{1,3}''',
+        \       '   \*- fffff: 0',
+        \       '   \*+ another_test:\( {...}\)\?',
         \       '+ Scope: Registers',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.variables ),
@@ -924,11 +924,11 @@ EOF
         \   AssertMatchList(
         \     [
         \       '- Scope: Locals',
-        \       ' \*- t (Test): {...}',
-        \       '   \*- i (int): 1234',
-        \       '   \*- c (char): 0 ''\\0\{1,3}''',
-        \       '   \*- fffff (float): 0',
-        \       '   \*+ another_test (AnotherTest):\( {...}\)\?',
+        \       ' \*- t: {...}',
+        \       '   \*- i: 1234',
+        \       '   \*- c: 0 ''\\0\{1,3}''',
+        \       '   \*- fffff: 0',
+        \       '   \*+ another_test:\( {...}\)\?',
         \       '+ Scope: Registers',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.variables ),
@@ -944,11 +944,11 @@ EOF
         \   AssertMatchList(
         \     [
         \       '- Scope: Locals',
-        \       ' \*- t (Test): {...}',
-        \       '   \*- i (int): 1234',
-        \       '   \*- c (char): 0 ''\\0\{1,3}''',
-        \       '   \*- fffff (float): 0',
-        \       '   \*+ another_test (AnotherTest):\( {...}\)\?',
+        \       ' \*- t: {...}',
+        \       '   \*- i: 1234',
+        \       '   \*- c: 0 ''\\0\{1,3}''',
+        \       '   \*- fffff: 0',
+        \       '   \*+ another_test:\( {...}\)\?',
         \       '+ Scope: Registers',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.variables ),
@@ -1003,10 +1003,10 @@ function! Test_SetVariableValue_Watch()
         \       'Watches: ----',
         \       'Expression: t',
         \       ' \*- Result: {...}',
-        \       '   \*- i (int): 0',
-        \       '   \*- c (char): 0 ''\\0\{1,3}''',
-        \       '   \*- fffff (float): 0',
-        \       '   \*+ another_test (AnotherTest):\( {...}\)\?',
+        \       '   \*- i: 0',
+        \       '   \*- c: 0 ''\\0\{1,3}''',
+        \       '   \*- fffff: 0',
+        \       '   \*+ another_test:\( {...}\)\?',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.watches ),
         \                 1,
@@ -1032,10 +1032,10 @@ EOF
         \       'Watches: ----',
         \       'Expression: t',
         \       ' \*- Result: {...}',
-        \       '   \*- i (int): 100',
-        \       '   \*- c (char): 0 ''\\0\{1,3}''',
-        \       '   \*- fffff (float): 0',
-        \       '   \*+ another_test (AnotherTest):\( {...}\)\?',
+        \       '   \*- i: 100',
+        \       '   \*- c: 0 ''\\0\{1,3}''',
+        \       '   \*- fffff: 0',
+        \       '   \*+ another_test:\( {...}\)\?',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.watches ),
         \                 1,
@@ -1052,10 +1052,10 @@ EOF
         \       'Watches: ----',
         \       'Expression: t',
         \       ' \*- Result: {...}',
-        \       '   \*- i (int): 1234',
-        \       '   \*- c (char): 0 ''\\0\{1,3}''',
-        \       '   \*- fffff (float): 0',
-        \       '   \*+ another_test (AnotherTest):\( {...}\)\?',
+        \       '   \*- i: 1234',
+        \       '   \*- c: 0 ''\\0\{1,3}''',
+        \       '   \*- fffff: 0',
+        \       '   \*+ another_test:\( {...}\)\?',
         \     ],
         \     getbufline( winbufnr( g:vimspector_session_windows.watches ),
         \                 1,
@@ -1134,3 +1134,4 @@ EOF
   call vimspector#test#setup#Reset()
   %bwipe!
 endfunction
+


### PR DESCRIPTION
This change removes the "type" from the variables and watches windows, replacing it with a hover popup that contains it. This is particularly useful for certain debug adapters like delve which include lots of repeated/duplicated data about the type of variables for some reason.

This also truncates the value so that we only display the first line of any multi-line values (again, the full value is visible in the hover popup).  Closes #487 (probably)

I'm changing the default here, which might annoy users, so there's an option `g:vimspector_variables_display_mode = 'full'` that restores the old behaviour. I may decide to remove it in future.