### PR TITLE
Instruction breakpoints

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,6 +46,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: 'Install requirements'
+      run: pip3 install --user -r dev_requirements.txt
+
     - run: |
         go install github.com/go-delve/delve/cmd/dlv@latest
       name: 'Install Delve for Go'
@@ -69,7 +72,7 @@ jobs:
 
     - name: "Upload test logs"
       uses: actions/upload-artifact@v2
-      if: failure()
+      if: success() || failure()
       with:
         name: 'test-logs-${{ runner.os }}-${{ matrix.runtime }}'
         path: 'tests/logs/**/*'
@@ -105,6 +108,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: 'Install requirements'
+      run: pip3 install --user -r dev_requirements.txt
+
     - run: |
         brew update-reset
         brew doctor || true
@@ -135,7 +141,8 @@ jobs:
     - run: ${{ matrix.runtime }} --version
       name: 'Print vim version information'
 
-    - run: ./run_tests --exe ${{ matrix.runtime }} --basedir $(pwd) --install --update --report messages --quiet
+    - run: |
+        ./run_tests --exe ${{ matrix.runtime }} --basedir $(pwd) --install --update --report messages --quiet
       name: 'Run the tests'
       id: run_tests
       env:
@@ -143,7 +150,7 @@ jobs:
 
     - name: "Upload test logs"
       uses: actions/upload-artifact@v2
-      if: failure()
+      if: success() || failure()
       with:
         name: 'test-logs-${{ runner.os }}-${{ matrix.runtime }}'
         path: 'tests/logs/**/*'

