### PR TITLE
Neovim: Support winbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,52 +250,20 @@ The following sections expand on the above brief overview.
 Vimspector requires:
 
 * One of:
-  * Vim 8.2 Huge build compiled with Python 3.6 or later
-  * Neovim 0.4.3 with Python 3.6 or later (experimental)
+  * Vim 8.2 Huge build compiled with Python 3.10 or later
+  * Neovim 0.8 with Python 3.10 or later (experimental)
 * One of the following operating systems:
   * Linux
   * macOS Mojave or later
   * Windows (experimental)
 
-Why such a new vim? Well 2 reasons:
+Which Linux versions? I only test on Ubuntu 20.04 and later and RHEL 7.
 
-1. Because vimspector uses a lot of new Vim features
-2. Because there are Vim bugs that vimspector triggers that will frustrate you
-   if you hit them.
+### Neovim limitations
 
-Why is neovim experimental? Because the author doesn't use neovim regularly, and
-there are no regression tests for vimspector in neovim, so it may break
-occasionally. Issue reports are handled on best-efforts basis, and PRs are
-welcome to fix bugs. See also the next section describing differences for neovim
-vs vim.
-
-Why is Windows support experimental? Because it's effort and it's not a priority
-for the author. PRs are welcome to fix bugs. Windows will not be regularly
-tested.
-
-Which Linux versions? I only test on Ubuntu 18.04 and later and RHEL 7.
-
-## Neovim differences
-
-neovim doesn't implement some features Vimspector relies on:
-
-* WinBar - used for the buttons at the top of the code window and for changing
-  the output window's current output.
-* Prompt Buffers - used to send commands in the Console and add Watches.
-  (*Note*: prompt buffers are available in neovim nightly)
-* Balloons - this allows for the variable evaluation popup to be displayed when
-  hovering the mouse. See below for how to create a keyboard mapping instead.
-
-Workarounds are in place as follows:
-
-* WinBar - There are [mappings](#mappings),
-  [`:VimspectorShowOutput`](#program-output) and
-  [`:VimspectorReset`](#closing-debugger)
-* Prompt Buffers - There are [`:VimspectorEval`](#console)
-  and [`:VimspectorWatch`](#watches)
-* Balloons - There is the `<Plug>VimspectorBalloonEval` mapping. There is no
-default mapping for this, so I recommend something like this to get variable
-display in a popup:
+neovim doesn't implement mouse hover balloons. Instead there is the
+`<Plug>VimspectorBalloonEval` mapping. There is no default mapping for this, so
+I recommend something like this to get variable display in a popup:
 
 ```viml
 " mnemonic 'di' = 'debug inspect' (pick your own, if you prefer!)
@@ -306,7 +274,7 @@ nmap <Leader>di <Plug>VimspectorBalloonEval
 xmap <Leader>di <Plug>VimspectorBalloonEval
 ```
 
-## Windows differences
+### Windows differences
 
 The following features are not implemented for Windows:
 
@@ -2454,6 +2422,17 @@ section `Custom mappings while debugging`.
 NOTE: This is a fairly advanced feature requiring some nontrivial vimscript.
 It's possible that this feature will be incorporated into Vimspector in future
 as it is a common requirement.
+
+## Disabling the WinBar
+
+You can tell vimspector not to draw the WinBar (the toolbars in the code,
+variables, output, etc. windows) by setting:
+
+```viml
+let g:vimspector_enable_winbar=0
+```
+
+The WinBar is in any case not displayed if the mouse is not enabled.
 
 ## Advanced UI customisation
 

--- a/autoload/vimspector/internal/neowinbar.vim
+++ b/autoload/vimspector/internal/neowinbar.vim
@@ -1,0 +1,33 @@
+" vimspector - A multi-language debugging system for Vim
+" Copyright 2020 Ben Jackson
+"
+" Licensed under the Apache License, Version 2.0 (the "License");
+" you may not use this file except in compliance with the License.
+" You may obtain a copy of the License at
+"
+"   http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing, software
+" distributed under the License is distributed on an "AS IS" BASIS,
+" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+" See the License for the specific language governing permissions and
+" limitations under the License.
+
+
+" Boilerplate {{{
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+" }}}
+"
+function! vimspector#internal#neowinbar#Do( idx, nclick, btn, mods ) abort
+  py3 __import__( "vimspector",
+        \         fromlist = [ "utils" ] ).utils.DoWinBarAction(
+        \ int( vim.eval( 'getmousepos().winid' ) ),
+        \ int( vim.eval( 'a:idx' ) ) )
+endfunction
+
+" Boilerplate {{{
+let &cpoptions=s:save_cpo
+unlet s:save_cpo
+" }}}
+

--- a/python3/vimspector/disassembly.py
+++ b/python3/vimspector/disassembly.py
@@ -47,25 +47,9 @@ class DisassemblyView( object ):
       'vimspectorPC': None,
     }
 
-    with utils.LetCurrentWindow( self._window ):
-      if utils.UseWinBar():
-        vim.command( 'nnoremenu WinBar.■\\ Stop '
-                     ':call vimspector#Stop()<CR>' )
-        vim.command( 'nnoremenu WinBar.▶\\ Cont '
-                     ':call vimspector#Continue()<CR>' )
-        vim.command( 'nnoremenu WinBar.▷\\ Pause '
-                     ':call vimspector#Pause()<CR>' )
-        vim.command( 'nnoremenu WinBar.↷\\ NextI '
-                     ':call vimspector#StepIOver()<CR>' )
-        vim.command( 'nnoremenu WinBar.→\\ StepI '
-                     ':call vimspector#StepIInto()<CR>' )
-        vim.command( 'nnoremenu WinBar.←\\ OutI '
-                     ':call vimspector#StepIOut()<CR>' )
-        vim.command( 'nnoremenu WinBar.⟲: '
-                     ':call vimspector#Restart()<CR>' )
-        vim.command( 'nnoremenu WinBar.✕ '
-                     ':call vimspector#Reset()<CR>' )
+    self._RenderWinBar()
 
+    with utils.LetCurrentWindow( self._window ):
       vim.command( 'augroup VimspectorDisassembly' )
       vim.command( 'autocmd!' )
       vim.command( f'autocmd WinScrolled { utils.WindowID( self._window ) } '
@@ -73,6 +57,21 @@ class DisassemblyView( object ):
       vim.command( 'augroup END' )
 
     signs.DefineProgramCounterSigns()
+
+
+  def _RenderWinBar( self ):
+    with utils.LetCurrentWindow( self._window ):
+      if utils.UseWinBar():
+        utils.SetWinBar(
+          ( '■ Stop', 'vimspector#Stop()', ),
+          ( '▶ Cont', 'vimspector#Continue()', ),
+          ( '▷ Pause', 'vimspector#Pause()', ),
+          ( '↷ Next', 'vimspector#StepIOver()', ),
+          ( '→ Step', 'vimspector#StepIInto()', ),
+          ( '← Out', 'vimspector#StepIOut()', ),
+          ( '↺', 'vimspector#Restart()', ),
+          ( '✕', 'vimspector#Reset()', )
+        )
 
 
   def ConnectionClosed( self, connection: DebugAdapterConnection ):
@@ -299,6 +298,8 @@ class DisassemblyView( object ):
 
     with utils.LetCurrentWindow( self._window ):
       utils.OpenFileInCurrentWindow( buf_name )
+      if utils.VimIsNeovim():
+        self._RenderWinBar()
       utils.SetUpUIWindow( self._window )
       self._window.options[ 'signcolumn' ] = 'yes'
 

--- a/python3/vimspector/output.py
+++ b/python3/vimspector/output.py
@@ -114,8 +114,6 @@ class OutputView( object ):
   def Clear( self ):
     for category, tab_buffer in self._buffers.items():
       self._CleanUpBuffer( category, tab_buffer )
-
-    # FIXME: nunmenu the WinBar ?
     self._buffers = {}
 
 
@@ -139,9 +137,7 @@ class OutputView( object ):
   def UseWindow( self, win ):
     assert not self._window.valid
     self._window = win
-    # TODO: Sorting of the WinBar ?
-    for category, _ in self._buffers.items():
-      self._RenderWinBar( category )
+    self._RenderWinBar()
 
 
   def _ShowOutput( self, category ):
@@ -153,6 +149,10 @@ class OutputView( object ):
       vim.current.buffer = self._buffers[ category ].buf
       vim.command( 'normal! G' )
 
+      if utils.VimIsNeovim():
+        # Sigh: https://github.com/neovim/neovim/issues/23165
+        self._RenderWinBar()
+
   def ShowOutput( self, category ):
     self._ToggleFlag( category, False )
     self._ShowOutput( category )
@@ -163,7 +163,7 @@ class OutputView( object ):
 
       if self._window.valid:
         with utils.LetCurrentWindow( self._window ):
-          self._RenderWinBar( category )
+          self._RenderWinBar()
 
 
   def RunJobWithOutput( self, category, cmd, **kwargs ):
@@ -205,7 +205,6 @@ class OutputView( object ):
 
       self._buffers[ category ] = TabBuffer( out, len( self._buffers ) )
       self._buffers[ category ].is_job = True
-      self._RenderWinBar( category )
     else:
       if category == 'Console':
         name = 'vimspector.Console'
@@ -227,7 +226,7 @@ class OutputView( object ):
       else:
         utils.SetUpHiddenBuffer( tab_buffer.buf, name )
 
-      self._RenderWinBar( category )
+    self._RenderWinBar()
 
     self._buffers[ category ].syntax = utils.SetSyntax(
       self._buffers[ category ].syntax,
@@ -239,7 +238,7 @@ class OutputView( object ):
         self._ShowOutput( category )
       utils.CleanUpHiddenBuffer( buf_to_delete )
 
-  def _RenderWinBar( self, category ):
+  def _RenderWinBar( self ):
     if not utils.UseWinBar():
       return
 
@@ -247,25 +246,18 @@ class OutputView( object ):
       return
 
     with utils.LetCurrentWindow( self._window ):
-      tab_buffer = self._buffers[ category ]
+      tab_buffers = sorted( self._buffers.items(),
+                            key = lambda i: i[ 1 ].index )
 
-      try:
-        if tab_buffer.flag:
-          vim.command( 'nunmenu WinBar.{}'.format( utils.Escape( category ) ) )
-        else:
-          vim.command( 'nunmenu WinBar.{}*'.format( utils.Escape( category ) ) )
-      except vim.error as e:
-        # E329 means the menu doesn't exist; ignore that.
-        if 'E329' not in str( e ):
-          raise
-
-      vim.command(
-        "nnoremenu <silent> 1.{0} WinBar.{1}{2} "
-        ":call vimspector#ShowOutputInWindow( {3}, '{1}' )<CR>".format(
-          tab_buffer.index,
-          utils.Escape( category ),
-          '*' if tab_buffer.flag else '',
-          utils.WindowID( self._window ) ) )
+      buttons = []
+      for category, tab_buffer in tab_buffers:
+        buttons.append(
+          ( category + ( '*' if tab_buffer.flag else '' ),
+            "vimspector#ShowOutputInWindow( {}, '{}' )".format(
+              utils.WindowID( self._window ),
+              utils.Escape( category ) ) )
+        )
+      utils.SetWinBar( *buttons )
 
   def GetCategories( self ):
     return list( self._buffers.keys() )

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -37,6 +37,9 @@ DEFAULTS = {
   'terminal_maxheight': 15,
   'terminal_minheight': 5,
 
+  # WinBar
+  'enable_winbar':      True,
+
   # Session files
   'session_file_name': '.vimspector.session',
 

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -246,10 +246,10 @@ class VariablesView( object ):
                                   session_id ) )
     with utils.LetCurrentWindow( variables_win ):
       if utils.UseWinBar():
-        vim.command( 'nnoremenu <silent> 1.1 WinBar.Set '
-                     ':call vimspector#SetVariableValue()<CR>' )
-        vim.command( 'nnoremenu <silent> 1.2 WinBar.Dump '
-                     ':call vimspector#ReadMemory()<CR>' )
+        utils.SetWinBar(
+          ( 'Set', 'vimspector#SetVariableValue()', ),
+          ( 'Dump', 'vimspector#ReadMemory()' )
+        )
       AddExpandMappings( mappings )
 
     # Set up the "Watches" buffer in the watches_win (and create a WinBar in
@@ -271,16 +271,13 @@ class VariablesView( object ):
           f'nnoremap <buffer> { mapping } :call vimspector#DeleteWatch()<CR>' )
 
       if utils.UseWinBar():
-        vim.command( 'nnoremenu <silent> 1.1 WinBar.Add '
-                     ':call vimspector#AddWatch()<CR>' )
-        vim.command( 'nnoremenu <silent> 1.2 WinBar.Delete '
-                     ':call vimspector#DeleteWatch()<CR>' )
-        vim.command( 'nnoremenu <silent> 1.3 WinBar.+/- '
-                     ':call vimspector#ExpandVariable()<CR>' )
-        vim.command( 'nnoremenu <silent> 1.4 WinBar.Set '
-                     ':call vimspector#SetVariableValue()<CR>' )
-        vim.command( 'nnoremenu <silent> 1.5 WinBar.Dump '
-                     ':call vimspector#ReadMemory()<CR>' )
+        utils.SetWinBar(
+          ( 'Add', 'vimspector#AddWatch()', ),
+          ( 'Delete', 'vimspector#DeleteWatch()', ),
+          ( '+/-', 'vimspector#ExpandVariable()', ),
+          ( 'Set', 'vimspector#SetVariableValue()', ),
+          ( 'Dump', 'vimspector#ReadMemory()', )
+        )
 
     # Set the (global!) balloon expr if supported
     has_balloon      = int( vim.eval( "has( 'balloon_eval' )" ) )

--- a/tests/ci/image/Dockerfile
+++ b/tests/ci/image/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && \
                      lsb-release \
                      ca-certificates \
                      software-properties-common && \
-  add-apt-repository ppa:neovim-ppa/stable && \
   curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
   apt-get update && \
   apt-get -y dist-upgrade && \
@@ -33,9 +32,9 @@ RUN apt-get update && \
                      nodejs \
                      pkg-config \
                      lua5.1 \
-                     luajit \
-                     neovim && \
+                     luajit && \
   pip3 install neovim
+
 
 RUN ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime && \
   dpkg-reconfigure --frontend noninteractive tzdata
@@ -69,6 +68,8 @@ RUN curl -LO https://github.com/love2d/love/releases/download/11.3/love-11.3-lin
     rm -rf love-11.3 && \
     rm -f love-11.3-linux-src.tar.gz
 
+RUN apt-get install -y ninja-build gettext cmake unzip curl
+
 RUN apt-get -y autoremove
 
 ## cleanup of files from setup
@@ -87,7 +88,20 @@ RUN mkdir -p $HOME/vim && \
     git clone --depth 1 --branch ${VIM_VERSION} https://github.com/vim/vim && \
     cd vim && \
     make -j 4 && \
-    make install
+    make install && \
+    cd && \
+    rm -rf $HOME/vim
+
+ARG NVIM_VERSION=v0.8.3
+
+RUN mkdir -p $HOME/nvim && \
+    cd $HOME/nvim && \
+    git clone --depth 1 --branch ${NVIM_VERSION} https://github.com/neovim/neovim && \
+    cd neovim && \
+    make CMAKE_BUILD_TYPE=Release CMAKE_GENERTOR=Ninja -j 4 && \
+    make install && \
+    cd && \
+    rm -rf $HOME/nvim
 
 # dotnet
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh \
@@ -99,5 +113,4 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh \
 RUN pip install "git+https://github.com/puremourning/asciinema@exit_code#egg=asciinema"
 
 # clean up
-RUN rm -rf ~/.cache && \
-    rm -rf $HOME/vim
+RUN rm -rf ~/.cache

--- a/tests/disassembly.test.vim
+++ b/tests/disassembly.test.vim
@@ -4,6 +4,9 @@ let s:buf = '_vimspector_disassembly'
 " fixed position in this test require that.
 let s:dlines = 5
 if has( 'nvim' )
+  " Making these tests work with neovim is tricky because for some reason it
+  " always says "not enough room" whereas vim works with the same layout!
+  let g:vimspector_enable_winbar = 0
   let s:offset = 1
 else
   let s:offset = 0

--- a/tests/manual/image/Dockerfile
+++ b/tests/manual/image/Dockerfile
@@ -27,3 +27,6 @@ ENV TEST_NO_RETRY 1
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 ADD --chown=dev:dev .vim/ /home/dev/.vim/
+RUN mkdir -p /home/dev/.config/nvim && \
+    cd /home/dev/.config/nvim && \
+    ln -s /home/dev/.vim/vimrc init.vim

--- a/tests/ui.test.vim
+++ b/tests/ui.test.vim
@@ -23,7 +23,6 @@ function! SetUp_Test_StandardLayout()
 endfunction
 
 function! Test_StandardLayout()
-  call SkipNeovim()
   call s:StartDebugging()
 
   call vimspector#StepOver()
@@ -537,7 +536,6 @@ function! Test_CloseOutput()
 endfunction
 
 function! Test_CloseOutput_Early()
-  call SkipNeovim()
   augroup TestCustomUI
     au!
     au User VimspectorUICreated
@@ -677,7 +675,6 @@ function! TearDown_Test_NoMouseNoWinBar()
 endfunction
 
 function! Test_VimspectorJumpedToFrame()
-  call SkipNeovim()
   let s:ended = 0
   let s:au_visited_buffers = {}
 
@@ -731,7 +728,6 @@ function! Test_VimspectorJumpedToFrame()
 endfunction
 
 function! Test_DebugInfo_NotConnected()
-  call SkipNeovim()
   redir => debug_message
   VimspectorDebugInfo
   redir END
@@ -744,7 +740,6 @@ function! Test_DebugInfo_NotConnected()
 endfunction
 
 function! Test_DebugInfo_Connected()
-  call SkipNeovim()
   call s:StartDebugging()
 
   " Just make sure there are no errors for now


### PR DESCRIPTION
Neovim's winbar uses the statusline syntax with some horrible hack to have it call a function on click. Ugh. So we just do that.

There's also an [annoying bug](https://github.com/neovim/neovim/issues/23165) which means we have to re-render the winbar whenever the buffer changes in a UI window.

Fixes #594 