### PR TITLE
Avoid switching windows all the time when updating the output buffers

### DIFF
--- a/python3/vimspector/output.py
+++ b/python3/vimspector/output.py
@@ -97,9 +97,8 @@ class OutputView( object ):
 
     # Scroll the buffer
     if self._window.valid:
-      with utils.RestoreCurrentWindow():
-        with utils.RestoreCurrentBuffer( self._window ):
-          self._ShowOutput( category )
+      utils.Call( 'win_execute', utils.WindowID( self._window ), 'normal! G' )
+
 
   def Reset( self ):
     self.Clear()


### PR DESCRIPTION
This can cause a bad traceback when you have fzf open in a popup-window-terminal, which doesn't allow window switching in vim.