### PR TITLE
Fix type error in configuration example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,8 +136,8 @@ But for now, consider the following example snippet:
       },
       "configuration": {
         "request": "launch" /* or it could be "attach" */,
-        "program": [
-          "${fileBasenameNoExtension}",
+        "program": "${fileBasenameNoExtension}",
+        "args": [
           "-c", "configuration_file.cfg",
           "-u", "${USER}",
           "--test-identifier", "${TestIdentifier}",


### PR DESCRIPTION
The value of `configurations.<config-name>.configuration.program` must have type string and should only be the executable. Arguments are passed via the value of `configurations.<config-name>.configuration.args`.