### PR TITLE
Open fold when jumping to a frame

### DIFF
--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -156,7 +156,7 @@ class CodeView( object ):
                               frame[ 'source' ][ 'path' ] )
       return False
 
-    vim.command( 'normal zv' )
+    vim.command( 'normal! zv' )
 
     self.current_syntax = utils.ToUnicode(
       vim.current.buffer.options[ 'syntax' ] )

--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -156,6 +156,8 @@ class CodeView( object ):
                               frame[ 'source' ][ 'path' ] )
       return False
 
+    vim.command( 'normal zv' )
+
     self.current_syntax = utils.ToUnicode(
       vim.current.buffer.options[ 'syntax' ] )
 


### PR DESCRIPTION
This simply does a `zv` after successfully setting cursor in position.
`zv` requires `+folding` to be enabled in Vim, which is one of the features of Vim huge build, and it's a requirement stated in README.

fix #679