### PR TITLE
Disallow simultaneous 'host' and 'container'

### DIFF
--- a/docs/schema/vimspector.schema.json
+++ b/docs/schema/vimspector.schema.json
@@ -86,9 +86,17 @@
           "allOf": [
             {
               "anyOf": [
-                { "required": [] },
-                { "required": [ "host" ] },
-                { "required": [ "container" ] }
+                {
+                  "oneOf": [
+                    { "required": [ "host" ] },
+                    { "required": [ "container" ] }
+                  ]
+                },
+                {
+                  "not": {
+                    "required": [ "host", "container" ]
+                  }
+                }
               ]
             },
             {


### PR DESCRIPTION
I was thinking a bit more about the schema change in #699 , and it didn't sit right with me so I tested it and turns out I was wrong.

This example shows a hard error when trying to have both `host` and `container` in the same adapter specification whereas the previous schema allowed it.
```
{
  "adapters": {
    "with-nothing-specified": {
      "extends": "CodeLLDB",
      "launch": {
        "remote": {
          "runCommands": [
            [ "echo", "hello" ]
          ]
        }
      }
    },
    "with-host-specified": {
      "extends": "CodeLLDB",
      "launch": {
        "remote": {
          "host": "127.0.0.1",
          "account": "mark",
          "runCommands": [
            [ "echo", "hello" ]
          ]
        }
      }
    },
    "with-both-host-and-container-specified": {
      "extends": "CodeLLDB",
      "launch": {
        "remote": {
          "host": "127.0.0.1",
          "container": "golden_beelzebub",
          "account": "mark",
          "runCommands": [ [ "echo", "hello" ] ]
        }
      }
    }
  },
  "configurations": {
    "test": {
      "remote-request": "launch",
      "adapter": "without-host-specified",
      "configuration": {
        "request": "attach",
        "pid": "123"
      }
    }
  }
}
```

Tested it on [jsonschemavalidator.net](https://www.jsonschemavalidator.net/).