### PR TITLE
Add `'file'` autocompletion in AskForInput

### DIFF
--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -610,7 +610,8 @@ def ExpandReferencesInString( orig_s,
               default_value = e.default_value
 
         mapping[ key ] = AskForInput( 'Enter value for {}: '.format( key ),
-                                      default_value )
+                                      default_value,
+                                      'file' )
 
         if mapping[ key ] is None:
           raise KeyboardInterrupt

--- a/tests/python/Test_ExpandReferencesInDict.py
+++ b/tests/python/Test_ExpandReferencesInDict.py
@@ -23,7 +23,7 @@ class TestExpandReferencesInDict( unittest.TestCase ):
       'five': '5ive!'
     }
 
-    def AskForInput( prompt, default_value = None ):
+    def AskForInput( prompt, default_value = None, completion = None ):
       if default_value is not None:
         return default_value
 


### PR DESCRIPTION
Even though we cannot know if the variable is a file, it doesn't hurt to
have autocompletion for the most common type.