### PR TITLE
docs(README): Fix typos and grammar issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Workarounds are in place as follows:
   and [`:VimspectorWatch`](#watches)
 * Balloons - There is the `<Plug>VimspectorBalloonEval` mapping. There is no
 default mapping for this, so I recommend something like this to get variable
-displays in popups:
+display in a popup:
 
 ```viml
 " mnemonic 'di' = 'debug inspect' (pick your own, if you prefer!)
@@ -325,9 +325,9 @@ vim -Nu /path/to/vimspector/tests/vimrc --cmd "let g:vimspector_enable_mappings=
 Then press `<F5>`.
 
 There's also a C++ project in `tests/testdata/cpp/simple/` with a `Makefile`
-which can be used to check if everything is working. This is used by the
-regression tests in CI so it should always work, and is a good way to check if 
-the problem is in your configuration rather than a bug.
+which can be used to check everything is working. This is used by the regression
+tests in CI so should always work, and is a good way to check if the problem is
+your configuration rather than a bug.
 
 ## Cloning the plugin
 
@@ -771,7 +771,7 @@ nmap <Leader>di <Plug>VimspectorBalloonEval
 xmap <Leader>di <Plug>VimspectorBalloonEval
 ```
 
-You may also wish to add mappings for going up/down the stack, for example:
+You may also wish to add mappings for navigating up/down the stack, for example:
 
 ```viml
 nmap <LocalLeader><F11> <Plug>VimspectorUpFrame

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Vimspector requires:
   * macOS Mojave or later
   * Windows (experimental)
 
-Why such a new vim ? Well 2 reasons:
+Why such a new vim? Well 2 reasons:
 
 1. Because vimspector uses a lot of new Vim features
 2. Because there are Vim bugs that vimspector triggers that will frustrate you
@@ -262,7 +262,7 @@ occasionally. Issue reports are handled on best-efforts basis, and PRs are
 welcome to fix bugs. See also the next section describing differences for neovim
 vs vim.
 
-Why Windows support experimental? Because it's effort and it's not a priority
+Why is Windows support experimental? Because it's effort and it's not a priority
 for the author. PRs are welcome to fix bugs. Windows will not be regularly
 tested.
 
@@ -288,7 +288,7 @@ Workarounds are in place as follows:
   and [`:VimspectorWatch`](#watches)
 * Balloons - There is the `<Plug>VimspectorBalloonEval` mapping. There is no
 default mapping for this, so I recommend something like this to get variable
-display in a popup:
+displays in popups:
 
 ```viml
 " mnemonic 'di' = 'debug inspect' (pick your own, if you prefer!)
@@ -325,9 +325,9 @@ vim -Nu /path/to/vimspector/tests/vimrc --cmd "let g:vimspector_enable_mappings=
 Then press `<F5>`.
 
 There's also a C++ project in `tests/testdata/cpp/simple/` with a `Makefile`
-which can be used to check everything is working. This is used by the regression
-tests in CI so should always work, and is a good way to check if the problem is
-your configuration rather than a bug.
+which can be used to check if everything is working. This is used by the
+regression tests in CI so it should always work, and is a good way to check if 
+the problem is in your configuration rather than a bug.
 
 ## Cloning the plugin
 
@@ -365,7 +365,7 @@ let g:vimspector_enable_mappings = 'HUMAN'
 packadd! vimspector
 ```
 
-See support/doc/example_vimrc.vim for a minimal example.
+See `support/doc/example_vimrc.vim` for a minimal example.
 
 ## Install some gadgets
 
@@ -475,7 +475,7 @@ Then add this to your `.vimrc`:
 let g:vimspector_base_dir=expand( '$HOME/.vim/vimspector-config' )
 ```
 
-When usnig `:VimspectorInstall`, the `g:vimspector_base_dir` setting is
+When using `:VimspectorInstall`, the `g:vimspector_base_dir` setting is
 respected unless `--basedir` is manually added (not recommended).
 
 See `--help` for more info on the various options.
@@ -555,7 +555,7 @@ Example:
 The gadget file is automatically written by `install_gadget.py` (or
 `:VimspectorInstall`).
 
-Vimspector will also load any fies matching:
+Vimspector will also load any files matching:
 `</path/to/vimspector>/gadgets/<os>/.gadgets.d/*.json`. These have the same
 format as `.gadgets.json` but are not overwritten when running
 `install_gadget.py`.
@@ -658,7 +658,9 @@ Copyright © 2018 Ben Jackson
 
 ## Sponsorship
 
-If you like Vimspector so much that you're wiling to part with your hard-earned cash, please consider donating to one of the following charities, which are meaningful to the author of Vimspector (in order of preference):
+If you like Vimspector so much that you're wiling to part with your hard-earned
+cash, please consider donating to one of the following charities, which are 
+meaningful to the author of Vimspector (in order of preference):
 
 * [Greyhound Rescue Wales](https://greyhoundrescuewales.co.uk)
 * [Cancer Research UK](https://www.cancerresearchuk.org)
@@ -769,7 +771,7 @@ nmap <Leader>di <Plug>VimspectorBalloonEval
 xmap <Leader>di <Plug>VimspectorBalloonEval
 ```
 
-You may also wish to add mappings for up/down the stack, for example:
+You may also wish to add mappings for going up/down the stack, for example:
 
 ```viml
 nmap <LocalLeader><F11> <Plug>VimspectorUpFrame
@@ -824,8 +826,8 @@ To launch with an ad-hoc config you can use:
 
 * `call vimspector#LaunchWithConfigurations( dict )`
 
-The argument is a `dict` which is the `configurations` section of a .vimspector file
-Pass one configuration in and that will be selected as the one to run.
+The argument is a `dict` which is the `configurations` section of a .vimspector
+file. Pass one configuration in and that will be selected as the one to run.
 For example:
 
 ```viml
@@ -862,7 +864,7 @@ See [the reference guide][vimspector-ref-config-selection] for details.
 
 ### Get configurations
 
-* Use `vimspector#GetConfigurations()` to get a list of configurations for
+* Use `vimspector#GetConfigurations()` to get a list of configurations for the
   filetype of the current buffer
 
 For example, to get an array of configurations and fuzzy matching on the result
@@ -889,9 +891,9 @@ nmap <Leader>db <Plug>VimspectorBreakpoints
 
 The following mappings apply by default in the breakpoints window:
 
-* `t`, `<F9>` - toggle, i.e. enable/dissable breakpoint
-* `T` - toggle, i.e. enable/dissable ALL breakpoints
-* `dd`, `<Del>` - delete the current breakpiont
+* `t`, `<F9>` - toggle, i.e. enable/disable breakpoint
+* `T` - toggle, i.e. enable/disable ALL breakpoints
+* `dd`, `<Del>` - delete the current breakpoint
 * `i`, `a`, `o` - add a new line breakpoint
 * `I`, `A`, `O` - add a new function breakpoint
 * `<Enter>` or double-click - jump to the line breakpoint
@@ -951,7 +953,7 @@ You can configure your choices in the `.vimspector.json`. See
 
 ### API Summary
 
-** NOTE: *** Previously, ToggleBreakpoint would cycle between 3 states:
+***NOTE:*** Previously, ToggleBreakpoint would cycle between 3 states:
 enabled, disabled, deleted. Many users found the 'disabled' state was rarely
 useful, so the behaviour has been changed. ToggleBreakpoint always creates or
 deletes a breakpoint. If you wish to 'disable' breakpoints, use the
@@ -1067,7 +1069,7 @@ autocmd SessionLoadPost * silent! VimspectorLoadSession
   `<leader><CR>` (if `modifyOtherKeys` doesn't work for you)
 * View the type of the variable via mouse hover.
 * When changing the stack frame the locals window updates.
-* While paused, hover to see values
+* While paused, hover to see values.
 
 ![locals window](https://puremourning.github.io/vimspector-web/img/vimspector-locals-window.png)
 
@@ -1144,7 +1146,7 @@ let g:ycm_semantic_triggers =  {
 ## Dump memory
 
 Some debug adapters provide a way to dump process memory associated with
-variables. This can be done from the Variables and Wathces windows with:
+variables. This can be done from the Variables and Watches windows with:
 
 * The WinBar option "Dump"
 * `<leader>m` mapping (by default, can be customised)
@@ -1169,8 +1171,8 @@ supported by the underlying debugger, threads can be paused and continued
 individually from within the Stack Trace window.
 
 A particular thread, highlighted with the `CursorLine` highlight group is the
-"focussed" thread. This is the thread that receives commands like "Stop In",
-"Stop Out", "Continue" and "Pause" in the code window. The focussed thread can
+"focussed" thread. This is the thread that receives commands like "Step In",
+"Step Out", "Continue" and "Pause" in the code window. The focussed thread can
 be changed manually to "switch to" that thread.
 
 * Use `<CR>`, or double-click with left mouse to expand/collapse a thread stack
@@ -1182,7 +1184,7 @@ be changed manually to "switch to" that thread.
   to set the "focussed" thread to the currently selected one. If the selected
   line is a stack frame, set the focussed thread to the thread of that frame and
   jump to that frame in the code window.
-* The current frame when a breakpoint is hit or if manuall jumping is also
+* The current frame when a breakpoint is hit or if manual jumping is also
   highlighted.
 
 ![stack trace](https://puremourning.github.io/vimspector-web/img/vimspector-callstack-window.png)
@@ -1279,7 +1281,7 @@ choose. The same applies for `vimspector#Stop()` which can take an argument:
 For an introduction to the configuration of `.vimspector.json`, take a look at
 the Getting Started section of the [Vimspector website][website].
 
-For full explanation, including how to use variables, substitutions and how to
+For a full explanation, including how to use variables, substitutions and how to
 specify exception breakpoints, see [the docs][vimspector-ref].
 
 The JSON configuration file allows C-style comments:
@@ -1287,7 +1289,7 @@ The JSON configuration file allows C-style comments:
 * `// comment to end of line ...`
 * `/* inline comment ... */`
 
-Current tested with the following debug adapters.
+Currently tested with the following debug adapters.
 
 ## C, C++, Rust, etc.
 
@@ -1396,7 +1398,7 @@ The cpptools documentation describes how to attach cpptools to gdbserver using
 
 ### C++ Remote launch and attach
 
-If you're feeling fancy, checkout the [reference guide][remote-debugging] for
+If you're feeling fancy, check out the [reference guide][remote-debugging] for
 an example of getting Vimspector to remotely launch and attach.
 
 * CodeLLDB (MacOS)


### PR DESCRIPTION
Just made some small edits to the README to fix some typos!