### PR TITLE
Disassembly scoll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,8 +1218,11 @@ use the default "step" commands (e.g. `<F10>`), the stepping is automatically
 chnged to per-instruction rather than per statement.
 
 Each time the process stops, vimspector requests about 2 windows full of
-instructions around the current PC. To see more, you have to make the window
-bigger and step. This is not ideal, and may be improved in future.
+instructions around the current PC. To see more, you can scroll the window.
+Vimspector will page in an extra screenful of instructions when the window
+scrolls to the top or near the bottom. This isn't perfect. Sometimes you have to
+scroll a bit more to make it page in (e.g. ctrl-e ctrl-y at the top).
+This is not ideal, and may be improved in future.
 
 You can control the intial height of the disassembly window with
 `let g:vimspector_disassembly_height = 10` (or whatver number of lines).

--- a/autoload/vimspector/internal/disassembly.vim
+++ b/autoload/vimspector/internal/disassembly.vim
@@ -1,0 +1,31 @@
+" vimspector - A multi-language debugging system for Vim
+" Copyright 2022 Ben Jackson
+"
+" Licensed under the Apache License, Version 2.0 (the "License");
+" you may not use this file except in compliance with the License.
+" You may obtain a copy of the License at
+"
+"   http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing, software
+" distributed under the License is distributed on an "AS IS" BASIS,
+" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+" See the License for the specific language governing permissions and
+" limitations under the License.
+
+
+" Boilerplate {{{
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+" }}}
+
+function! vimspector#internal#disassembly#OnWindowScrolled() abort
+  let win_id = expand( '<afile>' )
+  py3 _vimspector_session.OnDisassemblyWindowScrolled(
+        \ int( vim.eval( 'win_id' ) ) )
+endfunction
+
+" Boilerplate {{{
+let &cpoptions=s:save_cpo
+unlet s:save_cpo
+" }}}

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -838,7 +838,7 @@ class DebugSession( object ):
         self._stackTraceView.GetCurrentFrame(),
         True )
 
-  
+
   def OnDisassemblyWindowScrolled( self, win_id ):
     if self._disassemblyView:
       self._disassemblyView.OnWindowScrolled( win_id )

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -838,6 +838,11 @@ class DebugSession( object ):
         self._stackTraceView.GetCurrentFrame(),
         True )
 
+  
+  def OnDisassemblyWindowScrolled( self, win_id ):
+    if self._disassemblyView:
+      self._disassemblyView.OnWindowScrolled( win_id )
+
 
   @IfConnected()
   def AddWatch( self, expression ):

--- a/python3/vimspector/disassembly.py
+++ b/python3/vimspector/disassembly.py
@@ -17,7 +17,8 @@ import logging
 
 import vim
 
-from vimspector import signs, utils, debug_adapter_connection
+from vimspector import signs, utils
+from vimspector.debug_adapter_connection import DebugAdapterConnection
 
 SIGN_ID = 1
 
@@ -36,7 +37,7 @@ class DisassemblyView( object ):
     self._requesting = False
 
     self._api_prefix = api_prefix
-    self._connection: debug_adapter_connection.DebugAdapterConnection = connection
+    self._connection: DebugAdapterConnection = connection
 
     self.current_frame = None
     self.current_instructions = None

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -248,10 +248,7 @@ def RestoreCurrentBuffer( window ):
     yield
   finally:
     if window.valid:
-      with RestoreCurrentWindow():
-        with NoAutocommands():
-          JumpToWindow( window )
-          vim.current.buffer = old_buffer
+      Call( 'win_execute', WindowID( window ), f'bu { old_buffer.number }' )
 
 
 @contextlib.contextmanager
@@ -874,6 +871,10 @@ def WindowID( window, tab=None ):
   if tab is None:
     tab = window.tabpage
   return int( Call( 'win_getid', window.number, tab.number ) )
+
+
+def GetWindowInfo( window ):
+  return Call( 'getwininfo', WindowID( window ) )[ 0 ]
 
 
 @memoize


### PR DESCRIPTION
"Infinite" scrolling for the disassembly window.

The way this works is it dumbly requests an extra page when the top line of the window reaches 1, and when its >= buffer length minus 1 page.

We don't trim or anything, so it just grows. It always shrinks the next time we jump to a frame though.

We also drop any request if one is in progress, which is not ideal, but it's simple.