### PR TITLE
doautocmd VimspectorJumpedToFrame after cursor moved

### DIFF
--- a/python3/vimspector/code.py
+++ b/python3/vimspector/code.py
@@ -132,7 +132,6 @@ class CodeView( object ):
     with utils.LetCurrentWindow( self._window ):
       try:
         utils.OpenFileInCurrentWindow( frame[ 'source' ][ 'path' ] )
-        vim.command( 'doautocmd <nomodeline> User VimspectorJumpedToFrame' )
       except vim.error:
         self._logger.exception( 'Unexpected vim error opening file {}'.format(
           frame[ 'source' ][ 'path' ] ) )
@@ -157,6 +156,8 @@ class CodeView( object ):
       return False
 
     vim.command( 'normal! zv' )
+
+    vim.command( 'doautocmd <nomodeline> User VimspectorJumpedToFrame' )
 
     self.current_syntax = utils.ToUnicode(
       vim.current.buffer.options[ 'syntax' ] )


### PR DESCRIPTION
Before, this autocmd is called only when moved to a file but not after cursor is move as well. This PR resolves this.

This is inspired when solving https://github.com/puremourning/vimspector/issues/679#issuecomment-1268679344 and that suggestion wasn't success. That's because this wasn't executed:
https://github.com/puremourning/vimspector/blob/242764edc70808eb6ec7be5a057ca4d41c1b9329/python3/vimspector/code.py#L147-L149
However, I see this before it:
https://github.com/puremourning/vimspector/blob/242764edc70808eb6ec7be5a057ca4d41c1b9329/python3/vimspector/code.py#L140-L141
I'm not sure whether `SetCursorPosInWindow` should be located inside the `if`.