--- a/README.md
+++ b/README.md
@@ -21,14 +21,12 @@ For detailed explanation of the `.vimspector.json` format, see the
     * [Trying it out](#trying-it-out)
     * [Cloning the plugin](#cloning-the-plugin)
     * [Install some gadgets](#install-some-gadgets)
-       * [VimspectorInstall and VimspectorUpdate commands](#vimspectorinstall-and-vimspectorupdate-commands)
-       * [install_gadget.py](#install_gadgetpy)
     * [Manual gadget installation](#manual-gadget-installation)
        * [The gadget directory](#the-gadget-directory)
     * [Upgrade](#upgrade)
  * [About](#about)
     * [Background](#background)
-    * [What vimspector is not](#what-vimspector-is-not)
+ * [What Vimspector is not](#what-vimspector-is-not)
     * [Status](#status)
        * [Experimental](#experimental)
     * [Motivation](#motivation)
@@ -48,14 +46,17 @@ For detailed explanation of the `.vimspector.json` format, see the
        * [Conditional breakpoints and logpoints](#conditional-breakpoints-and-logpoints)
        * [Exception breakpoints](#exception-breakpoints)
        * [API Summary](#api-summary)
+       * [Instruction breakpoints](#instruction-breakpoints)
        * [Clear breakpoints](#clear-breakpoints)
        * [Run to Cursor](#run-to-cursor)
+       * [Go to current line](#go-to-current-line)
        * [Save and restore](#save-and-restore)
     * [Stepping](#stepping)
     * [Variables and scopes](#variables-and-scopes)
     * [Variable or selection hover evaluation](#variable-or-selection-hover-evaluation)
     * [Watches](#watches)
        * [Watch autocompletion](#watch-autocompletion)
+    * [Disassembly](#disassembly)
     * [Dump memory](#dump-memory)
     * [Stack Traces](#stack-traces)
     * [Program Output](#program-output)
@@ -74,6 +75,7 @@ For detailed explanation of the `.vimspector.json` format, see the
     * [Python](#python)
        * [Python Remote Debugging](#python-remote-debugging)
        * [Python Remote launch and attach](#python-remote-launch-and-attach)
+       * [Python 2](#python-2)
     * [TCL](#tcl)
     * [C♯](#c)
     * [Go](#go)
@@ -98,7 +100,7 @@ For detailed explanation of the `.vimspector.json` format, see the
     * [Example](#example)
  * [FAQ](#faq)
 
-<!-- Added by: ben, at: Sat  5 Mar 2022 18:59:09 GMT -->
+<!-- Added by: ben, at: Fri 21 Oct 2022 22:27:24 BST -->
 
 <!--te-->
 
@@ -1016,6 +1018,28 @@ Examples:
 * `VimspectorLoadSession` - read `.vimspector.session`
 * `VimspectorMkSession my_session_file` - create `my_session_file`
 * `VimspectorLoadSession my_session_file` - read `my_session_file`
+
+### Instruction breakpoints
+
+**NOTE**: Experimental feature, which may change significantly in future based
+on user feedback.
+
+Instruction breakpoints can be added from the [disassembly window](#disassembly)
+in the same way that you add [line breakpoints](#line-breakpoints) in the code
+window. The same mappings and functions work for adding and toggling them. Where
+supported by the debug adapter, you can even create logpoints and conditional
+breakpoints this way.
+
+Currently, instruction breakpoints are internally modelled as line breakpoints
+against the buffer containing the disassembly, but that may change in future, so
+please don't rely on this.
+
+Instruction breakpoints are also visible from and can be deleted/disabled from
+the [breakpoints window](#breakpoints-window).
+
+Currently, instruction breakpoints are automatically cleared when the debug
+session ends. The reason for this is that the addresses can't be guaranteed to
+be valid for any other debug session. However, this may also change in future. 
 
 ### Clear breakpoints
 

--- a/compiler/vimspector_test.vim
+++ b/compiler/vimspector_test.vim
@@ -36,6 +36,11 @@ if ! exists( ':' . s:make_cmd )
   let s:make_cmd = 'make'
 endif
 
+let s:standard_test_args = ' --quick --report messages '
+if has( 'nvim' )
+  let s:standard_test_args .= ' --exe nvim '
+endif
+
 function! VimGetCurrentFunction()
   echom s:GetCurrentFunction()[ 0 ]
 endfunction
@@ -127,7 +132,8 @@ function! s:RunTestUnderCursor()
   let l:cwd = getcwd()
   execute 'lcd ' . s:root_dir
   try
-    execute s:make_cmd . ' --report messages '
+    execute s:make_cmd
+          \ . s:standard_test_args
           \ . get( g:, 'vimspector_test_args', '' ) . ' '
           \ . l:test_arg
   finally
@@ -140,7 +146,8 @@ function! s:RunTest()
   let l:cwd = getcwd()
   execute 'lcd ' . s:root_dir
   try
-    execute s:make_cmd . ' --report messages '
+    execute s:make_cmd
+          \ . s:standard_test_args
           \ . get( g:, 'vimspector_test_args', '' )
           \ . ' %:p:t'
   finally
@@ -153,7 +160,8 @@ function! s:RunAllTests()
   let l:cwd = getcwd()
   execute 'lcd ' . s:root_dir
   try
-    execute s:make_cmd . ' --report messages '
+    execute s:make_cmd
+          \ . s:standard_test_args
           \ . get( g:, 'vimspector_test_args', '' )
   finally
     execute 'lcd ' . l:cwd

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,11 @@
-flake8==3.8.3
-flake8-comprehensions==3.2.3
-flake8-ycm>= 0.1.0
+flake8                  == 3.8.3
+flake8-comprehensions   == 3.2.3
+flake8-ycm              >= 0.1.0
+
+# asciinema is used to record the output in case of failure
+# asciinema               >= 2.2.0
+# use a fork which returns the exit code of child
+git+https://github.com/puremourning/asciinema@exit_code#egg=asciinema
 
 # Use fork of vint which is up to date
 git+https://github.com/puremourning/vint

--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -544,6 +544,11 @@ class ProjectBreakpoints( object ):
       'state': 'ENABLED',
       'line': line,
       'options': options,
+      # FIXME: This is crap. We should have a proper model for instruction
+      # breakpoints where we store the address rather than the "line number".
+      # We already have all of the plumbing to do that (give or take), but it
+      # requirs some refactoring and not deleting all the instruction
+      # breakpoints on server close
       'is_instruction_breakpoint': is_instruction_breakpoint,
       # 'sign_id': <filled in when placed>,
       #

--- a/python3/vimspector/disassembly.py
+++ b/python3/vimspector/disassembly.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import logging
 
 import vim
@@ -24,10 +23,12 @@ SIGN_ID = 1
 
 
 class DisassemblyView( object ):
-  def __init__( self, window, connection, api_prefix ):
+  def __init__( self, window, connection, api_prefix, render_event_emitter ):
     self._logger = logging.getLogger( __name__ )
     utils.SetUpLogging( self._logger )
 
+    self._render_emitter = render_event_emitter
+    self._render_emitter.subscribe( self._DisplayPC )
     self._window = window
     # Initially we don't care about the buffer. We only update it when we have
     # one crated from the request.
@@ -69,6 +70,8 @@ class DisassemblyView( object ):
   def ConnectionUp( self, connection ):
     self._connection = connection
 
+  def ConnectionClosed( self ):
+    self._connection = None
 
   def WindowIsValid( self ):
     return self._window is not None and self._window.valid
@@ -112,27 +115,70 @@ class DisassemblyView( object ):
       }
     } )
 
-    # TODO: Window scrolled autocommand to update ?
-
 
   def Clear( self ):
     self._UndisplayPC()
-    self._buf = None
+
+    with utils.ModifiableScratchBuffer( self._buf ):
+      utils.ClearBuffer( self._buf )
+
     self.current_frame = None
     self.current_instructions = None
-
-    with utils.ModifiableScratchBuffer( self._window.buffer ):
-      utils.ClearBuffer( self._window.buffer )
 
 
   def Reset( self ):
     self.Clear()
-
+    self._buf = None
     for b in self._scratch_buffers:
       utils.CleanUpHiddenBuffer( b )
 
     self._scratch_buffers = []
 
+
+  def IsDisassemblyBuffer( self, file_name ):
+    if not self._buf:
+      return False
+    return ( utils.NormalizePath( file_name ) ==
+                utils.NormalizePath( self._buf.name ) )
+
+  def GetMemoryReference( self ):
+    return self._instructionPointerReference
+
+  def GetOffsetForLine( self, line_num ):
+    if line_num <= 0 or line_num > self.instruction_count:
+      return None
+
+    # Offset is in bytes
+    pc = utils.ParseAddress(
+      self.current_instructions[ self._GetPCEntryOffset() ][ 'address' ] )
+    req = utils.ParseAddress(
+      self.current_instructions[ line_num - 1 ][ 'address' ] )
+    return req - pc
+
+  def ResolveAddressAtLine( self, line_num ):
+    if line_num <= 0 or line_num > self.instruction_count:
+      return None
+
+    return utils.ParseAddress(
+      self.current_instructions[ line_num - 1 ][ 'address' ] )
+
+  def FindLineForAddress( self, address ):
+    if not self.current_instructions:
+      return 0
+
+    for index, instruction in enumerate( self.current_instructions ):
+      the_addr = utils.ParseAddress( instruction[ 'address' ] )
+      if the_addr == address:
+        return index + 1
+    return 0
+
+  def _GetPCEntryOffset( self ):
+    return -self.instruction_offset
+
+  def GetBufferName( self ):
+    if not self._buf:
+      return None
+    return self._buf.name
 
   def _DrawInstructions( self, should_jump_to_location ):
     if not self._window.valid:
@@ -141,10 +187,7 @@ class DisassemblyView( object ):
     if not self.current_instructions:
       return
 
-    buf_name = os.path.join(
-      '_vimspector_disassembly',
-      self.current_frame[ 'instructionPointerReference' ] )
-
+    buf_name = '_vimspector_disassembly'
     file_name = ( self.current_frame.get( 'source' ) or {} ).get( 'path' ) or ''
     self._buf = utils.BufferForFile( buf_name )
 
@@ -174,14 +217,43 @@ class DisassemblyView( object ):
       utils.SetUpUIWindow( self._window )
       self._window.options[ 'signcolumn' ] = 'yes'
 
-    self._DisplayPC( buf_name )
+    # Re-render and re-calcaulte breakpoints
+    #
+    # TODO: If instruction breakpoints are persisted across runs, their
+    # addresses might be resolvable now that we've just got the disassembly.
+    #
+    # But this call won't actually _send_ any breakpoints to the server. THis
+    # means that they don't persist properly until you do something which
+    # triggers the breakpoints code to re-send all the breakpoints.
+    #
+    # Anyway, that complexity is why we always clear instruction breakpoints
+    # at the end of sessions.
+    self._render_emitter.emit()
 
-    if should_jump_to_location:
-      utils.JumpToWindow( self._window )
+    try:
+      if should_jump_to_location:
+        utils.JumpToWindow( self._window )
+        utils.SetCursorPosInWindow( self._window,
+                                    self._GetPCEntryOffset() + 1,
+                                    1,
+                                    make_visible = True )
+      else:
+        with utils.RestoreCursorPosition():
+          utils.SetCursorPosInWindow( self._window,
+                                      self._GetPCEntryOffset() + 1,
+                                      1,
+                                      make_visible = True )
+    except vim.error as e:
+      utils.UserMessage( f"Failed to set cursor position for disassembly: {e}",
+                         error = True )
 
 
-  def _DisplayPC( self, buf_name ):
+
+  def _DisplayPC( self ):
     self._UndisplayPC()
+
+    if not self._connection or not self._buf or not self.current_instructions:
+      return
 
     if len( self.current_instructions ) < self.instruction_count:
       self._logger.warn( "Invalid number of instructions returned by adapter: "
@@ -192,22 +264,13 @@ class DisassemblyView( object ):
 
     # otherwise, the current instruction is defined as the one we asked for,
     # accounting for any offset we asked for (note, 1-based line number)
-    self._signs[ 'vimspectorPC' ] = SIGN_ID
-    pc_line = -self.instruction_offset + 1
+    self._signs[ 'vimspectorPC' ] = SIGN_ID * 92
+    pc_line = self._GetPCEntryOffset() + 1
     signs.PlaceSign( self._signs[ 'vimspectorPC' ],
                      'VimspectorDisassembly',
                      'vimspectorPC',
-                     buf_name,
+                     self._buf.name,
                      pc_line )
-
-    try:
-      utils.SetCursorPosInWindow( self._window,
-                                  pc_line,
-                                  1,
-                                  make_visible = True )
-    except vim.error as e:
-      utils.UserMessage( f"Failed to set cursor position for disassembly: {e}",
-                         error = True )
 
 
   def _UndisplayPC( self ):

--- a/python3/vimspector/disassembly.py
+++ b/python3/vimspector/disassembly.py
@@ -204,9 +204,11 @@ class DisassemblyView( object ):
     utils.SetUpHiddenBuffer( self._buf, buf_name )
     instruction_bytes_len = max( len( i.get( 'instructionBytes', '' ) )
                                  for i in self.current_instructions )
+    if not instruction_bytes_len:
+      instruction_bytes_len = 1
     with utils.ModifiableScratchBuffer( self._buf ):
       utils.SetBufferContents( self._buf, [
-        f"{ utils.Hex( utils.ParseAddress( i['address'] ) )}:\t"
+        f"{ utils.Hex( utils.ParseAddress( i['address'] ) ) }:\t"
         f"{ i.get( 'instructionBytes', '' ):{instruction_bytes_len}}\t"
         f"{ i[ 'instruction' ] }"
           for i in self.current_instructions

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -48,9 +48,10 @@ SetUpLogging( _logger )
 
 
 def BufferNumberForFile( file_name, create = True ):
-  return int( vim.eval( "bufnr( '{0}', {1} )".format(
-    Escape( file_name ),
-    int( create ) ) ) )
+  with NoAutocommands():
+    return int( vim.eval( "bufnr( '{0}', {1} )".format(
+      Escape( file_name ),
+      int( create ) ) ) )
 
 
 def BufferForFile( file_name ):
@@ -962,12 +963,22 @@ def Base64ToHexDump( data, base_addr ):
 
 
 def ParseAddress( addr: str ):
+  if not addr:
+    return 0
+
   base = 10
   if addr.startswith( '0x' ):
     base = 16
-  return int( addr, base )
+
+  try:
+    return int( addr, base )
+  except ValueError:
+    return 0
 
 
 def Hex( val: int ):
   # TODO: is 16 always the right number ? what if your system is 32 bit
-  return f'0x{val:0>16x}'
+  try:
+    return f'0x{val:0>16x}'
+  except ValueError:
+    return f'0x{0:0>16x}'

--- a/run_tests
+++ b/run_tests
@@ -13,6 +13,9 @@ INSTALL=0
 UPDATE=0
 INSTALLER_ARGS=''
 VIM_EXE='vim'
+SCREENCOLS=160
+SCREENROWS=48
+ASCIINEMA="python3 -m asciinema"
 
 # 1 is stdout
 out_fd=1
@@ -106,7 +109,11 @@ IS_NVIM=$($VIM_EXE --version | grep -cm1 NVIM)
 VERSION_OPTIONS=$([ "$IS_NVIM" -ne 0 ] && echo '--headless' || echo '--not-a-term')
 
 RUN_VIM="${VIM_EXE} -N --clean ${VERSION_OPTIONS}"
-RUN_TEST="${RUN_VIM} -S lib/run_test.vim"
+
+# There seems to be a race condition with the way asciinema sets the pty size.
+# It does fork() then if is_child: execvpe(...) else: set_pty_size(). This means
+# the child might read the pty size before it's set. So we use a 1s sleepy.
+RUN_TEST="sleep 1 && ${RUN_VIM} -S lib/run_test.vim"
 
 # We use fd 3 for vim's output. Send it to stdout if not already redirected
 # Note: can't use ${out_fd} in a redirect because redirects happen before
@@ -255,10 +262,11 @@ for t in ${TESTS}; do
   TESTLOGDIR=${BASEDIR}/tests/logs/$t
 
   pushd ${TESTDIR} > /dev/null
-    if ${RUN_TEST} --cmd "${BASEDIR_CMD}" \
-                   --cmd 'au SwapExists * let v:swapchoice = "e"' $tt $T \
-                   >&3\
-       && [ -f $t.res ];  then
+    RUN="${RUN_TEST} --cmd \"${BASEDIR_CMD}\" \
+                     --cmd 'au SwapExists * let v:swapchoice = \"e\"'\
+                     $tt $T"
+
+    if ${ASCIINEMA} rec -q --cols $SCREENCOLS --rows $SCREENROWS --overwrite --command "${RUN}" $t.cast >&3 && [ -f $t.res ];  then
       echo "%PASS: $t PASSED"
     else
       echo "%FAIL: $t FAILED - see $TESTLOGDIR"
@@ -280,6 +288,7 @@ for t in ${TESTS}; do
       fi
     fi
 
+    mv $t.cast $TESTLOGDIR
     for l in messages debuglog test.log *.testlog; do
       # In CI we can't view the output files, so we just have to cat them
       if [ -f $l ]; then

--- a/run_tests
+++ b/run_tests
@@ -50,6 +50,15 @@ while [ -n "$1" ]; do
       VIM_EXE=$1
       shift
       ;;
+    "--failfast")
+      shift
+      export TEST_NO_RETRY=1
+      ;;
+    "--quick")
+      shift
+      export TEST_NO_RETRY=1
+      SKIP_BUILD=1
+      ;;
     "--skip-build")
       shift
       SKIP_BUILD=1
@@ -63,10 +72,6 @@ while [ -n "$1" ]; do
       out_fd=3
       exec 3>/dev/null
       INSTALLER_ARGS="${INSTALLER_ARGS} --quiet"
-      ;;
-    "--quick"|"--failfast")
-      shift
-      export TEST_NO_RETRY=1
       ;;
     "--gdb")
       shift
@@ -219,7 +224,8 @@ else
   echo "%SETUP - Building test programs..."
   set -e
     pushd tests/testdata/cpp/simple
-      make clean all
+      make clean
+      make -j all
     popd
     pushd support/test/csharp
       dotnet build

--- a/run_tests
+++ b/run_tests
@@ -61,6 +61,18 @@ while [ -n "$1" ]; do
       exec 3>/dev/null
       INSTALLER_ARGS="${INSTALLER_ARGS} --quiet"
       ;;
+    "--quick"|"--failfast")
+      shift
+      export TEST_NO_RETRY=1
+      ;;
+    "--gdb")
+      shift
+      export VIMSPECTOR_MIMODE=gdb
+      ;;
+    "--lldb")
+      shift
+      export VIMSPECTOR_MIMODE=lldb
+      ;;
     "--")
       shift
       break
@@ -119,14 +131,24 @@ else
 fi
 
 if [ -z "$VIMSPECTOR_MIMODE" ]; then
-  if which lldb >/dev/null 2>&1; then
-    export VIMSPECTOR_MIMODE=lldb
-  elif which gdb >/dev/null 2>&1; then
-    export VIMSPECTOR_MIMODE=gdb
-  else
-    echo "Couldn't guess VIMSPECTOR_MIMODE. Need lldb or gdb in path"
-    exit 1
-  fi
+  case $(uname) in
+    Linux)
+      export VIMSPECTOR_MIMODE=gdb
+      ;;
+    Darwin)
+      export VIMSPECTOR_MIMODE=lldb
+      ;;
+    *)
+      if which lldb-mi >/dev/null 2>&1; then
+        export VIMSPECTOR_MIMODE=lldb
+      elif which gdb >/dev/null 2>&1; then
+        export VIMSPECTOR_MIMODE=gdb
+      else
+        echo "Couldn't guess VIMSPECTOR_MIMODE. Specify --gdb/--lldb"
+        exit 1
+      fi
+      ;;
+  esac
 fi
 
 if [ -z "$VIMSPECTOR_ARCH" ]; then
@@ -137,6 +159,7 @@ if [ -z "$VIMSPECTOR_ARCH" ]; then
 fi
 
 BASEDIR_CMD="let g:vimspector_base_dir='${BASEDIR}'"
+TESTDIR=$(readlink -f "$(dirname $0)/tests")
 
 echo "Testing with:"
 echo " * VIMSPECTOR_MIMODE=$VIMSPECTOR_MIMODE"
@@ -145,6 +168,7 @@ echo " * RUN_VIM=$RUN_VIM"
 echo " * RUN_TEST=$RUN_TEST"
 echo " * BASEDIR=$BASEDIR"
 echo " * BASEDIR_CMD=$BASEDIR_CMD"
+echo " * TESTDIR=$TESTDIR"
 
 if [ "$INSTALL" = "1" ] || [ "$INSTALL" = "script" ]; then
   if ! python3 $(dirname $0)/install_gadget.py \
@@ -198,7 +222,6 @@ else
 fi
 
 # Start
-pushd $(dirname $0)/tests > /dev/null
 echo "Running Vimspector Vim tests"
 
 RESULT=0
@@ -206,58 +229,73 @@ RESULT=0
 TESTS="$@"
 
 if [ -z "$TESTS" ]; then
-  TESTS=*.test.vim
+  TESTS=${TESTDIR}/*.test.vim
 fi
 
 for t in ${TESTS}; do
-  echo ""
-  echo "%RUN: $t"
-
   # split on : into fileName and testName
-  IFS=: read -s t T <<< "$t"
+  IFS=: read -s tt T <<< "$t"
+
+  # Resolve into absolute path ($tt) and test file name ($t)
+  if [ -f "$tt" ]; then
+    tt=$(readlink -f "$tt")
+    t=$(basename "$tt")
+  elif [ -f "$TESTDIR/$tt" ]; then
+    t=$tt
+    tt=$TESTDIR/$t
+  else
+    echo "%ERROR: Unable to find a test named $t"
+    RESULT=1
+    break
+  fi
+
+  echo ""
+  echo "%RUN: $t ($tt)"
 
   TESTLOGDIR=${BASEDIR}/tests/logs/$t
 
-  if ${RUN_TEST} --cmd "${BASEDIR_CMD}" \
-                 --cmd 'au SwapExists * let v:swapchoice = "e"' $t $T \
-                 >&3\
-     && [ -f $t.res ];  then
-    echo "%PASS: $t PASSED"
-  else
-    echo "%FAIL: $t FAILED - see $TESTLOGDIR"
-    RESULT=1
-  fi
-
-  rm -rf $TESTLOGDIR
-  mkdir -p $TESTLOGDIR
-  ${RUN_VIM} --version > ${TESTLOGDIR}/vimversion
-  if [ "$VIMSPECTOR_TEST_STDOUT" = "messages" ]; then
-    if [ -f messages ]; then
-      echo "%MESSAGES"
-      cat messages
-      echo "%END"
+  pushd ${TESTDIR} > /dev/null
+    if ${RUN_TEST} --cmd "${BASEDIR_CMD}" \
+                   --cmd 'au SwapExists * let v:swapchoice = "e"' $tt $T \
+                   >&3\
+       && [ -f $t.res ];  then
+      echo "%PASS: $t PASSED"
     else
-      echo "%MESSAGES"
-      echo "No messages found"
-      echo "%END"
+      echo "%FAIL: $t FAILED - see $TESTLOGDIR"
+      RESULT=1
     fi
-  fi
 
-  for l in messages debuglog test.log *.testlog; do
-    # In CI we can't view the output files, so we just have to cat them
-    if [ -f $l ]; then
-      if [ "$VIMSPECTOR_TEST_STDOUT" = "all" ]; then
-        echo ""
-        echo ""
-        echo "*** START: $l ***"
-        cat $l
-        echo "*** END: $l ***"
+    rm -rf $TESTLOGDIR
+    mkdir -p $TESTLOGDIR
+    ${RUN_VIM} --version > ${TESTLOGDIR}/vimversion
+    if [ "$VIMSPECTOR_TEST_STDOUT" = "messages" ]; then
+      if [ -f messages ]; then
+        echo "%MESSAGES"
+        cat messages
+        echo "%END"
+      else
+        echo "%MESSAGES"
+        echo "No messages found"
+        echo "%END"
       fi
-      mv $l $TESTLOGDIR
     fi
-  done
 
-  rm -f $t.res
+    for l in messages debuglog test.log *.testlog; do
+      # In CI we can't view the output files, so we just have to cat them
+      if [ -f $l ]; then
+        if [ "$VIMSPECTOR_TEST_STDOUT" = "all" ]; then
+          echo ""
+          echo ""
+          echo "*** START: $l ***"
+          cat $l
+          echo "*** END: $l ***"
+        fi
+        mv $l $TESTLOGDIR
+      fi
+    done
+
+    rm -f $t.res
+  popd > /dev/null
 done
 
 # close out_fd if it's not stdout/stderr/
@@ -265,7 +303,6 @@ done
 
 
 echo "Done running tests"
-popd > /dev/null
 
 echo ""
 echo "All done. Exit with ${RESULT}"

--- a/support/test/cpp/simple_c_program/.vimspector.json
+++ b/support/test/cpp/simple_c_program/.vimspector.json
@@ -53,10 +53,13 @@
       }
     },
     "cpptools (lldb)": {
-      "adapter": "custom-cpptools",
+      "adapter": "vscode-cpptools",
       "variables": {
         "BUILDME": {
           "shell": "g++ -o ${workspaceRoot}/test -g -std=c++17 ${workspaceRoot}/test_c.cpp"
+        },
+        "arch": {
+          "shell": "uname -m"
         }
       },
       "configuration": {
@@ -67,11 +70,12 @@
         "MIDebuggerPath": "$HOME/.vim/vimspector-conf/gadgets/macos/vscode-cpptools/debugAdapters/lldb-mi/bin/lldb-mi",
         "logging": {
           "engineLogging": true
-        }
+        },
+        "targetArchitecture": "${arch}"
       }
     },
     "cpptools (gdb)": {
-      "adapter": "custom-cpptools",
+      "adapter": "vscode-cpptools",
       "variables": {
         "BUILDME": {
           "shell": "g++ -o ${workspaceRoot}/test -g -std=c++17 ${workspaceRoot}/test_c.cpp"

--- a/tests/breakpoints.test.vim
+++ b/tests/breakpoints.test.vim
@@ -985,7 +985,6 @@ function! Test_ListBreakpoints()
 endfunction
 
 function! Test_BreakpointMovements()
-  let g:test_is_flaky = 0
   lcd testdata/cpp/simple
   edit simple.cpp
 
@@ -1030,7 +1029,6 @@ function! Test_BreakpointMovements()
 endfunction
 
 function! Test_BreakpointMovements_MovedByServer()
-  let g:test_is_flaky = 0
   lcd testdata/cpp/simple
   edit simple.cpp
 

--- a/tests/ci/image/Dockerfile
+++ b/tests/ci/image/Dockerfile
@@ -95,6 +95,9 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh \
         update-alternatives --install /usr/bin/dotnet dotnet \
                                                       /usr/share/dotnet/dotnet 1
 
+# test requirements
+RUN pip install "git+https://github.com/puremourning/asciinema@exit_code#egg=asciinema"
+
 # clean up
 RUN rm -rf ~/.cache && \
     rm -rf $HOME/vim

--- a/tests/ci/image/Dockerfile
+++ b/tests/ci/image/Dockerfile
@@ -73,7 +73,7 @@ RUN apt-get -y autoremove
 ## cleanup of files from setup
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ARG VIM_VERSION=v8.2.0716
+ARG VIM_VERSION=v8.2.4797
 
 ENV CONF_ARGS "--with-features=huge \
                --enable-python3interp \
@@ -83,9 +83,8 @@ ENV CONF_ARGS "--with-features=huge \
 
 RUN mkdir -p $HOME/vim && \
     cd $HOME/vim && \
-    git clone https://github.com/vim/vim && \
+    git clone --depth 1 --branch ${VIM_VERSION} https://github.com/vim/vim && \
     cd vim && \
-    git checkout ${VIM_VERSION} && \
     make -j 4 && \
     make install
 

--- a/tests/disassembly.test.vim
+++ b/tests/disassembly.test.vim
@@ -1,0 +1,366 @@
+let s:fn='testdata/cpp/simple/tiny.c'
+let s:buf = '_vimspector_disassembly'
+let s:codelldb_supports_disassembly = 0
+" Need to make this small enough that this many lines fit on the screen as the
+" fixed position in this test require that.
+let s:dlines = 5
+if has( 'nvim' )
+  let s:offset = 1
+else
+  let s:offset = 0
+endif
+let s:dpc = s:dlines + s:offset
+
+function! SetUp()
+  let g:vimspector_disassembly_height = s:dlines
+  call vimspector#test#setup#SetUpWithMappings( 'HUMAN' )
+endfunction
+
+function! TearDown()
+  call vimspector#test#setup#TearDown()
+endfunction
+
+function! s:StartDebugging( ... )
+  let config = #{
+        \   fn: s:fn,
+        \   line: 3,
+        \   col: 1,
+        \   launch: #{ configuration: 'run-to-breakpoint' }
+        \ }
+  if a:0 > 0
+    call extend( config, a:1 )
+  endif
+
+  execute 'edit' config.fn
+  call cursor( 1, 1 )
+  call vimspector#SetLineBreakpoint( config.fn, config.line )
+  call vimspector#LaunchWithSettings( config.launch )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer(
+        \ config.fn,
+       \ config.line,
+        \ config.col )
+endfunction
+
+
+function! Test_Disassembly_Open_Close()
+  call s:StartDebugging()
+  call vimspector#ShowDisassembly()
+
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  let winid = g:vimspector_session_windows.disassembly
+  call assert_false( &wrap )
+  call assert_inrange( getwininfo( winid )[ 0 ].topline,
+                     \ getwininfo( winid )[ 0 ].botline,
+                     \ s:dpc )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+  quit
+
+  call vimspector#ShowDisassembly()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+  VimspectorReset
+  call vimspector#test#setup#WaitForReset()
+
+  call vimspector#test#setup#Reset()
+  %bwipeout!
+endfunction
+
+function! Test_Disassembly_StepGranularity_Mappings()
+  call s:StartDebugging()
+  call vimspector#ShowDisassembly()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+  let winid = g:vimspector_session_windows.disassembly
+
+  " The default mappings (i.e. F10 etc.) behave according to the current window
+  "
+  " Step over instruction
+  call cursor( 1, 1)
+  call feedkeys( "\<F10>", 'xt' )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+
+  " Jumps from within the disassembly view jump to the disassembly view
+  call cursor( 1, 1)
+  call vimspector#JumpToProgramCounter()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+  call assert_equal( 'vimspector-disassembly', &syntax )
+
+  " Check we're still on the same source line (which just about works on the
+  " suported architectures)
+
+  call win_gotoid( g:vimspector_session_windows.code )
+  call vimspector#JumpToProgramCounter()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 3, 1 )
+
+  " steps from code window are line steps
+  call cursor( 1, 1 )
+  call feedkeys( "\<F10>", 'xt' )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 4, 1 )
+
+  call vimspector#test#setup#Reset()
+  %bwipeout!
+endfunction
+
+function! Test_Disassembly_StepGranularity_API()
+  call s:StartDebugging()
+  call vimspector#ShowDisassembly()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+  let winid = g:vimspector_session_windows.disassembly
+
+  " The default mappings (i.e. F10 etc.) behave according to the current window
+  "
+  " Step over instruction
+  call cursor( 1, 1)
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+
+  " Jumps from within the disassembly view jump to the disassembly view
+  call cursor( 1, 1)
+  call vimspector#JumpToProgramCounter()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+
+  " Check we're still on the same source line (which just about works on the
+  " suported architectures)
+  call win_gotoid( g:vimspector_session_windows.code )
+  call vimspector#JumpToProgramCounter()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 3, 1 )
+
+  " steps from code window are line steps
+  call cursor( 1, 1 )
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 4, 1 )
+
+  call vimspector#test#setup#Reset()
+  %bwipeout!
+endfunction
+
+function! Test_Disassembly_StepInGranularity_API()
+  call s:StartDebugging()
+  call vimspector#ShowDisassembly()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+  let winid = g:vimspector_session_windows.disassembly
+
+  " The default mappings (i.e. F10 etc.) behave according to the current window
+  "
+  " Step over instruction
+  call cursor( 1, 1)
+  call vimspector#StepInto()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+
+  " Jumps from within the disassembly view jump to the disassembly view
+  call cursor( 1, 1)
+  call vimspector#JumpToProgramCounter()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+
+  " Check we're still on the same source line (which just about works on the
+  " suported architectures)
+  call win_gotoid( g:vimspector_session_windows.code )
+  call vimspector#JumpToProgramCounter()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 3, 1 )
+
+  " steps from code window are line steps
+  call cursor( 1, 1 )
+  call vimspector#StepInto()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 4, 1 )
+
+  call vimspector#test#setup#Reset()
+  %bwipeout!
+endfunction
+
+function! Test_Disassembly_StepGranularity_API_CodeLLDB()
+  call SkipIf( { -> !s:codelldb_supports_disassembly },
+             \ "CodeLLDB doesn't support this yet" )
+
+  call s:StartDebugging( #{
+        \ col: 13,
+        \ launch: #{ configuration: 'CodeLLDB' }
+        \ } )
+  call vimspector#ShowDisassembly()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+  let winid = g:vimspector_session_windows.disassembly
+
+  " The default mappings (i.e. F10 etc.) behave according to the current window
+  "
+  " Step over instruction
+  call cursor( 1, 1)
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+
+  " Jumps from within the disassembly view jump to the disassembly view
+  call cursor( 1, 1)
+  call vimspector#JumpToProgramCounter()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer(
+            \ s:buf,
+            \ s:dpc,
+            \ 'VimspectorDisassembly' )
+        \ } )
+
+  " Check we're still on the same source line (which just about works on the
+  " suported architectures)
+  "
+  " NOTE: codelldb is so good, it actually includes the column number and moves
+  " us to the + operator (on arm64 at least). 
+  "
+  " FIXME: These offsets are unlikely to be correct on x86, so maybe just don't
+  " check the column here.
+  call win_gotoid( g:vimspector_session_windows.code )
+  call vimspector#JumpToProgramCounter()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 3, 18 )
+
+  " steps from code window are line steps
+  call cursor( 1, 1 )
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 4, 10 )
+
+  call vimspector#test#setup#Reset()
+  %bwipeout!
+endfunction
+
+function! Test_Disassembly_StepInGranularity_API_Direct()
+  call s:StartDebugging()
+  call vimspector#ShowDisassembly()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  let winid = g:vimspector_session_windows.disassembly
+
+  " The default mappings (i.e. F10 etc.) behave according to the current window
+  "
+  " Step over instruction
+  call win_gotoid( g:vimspector_session_windows.code )
+  call vimspector#StepIOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 3, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( s:fn, 3 )
+        \ } )
+
+  " Check we're still on the same source line (which just about works on the
+  " steps from code window are line steps
+  call win_gotoid( winid )
+  call vimspector#StepSOver()
+  call cursor(1,1)
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( s:fn, 4 )
+        \ } )
+
+  call win_gotoid( g:vimspector_session_windows.code )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 4, 1 )
+
+  call vimspector#test#setup#Reset()
+  %bwipeout!
+endfunction
+
+function! Test_Disassembly_StepInGranularity_API_Direct_CodeLLDB()
+  call SkipIf( { -> !s:codelldb_supports_disassembly },
+             \ "CodeLLDB doesn't support this yet" )
+
+  call s:StartDebugging( #{
+        \ col: 13,
+        \ launch: #{ configuration: 'CodeLLDB' }
+        \ } )
+  call vimspector#ShowDisassembly()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  let winid = g:vimspector_session_windows.disassembly
+
+  " The default mappings (i.e. F10 etc.) behave according to the current window
+  "
+  " Step over instruction
+  call win_gotoid( g:vimspector_session_windows.code )
+  call vimspector#StepIOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 3, 13 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( s:fn, 3 )
+        \ } )
+
+  " Check we're still on the same source line (which just about works on the
+  " steps from code window are line steps
+  call win_gotoid( winid )
+  call vimspector#StepSOver()
+  call cursor(1,1)
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
+  call WaitForAssert( {->
+        \ vimspector#test#signs#AssertPCIsAtLineInBuffer( s:fn, 4 )
+        \ } )
+
+  call win_gotoid( g:vimspector_session_windows.code )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 4, 10 )
+
+  call vimspector#test#setup#Reset()
+  %bwipeout!
+endfunction

--- a/tests/get_configurations.test.vim
+++ b/tests/get_configurations.test.vim
@@ -32,6 +32,7 @@ function! Test_Get_Configurations_FilteredFiletypes()
 endfunction
 
 function! Test_PickConfiguration_FilteredFiletypes()
+  call ThisTestIsFlaky()
   let fn = '../support/test/multiple_filetypes/test.js'
   exe 'edit ' . fn
   normal! G

--- a/tests/lib/autoload/vimspector/test/signs.vim
+++ b/tests/lib/autoload/vimspector/test/signs.vim
@@ -15,10 +15,13 @@ function! vimspector#test#signs#AssertCursorIsAtLineInBuffer( buffer,
   endif
 endfunction
 
-function! vimspector#test#signs#AssertPCIsAtLineInBuffer( buffer, line ) abort
+function! vimspector#test#signs#AssertPCIsAtLineInBuffer(
+      \ buffer,
+      \ line,
+      \ group = 'VimspectorCode' ) abort
   call WaitFor( {-> bufexists( a:buffer ) } )
   let signs = sign_getplaced( a:buffer, {
-    \ 'group': 'VimspectorCode',
+    \ 'group': a:group,
     \ } )
 
   if assert_equal( 1, len( signs ), 'Number of buffers named ' . a:buffer )
@@ -26,7 +29,7 @@ function! vimspector#test#signs#AssertPCIsAtLineInBuffer( buffer, line ) abort
   endif
 
   if assert_true( len( signs[ 0 ].signs ) >= 1,
-                \ 'At least one VimspectorCode sign' )
+                \ 'At least one ' . a:group . ' sign' )
     return 1
   endif
 

--- a/tests/lib/plugin/shared.vim
+++ b/tests/lib/plugin/shared.vim
@@ -104,7 +104,7 @@ func s:WaitForCommon(expr, assert, timeout)
 endfunc
 
 function! ThisTestIsFlaky()
-  let g:test_is_flaky = v:true
+  " Deprectaed for now
 endfunction
 
 " In vim, py3eval( 'None' ) returns v:none, which is not equal v:null

--- a/tests/lib/plugin/shared.vim
+++ b/tests/lib/plugin/shared.vim
@@ -163,6 +163,12 @@ function! SkipOn( arch, system ) abort
   endif
 endfunction
 
+function! SkipIf( f, msg ) abort
+  if a:f()
+    throw 'skipped: ' . a:msg
+  endif
+endfunction
+
 function! FunctionBreakOnBrace() abort
   " Annoyingly, the behaviour of gcc 8 differs from clang _and_ it differs
   " between x86 and arm

--- a/tests/lib/run_test.vim
+++ b/tests/lib/run_test.vim
@@ -379,9 +379,6 @@ for s:test in sort(s:tests)
   " Silence, please!
   set belloff=all
 
-  " A test can set g:test_is_flaky to retry running the test.
-  let g:test_is_flaky = 0
-
   call RunTheTest(s:test)
 
   " Repeat a flaky test.  Give up when:
@@ -390,7 +387,6 @@ for s:test in sort(s:tests)
   " - it fails five times
   if len(v:errors) > 0
         \ && ( $TEST_NO_RETRY == '' || $TEST_NO_RETRY == '0' )
-        \ && g:test_is_flaky
     for retry in range( 10 )
       call add( s:messages, 'Found errors in ' . s:test . '. Retrying.' )
       call extend( s:messages, v:errors )

--- a/tests/testdata/cpp/simple/Makefile
+++ b/tests/testdata/cpp/simple/Makefile
@@ -1,12 +1,13 @@
+TARGETS=simple variables struct printer threads tiny
+
 CXXFLAGS=-g -O0 -std=c++17
-
-.PHONY: all
-
-TARGETS=simple variables struct printer threads
+CFLAGS=-g -O0
 LDLIBS=-lpthread
 
+.PHONY: all
 all: $(TARGETS)
 
+.PHONY: clean
 clean:
 	rm -f $(TARGETS)
 	rm -rf $(TARGETS:%=%.dSYM)

--- a/tests/testdata/cpp/simple/tiny.c
+++ b/tests/testdata/cpp/simple/tiny.c
@@ -1,0 +1,5 @@
+int main(int argc, char**argv)
+{
+  int res = argc + 1;
+  return res;
+}


### PR DESCRIPTION
Add support for instruction breakpoints to the disassembly window.

Bit flaky, but work reasonably as a quick win.

We model them as line breakpoints where the file/line point to the disassembly buffer. Then we use the address of the instruction associated with the breakpoint to find the new line whenever the disassembly changes. 