### PR TITLE
Allow the user to run 'runCommands' locally

### DIFF
--- a/doc/vimspector-ref.txt
+++ b/doc/vimspector-ref.txt
@@ -856,8 +856,8 @@ research that.
 
 Vimspector's tools are intended to automate your existing process for setting
 this up rather than to offer batteries-included approach. Ultimately, all
-Vimspector is going to do is run your commands over SSH, or docker, and
-co-ordinate with the adapter.
+Vimspector is going to do is run your commands over SSH, docker, or locally,
+and co-ordinate with the adapter.
 
 -------------------------------------------------------------------------------
                                                 *vimspector-ref-python-example*
@@ -880,7 +880,8 @@ Vimspector then orchestrates the various tools to set you up.
         "host": "${host}",
         "launch": {
           "remote": {
-            "host": "${host}",       // Remote host to ssh to (mandatory if not using container)
+            "host": "${host}", // Remote host to ssh to
+                               // If omitted, runCommand(s) is run locally
             "account": "${account}", // User to connect as (optional)
   
             // Optional.... Manual additional arguments for ssh
@@ -914,7 +915,8 @@ Vimspector then orchestrates the various tools to set you up.
         },
         "attach": {
           "remote": {
-            "host": "${host}", // Remote host to ssh to (mandatory if not using container)
+            "host": "${host}", // Remote host to ssh to
+                               // If omitted, runCommand(s) is run locally
             "account": "${account}", // User to connect as (optional)
             // Command to get the PID of the process to attach  (mandatory)
             "pidCommand": [

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -810,8 +810,8 @@ research that.
 
 Vimspector's tools are intended to automate your existing process for setting
 this up rather than to offer batteries-included approach. Ultimately, all
-Vimspector is going to do is run your commands over SSH, or docker, and
-co-ordinate with the adapter.
+Vimspector is going to do is run your commands over SSH, docker, or locally,
+and co-ordinate with the adapter.
 
 ### Python (debugpy) Example
 
@@ -834,7 +834,8 @@ Vimspector then orchestrates the various tools to set you up.
       "host": "${host}",
       "launch": {
         "remote": {
-          "host": "${host}",       // Remote host to ssh to (mandatory if not using container)
+          "host": "${host}", // Remote host to ssh to
+                             // If omitted, runCommand(s) is run locally
           "account": "${account}", // User to connect as (optional)
 
           // Optional.... Manual additional arguments for ssh
@@ -868,7 +869,8 @@ Vimspector then orchestrates the various tools to set you up.
       },
       "attach": {
         "remote": {
-          "host": "${host}", // Remote host to ssh to (mandatory if not using container)
+          "host": "${host}", // Remote host to ssh to
+                             // If omitted, runCommand(s) is run locally
           "account": "${account}", // User to connect as (optional)
           // Command to get the PID of the process to attach  (mandatory)
           "pidCommand": [

--- a/docs/schema/vimspector.schema.json
+++ b/docs/schema/vimspector.schema.json
@@ -82,10 +82,11 @@
       "properties": {
         "remote": {
           "type": "object",
-          "description": "Configures how Vimspector will marshal remote debugging requests. When remote debugging, Vimspector will either ssh to 'account'@'host' or docker exec -it to 'container' and run 'pidCommand', 'attachCommands', 'runCommands', etc. based on the 'remote-command' option in the debug configuration. If 'remote-command' is 'launch', it runs 'runCommand(s)', otherwise (it's 'attach') vimspector runs 'pidCommand', followed by 'attachCommand(s)'.Then it starts up the debug adapter with the debug configuration as normal. Usually this is configured with an 'attach' request (whether we remotely 'launched' or not). Once the initialization exchange is complete, Vimspector runs the optional 'initCompleteCommand' which can be used to force the application to break, e.g. by sending it SIGINT. This is required on some platforms which have buggy gdbservers (for example)",
+          "description": "Configures how Vimspector will marshal remote debugging requests. When remote debugging, Vimspector will either ssh to 'account'@'host', docker exec -it to 'container' or work locally and run 'pidCommand', 'attachCommands', 'runCommands', etc. based on the 'remote-command' option in the debug configuration. If 'remote-command' is 'launch', it runs 'runCommand(s)', otherwise (it's 'attach') vimspector runs 'pidCommand', followed by 'attachCommand(s)'.Then it starts up the debug adapter with the debug configuration as normal. Usually this is configured with an 'attach' request (whether we remotely 'launched' or not). Once the initialization exchange is complete, Vimspector runs the optional 'initCompleteCommand' which can be used to force the application to break, e.g. by sending it SIGINT. This is required on some platforms which have buggy gdbservers (for example)",
           "allOf": [
             {
-              "oneOf": [
+              "anyOf": [
+                { "required": [] },
                 { "required": [ "host" ] },
                 { "required": [ "container" ] }
               ]

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -1470,6 +1470,9 @@ class DebugSession( object ):
 
     return ssh
 
+  def _GetShellCommand( self ):
+    return []
+
   def _GetDockerCommand( self, remote ):
     docker = [ 'docker', 'exec' ]
     docker.append( remote[ 'container' ] )
@@ -1485,7 +1488,9 @@ class DebugSession( object ):
       return self._GetSSHCommand( remote )
     elif is_docker_cmd:
       return self._GetDockerCommand( remote )
-    raise ValueError( 'Could not determine remote exec command' )
+    else:
+      # if it's neither docker nor ssh, run locally
+      return self._GetShellCommand()
 
 
   def _GetCommands( self, remote, pfx ):


### PR DESCRIPTION
This allows one to run commands locally without having to `ssh` to `localhost` which helps when running `vimspector` in a docker container.