### PR TITLE
Fix link to additional language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ runtime dependencies). They are categorised by their level of support:
 Vimspector should work for any debug adapter that works in Visual Studio Code.
 
 To use Vimspector with a language that's not "built-in", see this
-[wiki page](https://github.com/puremourning/vimspector/wiki/languages).
+[wiki page](https://github.com/puremourning/vimspector/wiki/Additional-Language-Support).
 
 # Installation
 


### PR DESCRIPTION
It looks like the wiki page for community supported languages was moved from "/wiki/languages" to "/wiki/additional-language-support"

This PR fixes the link in the README to direct to the appropriate page.