### PR TITLE
Update path to `OpenDebugAD7` in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ Example:
         "pidSelect": "ask"
       },
       "command": [
-        "${gadgetDir}/vscode-cpptools/debugAdapters/OpenDebugAD7"
+        "${gadgetDir}/vscode-cpptools/debugAdapters/bin/OpenDebugAD7"
       ],
       "name": "cppdbg"
     }

--- a/doc/vimspector-ref.txt
+++ b/doc/vimspector-ref.txt
@@ -1013,7 +1013,7 @@ gdbserver and have to tell cpptools a few more options.
     "adapters": {
       "cpptools-remote": {
         "command": [
-          "${gadgetDir}/vscode-cpptools/debugAdapters/OpenDebugAD7"
+          "${gadgetDir}/vscode-cpptools/debugAdapters/bin/OpenDebugAD7"
         ],
         "name": "cppdbg",
         "configuration": {

--- a/doc/vimspector.txt
+++ b/doc/vimspector.txt
@@ -683,7 +683,7 @@ Example:
           "pidSelect": "ask"
         },
         "command": [
-          "${gadgetDir}/vscode-cpptools/debugAdapters/OpenDebugAD7"
+          "${gadgetDir}/vscode-cpptools/debugAdapters/bin/OpenDebugAD7"
         ],
         "name": "cppdbg"
       }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -967,7 +967,7 @@ and have to tell cpptools a few more options.
   "adapters": {
     "cpptools-remote": {
       "command": [
-        "${gadgetDir}/vscode-cpptools/debugAdapters/OpenDebugAD7"
+        "${gadgetDir}/vscode-cpptools/debugAdapters/bin/OpenDebugAD7"
       ],
       "name": "cppdbg",
       "configuration": {


### PR DESCRIPTION
The previous installation path of `OpenDebugAD7` was deprecated after https://github.com/microsoft/vscode-cpptools/pull/7858/.

Related discussion: https://github.com/puremourning/vimspector/discussions/597