### PR TITLE
Add support for vim-repeat

### DIFF
--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -40,16 +40,20 @@ let g:vimspector_home = expand( '<sfile>:p:h:h' )
 
 let s:mappings = get( g:, 'vimspector_enable_mappings', '' )
 
-function! s:set_repeat( map )
+" Let the <Plug>mapping can be repeated with the "." command, it's powered by
+" [repeat.vim](https://github.com/tpope/vim-repeat).
+function! s:SetRepeat( map ) abort
   try
     call repeat#set( a:map )
   catch /^Vim\%((\a\+)\)\=:E117:/
+    " Catch 'E117: Unknown function' exception if the user doesn't have the
+    " 'repeat.vim' installed.
   endtry
 endfunction
 
 nnoremap <silent> <Plug>VimspectorContinue
-      \ :<c-u>call vimspector#Continue()<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorContinue" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorContinue" )<CR>
+      \:<c-u>call vimspector#Continue()<CR>
 nnoremap <silent> <Plug>VimspectorLaunch
       \ :<c-u>call vimspector#Launch( v:true )<CR>
 nnoremap <silent> <Plug>VimspectorStop
@@ -59,45 +63,45 @@ nnoremap <silent> <Plug>VimspectorRestart
 nnoremap <silent> <Plug>VimspectorPause
       \ :<c-u>call vimspector#Pause()<CR>
 nnoremap <silent> <Plug>VimspectorToggleBreakpoint
-      \ :<c-u>call vimspector#ToggleBreakpoint()<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorToggleBreakpoint" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorToggleBreakpoint" )<CR>
+      \:<c-u>call vimspector#ToggleBreakpoint()<CR>
 nnoremap <silent> <Plug>VimspectorToggleConditionalBreakpoint
-      \ :<c-u>call vimspector#ToggleAdvancedBreakpoint()<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorToggleConditionalBreakpoint" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorToggleConditionalBreakpoint" )<CR>
+      \:<c-u>call vimspector#ToggleAdvancedBreakpoint()<CR>
 nnoremap <silent> <Plug>VimspectorAddFunctionBreakpoint
-      \ :<c-u>call vimspector#AddFunctionBreakpoint( expand( '<cexpr>' ) )<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorAddFunctionBreakpoint" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorAddFunctionBreakpoint" )<CR>
+      \:<c-u>call vimspector#AddFunctionBreakpoint( expand( '<cexpr>' ) )<CR>
 nnoremap <silent> <Plug>VimspectorStepOver
-      \ :<c-u>call vimspector#StepOver()<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorStepOver" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorStepOver" )<CR>
+      \:<c-u>call vimspector#StepOver()<CR>
 nnoremap <silent> <Plug>VimspectorStepInto
-      \ :<c-u>call vimspector#StepInto()<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorStepInto" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorStepInto" )<CR>
+      \:<c-u>call vimspector#StepInto()<CR>
 nnoremap <silent> <Plug>VimspectorStepOut
-      \ :<c-u>call vimspector#StepOut()<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorStepOut" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorStepOut" )<CR>
+      \:<c-u>call vimspector#StepOut()<CR>
 
 nnoremap <silent> <Plug>VimspectorRunToCursor
-      \ :<c-u>call vimspector#RunToCursor()<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorRunToCursor" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorRunToCursor" )<CR>
+      \:<c-u>call vimspector#RunToCursor()<CR>
 nnoremap <silent> <Plug>VimspectorGoToCurrentLine
-      \ :<c-u>call vimspector#GoToCurrentLine()<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorGoToCurrentLine" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorGoToCurrentLine" )<CR>
+      \:<c-u>call vimspector#GoToCurrentLine()<CR>
 
 " Eval for normal mode
 nnoremap <silent> <Plug>VimspectorBalloonEval
-      \ :<c-u>call vimspector#ShowEvalBalloon( 0 )<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorBalloonEval" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorBalloonEval" )<CR>
+      \:<c-u>call vimspector#ShowEvalBalloon( 0 )<CR>
 " And for visual modes
 xnoremap <silent> <Plug>VimspectorBalloonEval
