### PR TITLE
fix exception with key "line"

### DIFF
--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -278,7 +278,7 @@ class ProjectBreakpoints( object ):
       for bp in breakpoints:
         self._SignToLine( file_name, bp )
 
-        if 'server_bp' in bp:
+        if 'server_bp' in bp and 'line' in bp[ 'server_bp' ]:
           line = bp[ 'server_bp' ][ 'line' ]
           if bp[ 'server_bp' ][ 'verified' ]:
             state = 'VERIFIED'
@@ -819,7 +819,7 @@ class ProjectBreakpoints( object ):
           bp[ 'sign_id' ] = self._next_sign_id
           self._next_sign_id += 1
 
-        if 'server_bp' in bp:
+        if 'server_bp' in bp and 'line' in bp[ 'server_bp' ]:
           line = bp[ 'server_bp' ][ 'line' ]
           verified = bp[ 'server_bp' ][ 'verified' ]
         else:


### PR DESCRIPTION
Working with Chrome debug, initially, the state of `pb` is:

```python
bp = {'state': 'ENABLED', 'line': 207, 'options': {}, 'sign_id': 3, 'server_bp': {'id': 1000, 'verified': False, 'message': 'Breakpoint set but not yet bound'}}
```
![Screen Shot 2022-03-08 at 12 47 37 PM](https://user-images.githubusercontent.com/15852839/157174477-139c0432-2e10-4d09-86ae-24ae2e9d2085.png)

Clearly, access `bp['server_bp']['line']` will throw an error (instead of return `None`) in Python 3. This PR make sure that we only access `line` key when it exists.