### PR TITLE
Fix variable name mismatch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ For example:
                \    "adapter": "netcoredbg",
                \    "configuration": {
                \      "request": "attach",
-               \      "processId": proc_id
+               \      "processId": pid
                \    }
                \  }
                \})


### PR DESCRIPTION
Example sets variable `pid`, but then uses `proc_id`