-      \ :<c-u>call vimspector#ShowEvalBalloon( 1 )<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorBalloonEval" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorBalloonEval" )<CR>
+      \:<c-u>call vimspector#ShowEvalBalloon( 1 )<CR>
 nnoremap <silent> <Plug>VimspectorUpFrame
-      \ :<c-u>call vimspector#UpFrame()<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorUpFrame" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorUpFrame" )<CR>
+      \:<c-u>call vimspector#UpFrame()<CR>
 nnoremap <silent> <Plug>VimspectorDownFrame
-      \ :<c-u>call vimspector#DownFrame()<CR>
-      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorDownFrame" )<CR>
+      \ :<c-u>call <SID>SetRepeat( "\<Plug>VimspectorDownFrame" )<CR>
+      \:<c-u>call vimspector#DownFrame()<CR>
 
 nnoremap <silent> <Plug>VimspectorBreakpoints
       \ :<c-u>call vimspector#ListBreakpoints()<CR>

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -40,9 +40,16 @@ let g:vimspector_home = expand( '<sfile>:p:h:h' )
 
 let s:mappings = get( g:, 'vimspector_enable_mappings', '' )
 
+function! s:set_repeat( map )
+  try
+    call repeat#set( a:map )
+  catch /^Vim\%((\a\+)\)\=:E117:/
+  endtry
+endfunction
+
 nnoremap <silent> <Plug>VimspectorContinue
       \ :<c-u>call vimspector#Continue()<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorContinue")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorContinue" )<CR>
 nnoremap <silent> <Plug>VimspectorLaunch
       \ :<c-u>call vimspector#Launch( v:true )<CR>
 nnoremap <silent> <Plug>VimspectorStop
@@ -53,45 +60,44 @@ nnoremap <silent> <Plug>VimspectorPause
       \ :<c-u>call vimspector#Pause()<CR>
 nnoremap <silent> <Plug>VimspectorToggleBreakpoint
       \ :<c-u>call vimspector#ToggleBreakpoint()<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorToggleBreakpoint")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorToggleBreakpoint" )<CR>
 nnoremap <silent> <Plug>VimspectorToggleConditionalBreakpoint
       \ :<c-u>call vimspector#ToggleAdvancedBreakpoint()<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorToggleConditionalBreakpoint")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorToggleConditionalBreakpoint" )<CR>
 nnoremap <silent> <Plug>VimspectorAddFunctionBreakpoint
       \ :<c-u>call vimspector#AddFunctionBreakpoint( expand( '<cexpr>' ) )<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorAddFunctionBreakpoint")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorAddFunctionBreakpoint" )<CR>
 nnoremap <silent> <Plug>VimspectorStepOver
       \ :<c-u>call vimspector#StepOver()<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorStepOver")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorStepOver" )<CR>
 nnoremap <silent> <Plug>VimspectorStepInto
       \ :<c-u>call vimspector#StepInto()<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorStepInto")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorStepInto" )<CR>
 nnoremap <silent> <Plug>VimspectorStepOut
       \ :<c-u>call vimspector#StepOut()<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorStepOut")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorStepOut" )<CR>
 
 nnoremap <silent> <Plug>VimspectorRunToCursor
       \ :<c-u>call vimspector#RunToCursor()<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorRunToCursor")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorRunToCursor" )<CR>
 nnoremap <silent> <Plug>VimspectorGoToCurrentLine
       \ :<c-u>call vimspector#GoToCurrentLine()<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorGoToCurrentLine")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorGoToCurrentLine" )<CR>
 
 " Eval for normal mode
 nnoremap <silent> <Plug>VimspectorBalloonEval
       \ :<c-u>call vimspector#ShowEvalBalloon( 0 )<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorBalloonEval")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorBalloonEval" )<CR>
 " And for visual modes
 xnoremap <silent> <Plug>VimspectorBalloonEval
       \ :<c-u>call vimspector#ShowEvalBalloon( 1 )<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorBalloonEval")<CR>
