### PR TITLE
Allow configuration of via .vimrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ $ curl -L <url> | tar -C $HOME/.vim/pack zxvf -
 let g:vimspector_enable_mappings = 'HUMAN'
 ```
 
-5. Configure your project's debug profiles (create `.vimspector.json`)
+5. Configure your project's debug profiles (create `.vimspector.json`, or set
+   `g:vimspector_configurations`)
 
 Alternatively, you can clone the repo and select which gadgets are installed:
 
@@ -215,7 +216,8 @@ Alternatively, you can clone the repo and select which gadgets are installed:
 1. Install the plugin as a Vim package. See `:help packages`.
 2. Add `packadd! vimspector` to you `.vimrc`
 2. Install some 'gadgets' (debug adapters) - see `:VimspectorInstall ...`
-3. Configure your project's debug profiles (create `.vimspector.json`)
+3. Configure your project's debug profiles (create `.vimspector.json`, or set
+   `g:vimspector_configurations`)
 
 If you prefer to use a plugin manager, see the plugin manager's docs. For
 Vundle, use:
@@ -475,12 +477,12 @@ probably still make it work, but it's more effort.
 
 You essentially need to get a working installation of the debug adapter, find
 out how to start it, and configure that in an `adapters` entry in either your
-`.vimspector.json` or in `.gadgets.json`.
+`.vimspector.json` or in `.gadgets.json` or in `g:vimspector_adapters`.
 
 The simplest way in practice is to install or start Visual Studio Code and use
 its extension manager to install the relevant extension. You can then configure
 the adapter manually in the `adapters` section of your `.vimspector.json` or in
-a `gadgets.json`.
+a `gadgets.json` or in `g:vimspector_adapters`.
 
 PRs are always welcome to add supported languages (which roughly translates to
 updating `python/vimspector/gadgets.py` and testing it).
@@ -2293,13 +2295,50 @@ hi link jsonComment Comment
    displays this information in the output window. It *does not* and *will not ever*
    collect, use, forward or otherwise share any data with any third parties.
 10. Do I _have_ to put a `.vimspector.json` in the root of every project? No, you
-    can put all of your adapter and debug configs in a [single directory](https://puremourning.github.io/vimspector/configuration.html#debug-configurations) if you want to, but note
-    the caveat that `${workspaceRoot}` won't be calculated correctly in that case.
-    The vimsepctor author uses this [a lot](https://github.com/puremourning/.vim-mac/tree/master/vimspector-conf)
+    can use `g:vimspector_adapters` and `g:vimspector_configurations` or put all
+    of your adapter and debug configs in a [single directory](https://puremourning.github.io/vimspector/configuration.html#debug-configurations)
+    if you want to, but note the caveat that `${workspaceRoot}` won't be
+    calculated correctly in that case.  The vimsepctor author uses this [a lot](https://github.com/puremourning/.vim-mac/tree/master/vimspector-conf)
 11. I'm confused about remote debugging configuration, can you explain it?
-    eh... kind of. Reference: https://puremourning.github.io/vimspector/configuration.html#remote-debugging-support. Some explanations here too: https://github.com/puremourning/vimspector/issues/478#issuecomment-943515093
-12. I'm trying to debug a Django (django?) project and it's not working. Can you help? sure, check [this link which has a working example](https://www.reddit.com/r/neovim/comments/mz4ari/how_to_set_up_vimspector_for_django_debugging/). Or google it.
+    eh... kind of. Reference:
+    https://puremourning.github.io/vimspector/configuration.html#remote-debugging-support.
+    Some explanations here too:
+    https://github.com/puremourning/vimspector/issues/478#issuecomment-943515093
+12. I'm trying to debug a Django (django?) project and it's not working. Can you
+    help? sure, check [this link which has a working example](https://www.reddit.com/r/neovim/comments/mz4ari/how_to_set_up_vimspector_for_django_debugging/).
+    Or google it.
 
+
+Example `g:vimspector_adapters` and `g:vimspector_configurations`:
+
+```viml
+let g:vimspector_adapters = #{
+      \   test_debugpy: #{ extends: 'debugpy' }
+      \ }
+
+let g:vimspector_configurations = {
+      \ "test_debugpy_config": {
+      \   "adapter": "test_debugpy",
+      \   "filetypes": [ "python" ],
+      \   "configuration": {
+      \     "request": "launch",
+      \     "type": "python",
+      \     "cwd": "${fileDirname}",
+      \     "args": [],
+      \     "program": "${file}",
+      \     "stopOnEntry": v:false,
+      \     "console": "integratedTerminal",
+      \     "integer": 123,
+      \   },
+      \   "breakpoints": {
+      \     "exception": {
+      \       "raised": "N",
+      \       "uncaught": "",
+      \       "userUnhandled": ""
+      \     }
+      \   }
+      \ } }
+```
 
 [ycmd]: https://github.com/Valloric/ycmd
 [gitter]: https://gitter.im/vimspector/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,6 +356,7 @@ Vimspector reads a series of files to build the `adapters` object. The
 named `example-adapter` in a later file _completely replaces_ a previous
 definition.
 
+* The contents of `g:vimspector_adapters` vim variable (dict)
 * `<vimspector home>/gadgets/<OS>/.gadgets.json` - the file written by
   `install_gadget.py` and not usually edited by users.
 * `<vimspector home>/gadgets/<OS>/.gadgets.d/*.json` (sorted alphabetically).
@@ -414,6 +415,7 @@ further restrict project configurations by filetype.
 
 There are two locations for debug configurations for a project:
 
+* `g:vimspector_configurations` vim variable (dict)
 * `<vimspector home>/configurations/<OS>/<filetype>/*.json`
 * `.vimspector.json` in the project source
 

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -92,7 +92,7 @@ class DebugSession( object ):
   def GetConfigurations( self, adapters ):
     current_file = utils.GetBufferFilepath( vim.current.buffer )
     filetypes = utils.GetBufferFiletypes( vim.current.buffer )
-    configurations = {}
+    configurations = settings.Dict( 'configurations' )
 
     for launch_config_file in PathsToAllConfigFiles( VIMSPECTOR_HOME,
                                                      current_file,
@@ -119,7 +119,7 @@ class DebugSession( object ):
     return launch_config_file, filetype_configurations, configurations
 
   def Start( self,
-             force_choose=False,
+             force_choose = False,
              launch_variables = None,
              adhoc_configurations = None ):
     # We mutate launch_variables, so don't mutate the default argument.
@@ -131,7 +131,7 @@ class DebugSession( object ):
                        launch_variables )
 
     current_file = utils.GetBufferFilepath( vim.current.buffer )
-    adapters = {}
+    adapters = settings.Dict( 'adapters' )
 
     launch_config_file = None
     configurations = None

--- a/tests/get_configurations.test.vim
+++ b/tests/get_configurations.test.vim
@@ -52,3 +52,25 @@ function! Test_PickConfiguration_FilteredFiletypes()
   call vimspector#test#setup#Reset()
   %bwipe!
 endfunction
+
+function Test_Get_Configurations_VimDict()
+  call vimspector#test#setup#PushSetting( 'vimspector_configurations', #{
+        \ test_config: #{
+        \    extends: 'launch - netcoredbg'
+        \   }
+        \ } )
+  lcd ../support/test/csharp/
+
+  let configs = vimspector#GetConfigurations()
+  call assert_equal( [
+        \   'test_config',
+        \   'launch - netcoredbg',
+        \   'launch - netcoredbg - with debug log',
+        \   'launch - mono',
+        \ ],
+        \ configs )
+
+  lcd -
+  %bwipe!
+endfunction
+

--- a/tests/language_csharp.test.vim
+++ b/tests/language_csharp.test.vim
@@ -49,6 +49,48 @@ function! Test_CSharp_Simple_Adhoc_Config()
   %bwipeout!
 endfunction
 
+function! Test_CSharp_Simple_VimDict_Config()
+  call vimspector#test#setup#PushSetting( 'vimspector_adapters', {
+  \   'test_adapter': {
+  \     'extends': 'netcoredbg',
+  \   }
+  \ } )
+  call vimspector#test#setup#PushSetting( 'vimspector_configurations', {
+  \   'test_configuration': {
+  \     'adapter': 'test_adapter',
+  \     'configuration': {
+  \       'request': 'launch',
+  \       'program': '${workspaceRoot}/bin/Debug/netcoreapp5.0/csharp.dll',
+  \       'args': [],
+  \       'stopAtEntry': v:false
+  \     }
+  \   }
+  \ } )
+  call SkipUnsupported()
+  let fn='Program.cs'
+  lcd ../support/test/csharp
+  exe 'edit ' . fn
+
+  call vimspector#SetLineBreakpoint( fn, 31 )
+  call vimspector#LaunchWithSettings(
+        \ { 'configuration': 'test_configuration' } )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 31, 7 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 31 )
+        \ } )
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 32, 12 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 32 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction
+
 function! Test_CSharp_Simple()
   call SkipUnsupported()
 

--- a/tests/manual/run
+++ b/tests/manual/run
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+cd $(dirname $0)
 CONTAINER=puremourning/vimspector:manual-$(uname -m )
 
 docker run --cap-add=SYS_PTRACE \


### PR DESCRIPTION
Apparently some people want to do this. Now that we have the 'filetypes'
option in the configuration it does seem reasonable as an alternative to
the g:vimspector_base_dir/configuration/os/language/blah.json which
seems to confuse users quite a lot.

example:

```
let g:vimspector_adapters = #{
      \   test_debugpy: #{ extends: 'debugpy' }
      \ }

let g:vimspector_configurations = {
      \ "test_debugpy_config": {
      \   "adapter": "test_debugpy",
      \   "filetypes": [ "python" ],
      \   "configuration": {
      \     "request": "launch",
      \     "type": "python",
      \     "cwd": "${fileDirname}",
      \     "args": [],
      \     "program": "${file}",
      \     "stopOnEntry": v:false,
      \     "console": "integratedTerminal",
      \     "integer": 123,
      \   },
      \   "breakpoints": {
      \     "exception": {
      \       "raised": "N",
      \       "uncaught": "",
      \       "userUnhandled": ""
      \     }
      \   }
      \ } }

```

config is re-read every time launching so scripts can modify as/when required.