### PR TITLE
avoid unnecessary string concat

### DIFF
--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -506,7 +506,7 @@ function! vimspector#CompleteOutput( ArgLead, CmdLine, CursorPos ) abort
   endif
   let buffers = py3eval( '_vimspector_session.GetOutputBuffers() '
                        \ . ' if _vimspector_session else []' )
-  return join( buffers, "\n" )
+  return buffers
 endfunction
 
 function! vimspector#CompleteExpr( ArgLead, CmdLine, CursorPos ) abort

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -144,7 +144,7 @@ endif
 command! -bar -nargs=1 -complete=custom,vimspector#CompleteExpr
       \ VimspectorWatch
       \ call vimspector#AddWatch( <f-args> )
-command! -bar -nargs=? -complete=custom,vimspector#CompleteOutput
+command! -bar -nargs=? -complete=customlist,vimspector#CompleteOutput
       \ VimspectorShowOutput
       \ call vimspector#ShowOutput( <f-args> )
 command! -bar


### PR DESCRIPTION
## About this PR
- I've searched for `vimspector#CompleteOutput` and didn't find other references.
- As [this line](https://github.com/puremourning/vimspector/blob/3378018bc1cdd1d9b70734c3e970bc52fd983415/python3/vimspector/output.py#L60) indicates, `vimspector#CompleteOutput` won't return a list with items not an instance of string; hence nothing will be ignored by `customlist`
- I've tested this by command `:VimspectorShowOutput` **_on Vim 8.2 only, and I don't use neovim_**

## About RFC
I'm thinking of another feature which will be based on this PR, but not related to the title. So I'm concealing below.
<details>

I would like to add a command `VimspectorShowBuffer` which allows one to faster switch faster among all the buffers.
In order to do this, I'm considering making use of `vimspector#CompleteOutput()` and `g:vimspector_session_windows` to be the completion of the new command.
</details>