### PR TITLE
Allow truthy values for default and autoselect

### DIFF
--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -172,8 +172,8 @@ class DebugSession( object ):
     else:
       # Find a single configuration with 'default' True and autoselect not False
       defaults = { n: c for n, c in configurations.items()
-                   if c.get( 'default', False ) is True
-                   and c.get( 'autoselect', True ) is not False }
+                   if c.get( 'default', False )
+                   and c.get( 'autoselect', True ) }
 
       if len( defaults ) == 1:
         configuration_name = next( iter( defaults.keys() ) )

--- a/support/test/multiple_filetypes/.vimspector.json
+++ b/support/test/multiple_filetypes/.vimspector.json
@@ -7,7 +7,7 @@
       "configuration": {
         "request": "launch",
         "protocol": "auto",
-        "stopOnEntry": true,
+        "stopOnEntry": false,
         "console": "integratedTerminal",
         "program": "${workspaceRoot}/test.js",
         "cwd": "${workspaceRoot}"
@@ -26,7 +26,7 @@
       "configuration": {
         "request": "launch",
         "program": "${workspaceRoot}/test.py",
-        "stopOnEntry": true,
+        "stopOnEntry": false,
         "cwd": "${workspaceRoot}"
       },
       "breakpoints": {

--- a/tests/get_configurations.test.vim
+++ b/tests/get_configurations.test.vim
@@ -35,6 +35,7 @@ function! Test_PickConfiguration_FilteredFiletypes()
   let fn = '../support/test/multiple_filetypes/test.js'
   exe 'edit ' . fn
   normal! G
+  call vimspector#SetLineBreakpoint( fn, 1 )
   call vimspector#Launch()
   call WaitForAssert( { ->
         \ vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 1, 1  )
@@ -44,6 +45,7 @@ function! Test_PickConfiguration_FilteredFiletypes()
   let fn = '../support/test/multiple_filetypes/test.py'
   exe 'edit ' . fn
   normal! G
+  call vimspector#SetLineBreakpoint( fn, 1 )
   call vimspector#Launch()
   call WaitForAssert( { ->
         \ vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 1, 1  )

--- a/tests/language_csharp.test.vim
+++ b/tests/language_csharp.test.vim
@@ -60,11 +60,100 @@ function! Test_CSharp_Simple_VimDict_Config()
   \     'adapter': 'test_adapter',
   \     'configuration': {
   \       'request': 'launch',
+  \       'default': v:true,
   \       'program': '${workspaceRoot}/bin/Debug/netcoreapp5.0/csharp.dll',
   \       'args': [],
   \       'stopAtEntry': v:false
   \     }
+  \   },
+  \   'ignored_configuration': { 'adapter': 'does_not_exist' }
+  \ } )
+  call SkipUnsupported()
+  let fn='Program.cs'
+  lcd ../support/test/csharp
+  exe 'edit ' . fn
+
+  call vimspector#SetLineBreakpoint( fn, 31 )
+  call vimspector#LaunchWithSettings(
+        \ { 'configuration': 'test_configuration' } )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 31, 7 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 31 )
+        \ } )
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 32, 12 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 32 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction
+
+function! Test_CSharp_Simple_VimDict_Config_TruthyDefault()
+  call vimspector#test#setup#PushSetting( 'vimspector_adapters', {
+  \   'test_adapter': {
+  \     'extends': 'netcoredbg',
   \   }
+  \ } )
+  call vimspector#test#setup#PushSetting( 'vimspector_configurations', {
+  \   'test_configuration': {
+  \     'adapter': 'test_adapter',
+  \     'configuration': {
+  \       'request': 'launch',
+  \       'default': 1,
+  \       'program': '${workspaceRoot}/bin/Debug/netcoreapp5.0/csharp.dll',
+  \       'args': [],
+  \       'stopAtEntry': v:false
+  \     }
+  \   },
+  \   'ignored_configuration': { 'adapter': 'does_not_exist' }
+  \ } )
+  call SkipUnsupported()
+  let fn='Program.cs'
+  lcd ../support/test/csharp
+  exe 'edit ' . fn
+
+  call vimspector#SetLineBreakpoint( fn, 31 )
+  call vimspector#LaunchWithSettings(
+        \ { 'configuration': 'test_configuration' } )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 31, 7 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 31 )
+        \ } )
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 32, 12 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( fn, 32 )
+        \ } )
+
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction
+
+function! Test_CSharp_Simple_VimDict_Config_Autoselect()
+  call vimspector#test#setup#PushSetting( 'vimspector_adapters', {
+  \   'test_adapter': {
+  \     'extends': 'netcoredbg',
+  \   }
+  \ } )
+  call vimspector#test#setup#PushSetting( 'vimspector_configurations', {
+  \   'test_configuration': {
+  \     'adapter': 'test_adapter',
+  \     'configuration': {
+  \       'request': 'launch',
+  \       'program': '${workspaceRoot}/bin/Debug/netcoreapp5.0/csharp.dll',
+  \       'args': [],
+  \       'stopAtEntry': v:false
+  \     }
+  \   },
+  \   'ignored_configuration': { 'adapter': 'does_not_exist', 'autoselect': 0 }
   \ } )
   call SkipUnsupported()
   let fn='Program.cs'


### PR DESCRIPTION
This makes it easier for people who don't know about v:true/v:false when
writing config in viml. It might be a trap, though probably not.

Fixes #587