### PR TITLE
Fix crash when entering a new tab before vimspector is initialised

### DIFF
--- a/autoload/vimspector/internal/state.vim
+++ b/autoload/vimspector/internal/state.vim
@@ -93,11 +93,12 @@ endfunction
 
 function! vimspector#internal#state#OnTabEnter() abort
   py3 <<EOF
-session = _vimspector_session_man.SessionForTab(
-  int( vim.eval( 'tabpagenr()' ) ) )
+if '_vimspector_session_man' in globals():
+  session = _vimspector_session_man.SessionForTab(
+    int( vim.eval( 'tabpagenr()' ) ) )
 
-if session is not None:
-  _vimspector_session = session
+  if session is not None:
+    _vimspector_session = session
 EOF
 endfunction
 

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -955,7 +955,7 @@ def SetWinBar( *args ):
   for idx, button in enumerate( args ):
     button, action = button
     button = button.replace( ' ', '\\ ' )
-    vim.command( f'nnoremenu <silent> 1.{idx} '
+    vim.command( f'nnoremenu <silent> 1.{idx + 1} '
                  f'WinBar.{ button } '
                  f':call {action}<CR>' )
 


### PR DESCRIPTION
Fixes #754 