### PR TITLE
Fix line formatting of error message

### DIFF
--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -1515,11 +1515,8 @@ class DebugSession( object ):
     def failure_handler( reason, msg ):
       text = [
         'Launch Failed',
-        '',
-        reason,
-        '',
-        'Use :VimspectorReset to close'
-      ]
+        '' ] + reason.splitlines() + [
+        '', 'Use :VimspectorReset to close' ]
       self._logger.info( "Launch failed: %s", '\n'.join( text ) )
       self._splash_screen = utils.DisplaySplash( self._api_prefix,
                                                  self._splash_screen,


### PR DESCRIPTION
From a conversation on gitter:
> As regards this latter nuisance I think it's due to https://github.com/puremourning/vimspector/blob/4c693f33e3038c1199e0f2e1045f340339714b60/python3/vimspector/debug_session.py#L1523


> it's probably this actually: https://github.com/puremourning/vimspector/blob/4c693f33e3038c1199e0f2e1045f340339714b60/python3/vimspector/debug_session.py#L1519
>
> should probably be `reason.splitlines()`

---

This is the first code ever I write in Python. I'm happy to learn what's wrong (or what would be better) with it :smile: 