### PR TITLE
Enable PID picker injection

### DIFF
--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -435,6 +435,7 @@ class DebugSession( object ):
       # working directory.
       'cwd': os.getcwd,
       'unusedLocalPort': utils.GetUnusedLocalPort,
+      'selectProcess': _SelectProcess,
     }
 
     # Pretend that vars passed to the launch command were typed in by the user
@@ -1596,7 +1597,7 @@ class DebugSession( object ):
       if attach_config[ 'pidSelect' ] == 'ask':
         prop = attach_config[ 'pidProperty' ]
         if prop not in launch_config:
-          pid = utils.AskForInput( 'Enter PID to attach to: ' )
+          pid = _SelectProcess()
           if pid is None:
             return
           launch_config[ prop ] = pid
@@ -2204,3 +2205,10 @@ def PathsToAllConfigFiles( vimspector_base, current_file, filetypes ):
 
   yield utils.PathToConfigFile( '.vimspector.json',
                                 os.path.dirname( current_file ) )
+
+
+def _SelectProcess():
+  custom_picker = settings.Get( 'custom_process_picker_expr' )
+  if custom_picker:
+    return int( vim.eval( custom_picker ) )
+  return int( utils.AskForInput( 'Enter Process ID: ' ) )

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -109,7 +109,7 @@ DEFAULTS = {
 
   # Custom
   'java_hotcodereplace_mode': 'ask',
-  'custom_process_picker_expr': '',
+  'custom_process_picker_func': '',
 
   # Debug configs
   'adapters': {},

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -109,6 +109,7 @@ DEFAULTS = {
 
   # Custom
   'java_hotcodereplace_mode': 'ask',
+  'custom_process_picker_expr': '',
 
   # Debug configs
   'adapters': {},

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -583,7 +583,9 @@ VAR_MATCH = re.compile(
     \$(?:                               # A dollar, followed by...
       (?P<escaped>\$)                |  # Another dollar = escaped
       (?P<named>[_a-z][_a-z0-9]*)    |  # or An identifier - named param
-      {(?P<braced>[_a-z][_a-z0-9]*)} |  # or An {identifier} - braced param
+                # or An {identifier} - braced param
+                # or An {identifier([arg,...])} - braced calculus call
+      {(?P<braced>[_a-z][_a-z0-9]*)(?:\((?P<args>[^\)]*)\))?} |
       {(?P<braceddefault>               # or An {id:default} - default param, as
         (?P<defname>[_a-z][_a-z0-9]*)   #   an ID
         :                               #   then a colon
@@ -596,19 +598,42 @@ VAR_MATCH = re.compile(
 
 
 class MissingSubstitution( Exception ):
-  def __init__( self, name, default_value = None ):
+  def __init__( self, name, default_value = None, args = (), arg_hash = '' ):
     self.name = name
     self.default_value = default_value
+    self.args = args
+    self.arg_hash = arg_hash
 
 
 def _Substitute( template, mapping ):
   def convert( mo ):
     # Check the most common path first.
+    args: str = mo.group( 'args' )
+    if args is None:
+      args = ()
+      arg_hash = ''
+    else:
+      # The args string must be the "internal" json of a list
+      # The key in mapping is just the calculus function a hash of the string
+      # representation of the arguments. This is important because things like
+      # unusedLocalPort should always return the same value. As a consequence
+      # multiple "calls" to the same calculus function with the same arguments
+      # only trigger one actual call.. shrug?
+      arg_hash = str( hash( args ) )
+      args = ( arg for arg in json.loads( "[" + args + "]" ) )
+
     named = mo.group( 'named' ) or mo.group( 'braced' )
     if named is not None:
-      if named not in mapping:
-        raise MissingSubstitution( named )
-      return str( mapping[ named ] )
+      if named + arg_hash not in mapping:
+        raise MissingSubstitution( named,
+                                   args = args,
+                                   arg_hash = arg_hash )
+
+      _logger.debug( "Returning %s from the map for %s with args %s",
+                     named + arg_hash,
+                     named,
+                     args )
+      return str( mapping[ named + arg_hash ] )
 
     if mo.group( 'escaped' ) is not None:
       return '$'
@@ -618,7 +643,7 @@ def _Substitute( template, mapping ):
       if named not in mapping:
         raise MissingSubstitution(
           named,
-          mo.group( 'default' ).replace( '\\}', '}' ) )
+          default_value = mo.group( 'default' ).replace( '\\}', '}' ) )
       return str( mapping[ named ] )
 
     if mo.group( 'invalid' ) is not None:
@@ -638,19 +663,25 @@ def ExpandReferencesInString( orig_s,
 
   # Parse any variables passed in in mapping, and ask for any that weren't,
   # storing the result in mapping
-  bug_catcher = 0
-  while bug_catcher < 100:
-    ++bug_catcher
-
+  while True:
     try:
       s = _Substitute( s, mapping )
       break
     except MissingSubstitution as e:
-      key = e.name
+      key = e.name + e.arg_hash
 
-      if key in calculus:
-        mapping[ key ] = calculus[ key ]()
+      if e.name in calculus:
+        mapping[ key ] = calculus[ e.name ]( *e.args )
+        _logger.debug( "Put %s into mapping for %s with args %s",
+                       key,
+                       e.name,
+                       e.args )
+      elif e.args:
+        raise ValueError( f"Invalid arguments '{ e.args }' supplied for named "
+                          f"variable '{ e.name }'. This varibale does not take "
+                          "formal arguments" )
       else:
+        assert key == e.name
         default_value = user_choices.get( key )
         # Allow _one_ level of additional substitution. This allows a very real
         # use case of "program": ${program:${file\\}}

--- a/support/custom_process_picker_fzf.vim
+++ b/support/custom_process_picker_fzf.vim
@@ -1,0 +1,22 @@
+scriptencoding utf-8
+
+let cpo = &cpo
+set cpo&
+
+" Custom process picker {{{
+
+function! PickProcessWithFzf( ... ) abort
+  if a:0 == 0
+    let source = 'ps -e'
+  else
+    let source = 'ps -e | grep ' .. a:1
+  endif
+
+  return split( fzf#run( fzf#wrap( { 'source': source }, 1 ) )[ 0 ] )[ 0 ]
+endfunction
+
+let g:vimspector_custom_process_picker_func = 'PickProcessWithFzf'
+
+" }}}
+
+let &cpo=cpo

--- a/support/test/cpp/simple_c_program/.vimspector.json
+++ b/support/test/cpp/simple_c_program/.vimspector.json
@@ -87,6 +87,12 @@
         "stopAtEntry": true,
         "MIMode": "gdb"
       }
+    },
+    "cpptools-attach": {
+      "extends": "cpptools",
+      "configuration": {
+        "request": "attach"
+      }
     }
   }
 }

--- a/tests/pidpickerinjection.test.vim
+++ b/tests/pidpickerinjection.test.vim
@@ -1,0 +1,27 @@
+function! SetUp()
+  call vimspector#test#setup#SetUpWithMappings( v:null )
+endfunction
+
+function! TearDown()
+  call vimspector#test#setup#TearDown()
+endfunction
+
+function! Test_PID_Picker()
+  let fn='test_c.cpp'
+  lcd ../support/test/cpp/simple_c_program
+  exe 'edit ' . fn
+
+  function! PickProcess() abort
+    let s:process_picker_called = v:true
+    return 12345 " doesn't matter
+  endfunction
+  let g:vimspector_custom_process_picker_expr = 'PickProcess()'
+
+  let s:process_picker_called = v:false
+  call vimspector#LaunchWithSettings( { 'configuration': 'cpptools-attach' } )
+  call assert_true(s:process_picker_called)
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction

--- a/tests/pidpickerinjection.test.vim
+++ b/tests/pidpickerinjection.test.vim
@@ -6,7 +6,11 @@ function! TearDown()
   call vimspector#test#setup#TearDown()
 endfunction
 
-function! Test_PID_Picker()
+function! Test_PID_Picker_NotCalled_NoArguments_BuiltInPidSelect()
+  " Mock AskForInput and do same as below to prove the case where it's not set
+endfunction
+
+function! Test_PID_Picker_Called_NoArguments_BuiltInPidSelect_RetInt()
   let fn='test_c.cpp'
   lcd ../support/test/cpp/simple_c_program
   exe 'edit ' . fn
@@ -15,13 +19,39 @@ function! Test_PID_Picker()
     let s:process_picker_called = v:true
     return 12345 " doesn't matter
   endfunction
-  let g:vimspector_custom_process_picker_expr = 'PickProcess()'
+  let g:vimspector_custom_process_picker_func = 'PickProcess'
 
   let s:process_picker_called = v:false
   call vimspector#LaunchWithSettings( { 'configuration': 'cpptools-attach' } )
-  call assert_true(s:process_picker_called)
+  call assert_true( s:process_picker_called )
   call vimspector#test#setup#Reset()
 
   lcd -
   %bwipeout!
+endfunction
+
+function! Test_PID_Picker_Called_NoArguments_BuiltInPidSelect_RetStr()
+  let fn='test_c.cpp'
+  lcd ../support/test/cpp/simple_c_program
+  exe 'edit ' . fn
+
+  function! PickProcess() abort
+    let s:process_picker_called = v:true
+    return '12345' " doesn't matter
+  endfunction
+  let g:vimspector_custom_process_picker_func = 'PickProcess'
+
+  let s:process_picker_called = v:false
+  call vimspector#LaunchWithSettings( { 'configuration': 'cpptools-attach' } )
+  call assert_true( s:process_picker_called )
+  call vimspector#test#setup#Reset()
+
+  lcd -
+  %bwipeout!
+endfunction
+
+function! Test_PID_Picker_Called_NoArguments_FromCalculus()
+endfunction
+
+function! Test_PID_Picker_Called_WithArguments_FromCalculus()
 endfunction


### PR DESCRIPTION
Fundamentally, this is the code you sketched.

I'm not sure how to test it. I guess by inspection we can be sure it doesn't alter the current behavior.

Whether a customization actually works I guess is another story. But that's maybe ok, as in, the user has to make sure to write an appropriate function to make it work.

Anyway, I have this in my vimrc to make use of it:
```
let g:vimspector_custom_process_picker = 'PickProcess()'

function! PickProcess() abort
  return str2nr(split(fzf#run({'source': 'ps -e'})[0])[0])
endfunction
```
which I think could go in an example in the doc.

If you are happy with it, I can do it.


TODO:

* [ ] docs
* [ ] tests for attachment