-
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorBalloonEval" )<CR>
 nnoremap <silent> <Plug>VimspectorUpFrame
       \ :<c-u>call vimspector#UpFrame()<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorUpFrame")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorUpFrame" )<CR>
 nnoremap <silent> <Plug>VimspectorDownFrame
       \ :<c-u>call vimspector#DownFrame()<CR>
-      \:<c-u>silent! call repeat#set("\<Plug>VimspectorDownFrame")<CR>
+      \:<c-u>call <SID>set_repeat( "\<Plug>VimspectorDownFrame" )<CR>
 
 nnoremap <silent> <Plug>VimspectorBreakpoints
       \ :<c-u>call vimspector#ListBreakpoints()<CR>

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -42,6 +42,7 @@ let s:mappings = get( g:, 'vimspector_enable_mappings', '' )
 
 nnoremap <silent> <Plug>VimspectorContinue
       \ :<c-u>call vimspector#Continue()<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorContinue")<CR>
 nnoremap <silent> <Plug>VimspectorLaunch
       \ :<c-u>call vimspector#Launch( v:true )<CR>
 nnoremap <silent> <Plug>VimspectorStop
@@ -52,33 +53,45 @@ nnoremap <silent> <Plug>VimspectorPause
       \ :<c-u>call vimspector#Pause()<CR>
 nnoremap <silent> <Plug>VimspectorToggleBreakpoint
       \ :<c-u>call vimspector#ToggleBreakpoint()<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorToggleBreakpoint")<CR>
 nnoremap <silent> <Plug>VimspectorToggleConditionalBreakpoint
       \ :<c-u>call vimspector#ToggleAdvancedBreakpoint()<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorToggleConditionalBreakpoint")<CR>
 nnoremap <silent> <Plug>VimspectorAddFunctionBreakpoint
       \ :<c-u>call vimspector#AddFunctionBreakpoint( expand( '<cexpr>' ) )<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorAddFunctionBreakpoint")<CR>
 nnoremap <silent> <Plug>VimspectorStepOver
       \ :<c-u>call vimspector#StepOver()<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorStepOver")<CR>
 nnoremap <silent> <Plug>VimspectorStepInto
       \ :<c-u>call vimspector#StepInto()<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorStepInto")<CR>
 nnoremap <silent> <Plug>VimspectorStepOut
       \ :<c-u>call vimspector#StepOut()<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorStepOut")<CR>
 
 nnoremap <silent> <Plug>VimspectorRunToCursor
       \ :<c-u>call vimspector#RunToCursor()<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorRunToCursor")<CR>
 nnoremap <silent> <Plug>VimspectorGoToCurrentLine
       \ :<c-u>call vimspector#GoToCurrentLine()<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorGoToCurrentLine")<CR>
 
 " Eval for normal mode
 nnoremap <silent> <Plug>VimspectorBalloonEval
       \ :<c-u>call vimspector#ShowEvalBalloon( 0 )<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorBalloonEval")<CR>
 " And for visual modes
 xnoremap <silent> <Plug>VimspectorBalloonEval
       \ :<c-u>call vimspector#ShowEvalBalloon( 1 )<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorBalloonEval")<CR>
 
 nnoremap <silent> <Plug>VimspectorUpFrame
       \ :<c-u>call vimspector#UpFrame()<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorUpFrame")<CR>
 nnoremap <silent> <Plug>VimspectorDownFrame
       \ :<c-u>call vimspector#DownFrame()<CR>
+      \:<c-u>silent! call repeat#set("\<Plug>VimspectorDownFrame")<CR>
 
 nnoremap <silent> <Plug>VimspectorBreakpoints
       \ :<c-u>call vimspector#ListBreakpoints()<CR>


### PR DESCRIPTION
[vim-repeat](https://github.com/tpope/vim-repeat) is a popular Vim plugin that can use "`.`" to repeat `<Plug>`mappings or commands. I think this usage is very suitable for debuggers. 

This PR adds support for vim-repeat for stepping, breakpoint, frame and eval operations, which are usually used continuously during debugging.