### PR TITLE
Add -t to docker exec to support colorful output

### DIFF
--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -1474,7 +1474,7 @@ class DebugSession( object ):
     return []
 
   def _GetDockerCommand( self, remote ):
-    docker = [ 'docker', 'exec' ]
+    docker = [ 'docker', 'exec', '-t' ]
     docker.append( remote[ 'container' ] )
     return docker
 


### PR DESCRIPTION
Just adds a `-t` to the current `docker exec` command to support outputting colours in the output terminal when debugging code on a docker container