### PR TITLE
Don't open message box for gVim when no Python 3

### DIFF
--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -15,7 +15,7 @@
 
 if !has( 'python3' )
   echohl WarningMsg
-  echom 'Vimspector unavailable: Requires Vim compiled with +python3'
+  autocmd VimEnter * ++once echom 'Vimspector unavailable: Requires Vim compiled with +python3'
   echohl None
   finish
 endif
@@ -206,4 +206,3 @@ augroup END
 " boilerplate {{{
 call s:restore_cpo()
 " }}}
-


### PR DESCRIPTION
Opening gVim without Python 3 on Windows causes a very irritating message box to appear. Guarding the `echom` with autocommand ensures the warning to be displayed in command line as intended.