### PR TITLE
Fix typo in mappings anchor link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ For example, to get an array of configurations and fuzzy matching on the result
 
 ## Breakpoints
 
-See the [mappings](€mappings) section for the default mappings for working with
+See the [mappings](#mappings) section for the default mappings for working with
 breakpoints. This section describes the full API in vimscript functions.
 
 ### Summary


### PR DESCRIPTION
Fixes a typo in the docs (euro symbol used instead of hash in internal anchor link).