### PR TITLE
Support multiple independent root level sessions (tabs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,18 +1060,22 @@ pick one.
 Vimspector can save and restore breakpoints (and some other stuff) to a session
 file. The following commands exist for that:
 
-* `VimspectorMkSession [file name]` - save the current set of line breakpoints,
+* `VimspectorMkSession [file/dir name]` - save the current set of line breakpoints,
   logpoints, conditional breakpoints, function breakpoints and exception
-  breakpoint filters to the session file.
-* `VimspectorLoadSession [file name]` - read breakpoints from the session file
-  and replace any currently set breakpoints. Prior to loading, all current
-  breakpoints are cleared (as if `vimspector#ClearLineBreakpoints()` was
-  called).
+  breakpoint filters to the supplied session file or the default file in the
+  supplied directory.
+* `VimspectorLoadSession [file/dir name]` - read breakpoints from the session
+  file supplied or the default file in the supplied directory and replace any
+  currently set breakpoints. Prior to loading, all current breakpoints are
+  cleared (as if `vimspector#ClearLineBreakpoints()` was called).
 
-In both cases, the file name argument is optional. By default, the file is named
-`.vimspector.session`, but this can be changed globally by setting
+In both cases, the file/dir name argument is optional. By default, the file is
+named `.vimspector.session`, but this can be changed globally by setting
 `g:vimspector_session_file_name` to something else, or by manually specifying a
-path when calling the command.
+path when calling the command. If you supply a directory, the default or
+configured session file name is read fron or written to that directory.
+Othewise, the file is read based on the currently open buffer or written to the
+current working directory.
 
 Advanced users may wish to automate the process of loading and saving, for
 example by adding `VimEnter` and `VimLeave` autocommands. It's recommended in

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ And a couple of brief demos:
 - logging/stdout display
 - simple stable API for custom tooling (e.g. integrate with language server)
 - view hex dump of process memory
+- multiple independent debugging sessions (debug different apps in tabs)
 - multi-process (multi-session) debugging
 
 ## Supported languages
@@ -569,9 +570,15 @@ Vimspector is a vim UI on top of the Debug Adapter Protocol. It's intended to be
 Vimspector is not:
 
 * a debugger! It's just the UI and some glue.
-* fast. It's abstractions all the way down. If you want a fast, native debugger, there are other options.
-* comprehensive. It's limited by DAP, and limited by my time. I implement the features I think most users will need, not every feature possible.
-* for everyone. Vimspector intentionally provides a "one size fits all" UI and aproach. This means that it can only provide essential/basic debugging features for a given language. This makes it convenient for everyday usage, but not ideal for power users or those with very precise or specific requirements. See [motivation](#motivation) for more info. 
+* fast. It's abstractions all the way down. If you want a fast, native debugger,
+  there are other options.
+* comprehensive. It's limited by DAP, and limited by my time. I implement the
+  features I think most users will need, not every feature possible.
+* for everyone. Vimspector intentionally provides a "one size fits all" UI and
+  aproach. This means that it can only provide essential/basic debugging
+  features for a given language. This makes it convenient for everyday usage,
+  but not ideal for power users or those with very precise or specific
+  requirements. See [motivation](#motivation) for more info. 
 
 ## Status
 
@@ -781,12 +788,19 @@ users, the [mappings](#mappings) section contains the most common commands and
 default usage. This section can be used as a reference to create your own
 mappings or custom behaviours.
 
+All the below instructions assume a single debugging session. For deatils on how
+to debug multiple independent apps at the same time, see
+[multiple debugging sessions][#multiple-debugging-sessions].
+
 ## Launch and attach by PID:
 
 * Create `.vimspector.json`. See [below](#supported-languages).
 * `:call vimspector#Launch()` and select a configuration.
 
 ![debug session](https://puremourning.github.io/vimspector-web/img/vimspector-overview.png)
+
+Launching a new session makes it the active
+[debugging session][#multiple-debugging-sessions].
 
 ### Launch with options
 
@@ -872,6 +886,12 @@ For example, to get an array of configurations and fuzzy matching on the result
 
 See the [mappings](#mappings) section for the default mappings for working with
 breakpoints. This section describes the full API in vimscript functions.
+
+Breakpoints are associated with the current
+[debugging session][#multiple-debugging-sessions]. When switching between
+sessions, the breakpont signs for the previous session are removed and the
+breakpoints for the newly activated session are displayed. While it might be
+useful to see breakpoints for all sessions, this can be very confusing.
 
 ### Breakpoints Window
 
@@ -1253,16 +1273,20 @@ be changed manually to "switch to" that thread.
 
 The stack trace is represented by the buffer `vimspector.StackTrace`.
 
-### Multiple sessions
+### Child sessions
 
-If there are multiple concurrent debug sessions, such as where the debugee
-launches multiple child processes and the debug adapter supports multi-session
+If there are child debug sessions, such as where the debugee
+launches child processes and the debug adapter supports multi-session
 debugging, then each session's threads are shown separately. The currently
 active session is the one that is highlighted as the currently active
 thread/stack frame. To switch control to a different session, focus a thread
 within that session.
 
 ![multiple sessions](https://user-images.githubusercontent.com/10584846/232473234-666d1a77-81f2-40d5-bc65-ebab774888ce.png)
+
+Note: This refers to sessions created as children of an existing session, and is
+not to be confused with
+[multiple (parent) debugging sessions][#multiple-debugging-sessions].
 
 ## Program Output
 
@@ -1348,6 +1372,78 @@ choice as to whether or not to terminate the debuggee, you will be prompted to
 choose. The same applies for `vimspector#Stop()` which can take an argument:
 `vimspector#Stop( { 'interactive': v:true } )`.
 
+# Multiple debugging sessions
+
+**NOTE**: This feature is _experimental_ and any part of it may change in
+response to user feedback.
+
+Vimspector supports starting an arbitrary number of debug sessions. Each session
+is associated with an individual UI tab. Typically, you only debug a single app
+and so don't need to think about this, but this advanced feature can be useful
+if you need to simultaneously debug multiple, independent applications, or
+multiple independent instances of your application.
+
+At any time there is a single "active" root session. Breakpoints are associated
+with the current session, and all UI and API commands are applied to the
+currently active session.
+
+When switching between root sessions, the breakpont signs for the previous
+session are removed and the breakpoints for the newly activated session are
+displayed.  While it might be useful to see breakpoints for all sessions, this
+can be very confusing.
+
+A typical workflow might be:
+
+1. Start debugging a server app (e.g. `:edit server.cc` then `<F5>`). This
+   starts a debug session named after the configuration selected. You could
+   rename it `:VimspectorRenameSession server`.
+2. Open the client code in a new tab (e.g. `:tabedit client.cc`)
+3. Instantiate and make active a new debugging session and name it `client`:
+   `:VimspectorNewSession client` (`client` is now the active session).
+4. Add a breakpoint in the `client` session and start debugging with `<F5>`.
+
+You now have 2 vimspector tabs. Intuitively, wwitching to a particular tab will
+make its session active. You can also manually switch the active session with
+`:VimspectorSwitchToSession <name>`.
+
+So, in summary you have the following facilities:
+
+* `VimspectorNewSession <name>`
+  This creates a new session and makes it active. Optional name is used
+  in place of the generated one when starting a launch.
+* Switching to a specific debug tab makes that session active. This is
+  intuitive and probably the most common way to work with this.
+* Switching manually using `VimspectorSwitchToSession <tab complete>`.
+* Name/Rename session with `VimspectorRenameSession <new name>`
+* Root-level sessions are never 'destroyed' but you can manually destroy
+  them (if you're brave) using `VimspectorDestroySession <name>`. You
+  can't destroy a running/active session.
+* `vimspector#GetSessionName()` useful for putting in a statusline. 
+
+Here's an example of how you can display the current session name in the
+`statusline` (see `:help statusline`, or the documentation for your fancy status
+line plugin).
+
+```viml
+function! StlVimspectorSession()
+  " Only include in buffers containing actual files
+  if !empty( &buftype )
+    return ''
+  endif
+
+  " Abort if vimspector not loaded
+  if !exists( '*vimspector#GetSessionName' )
+    return ''
+  endif
+
+  return vimspector#GetSessionName()
+endfunction
+
+" ... existing statusline stuff
+" set statusline=...
+" Show the vimspector active session name (max 20 chars) if there is onw.
+set statusline+=%(\ %.20{StlVimspectorSession()}\ %)
+```
 
 # Debug profile configuration
 
@@ -1905,7 +2001,8 @@ curl "http://localhost?XDEBUG_SESSION_START=xdebug"
 or use the previously mentioned Xdebug Helper extension (which sets a `XDEBUG_SESSION` cookie)
 
 ### Debug cli application
-```
+
+```sh
 export XDEBUG_CONFIG="idekey=xdebug"
 php <path to script>
 ```
@@ -1919,7 +2016,7 @@ Requires:
 * `install_gadget.py --force-enable-node`
 * Options described here:
   https://github.com/microsoft/vscode-js-debug/blob/main/OPTIONS.md
-* Example: `support/test/node/simple`, `support/test/node/multiprocess'
+* Example: `support/test/node/simple`, `support/test/node/multiprocess`
 
 ```json
 {
@@ -2225,7 +2322,7 @@ define them in your `vimrc`.
 | `vimspectorBPDisabled`    | Disabled breakpoint                     | 9        |
 | `vimspectorPC`            | Program counter (i.e. current line)     | 200      |
 | `vimspectorPCBP`          | Program counter and breakpoint          | 200      |
-| `vimspectorNonActivePC``  | Program counter for non-focused thread  | 9        |
+| `vimspectorNonActivePC`   | Program counter for non-focused thread  | 9        |
 | `vimspectorCurrentThread` | Focussed thread in stack trace view     | 200      |
 | `vimspectorCurrentFrame`  | Current stack frame in stack trace view | 200      |
 

--- a/autoload/vimspector.vim
+++ b/autoload/vimspector.vim
@@ -45,7 +45,76 @@ function! s:Enabled() abort
     let s:enabled = vimspector#internal#state#Reset()
   endif
 
+  if s:enabled && py3eval( '_vimspector_session is None' )
+    " We have no active session, so create one
+    call vimspector#internal#state#NewSession( {} )
+  endif
+
   return s:enabled
+endfunction
+
+function! vimspector#NewSession( ... ) abort
+  if !s:Enabled()
+    return
+  endif
+
+  let options = {}
+  if a:0 > 0
+    call extend( options, { 'session_name': a:1 } )
+  endif
+
+  call vimspector#internal#state#NewSession( options )
+endfunction
+
+function! vimspector#SwitchToSession( name ) abort
+  if !s:Enabled()
+    return
+  endif
+
+  py3 << EOF
+s = _vimspector_session_man.FindSessionByName( vim.eval( 'a:name' ) )
+if s is not None:
+  _VimspectorSwitchTo( s )
+EOF
+endfunction
+
+function! vimspector#DestroySession( name ) abort
+  if !s:Enabled()
+    return
+  endif
+
+  py3 << EOF
+
+s = _vimspector_session_man.FindSessionByName( vim.eval( 'a:name' ) )
+if s is not None:
+  s = _vimspector_session_man.DestroyRootSession( s, _vimspector_session )
+  _VimspectorMakeActive( s )
+
+EOF
+endfunction
+
+function! vimspector#CompleteSessionName( ArgLead, CmdLine, CursorPos ) abort
+  " Don't call s:Enabled() because we don't want this function to initialise a
+  " new session
+  if !s:Initialised() || !s:enabled || py3eval( '_vimspector_session is None' )
+    return ''
+  endif
+  return py3eval( '"\n".join( _vimspector_session_man.GetSessionNames() )' )
+endfunction
+
+function! vimspector#GetSessionName() abort
+  if !s:Initialised() || !s:enabled || py3eval( '_vimspector_session is None' )
+    return ''
+  endif
+
+  return py3eval( '_vimspector_session.Name()' )
+endfunction
+
+function! vimspector#RenameSession( name ) abort
+  if !s:Enabled()
+    return
+  endif
+  py3 _vimspector_session.name = vim.eval( 'a:name' )
 endfunction
 
 function! vimspector#Launch( ... ) abort
@@ -548,7 +617,7 @@ endfunction
 
 function! vimspector#CompleteOutput( ArgLead, CmdLine, CursorPos ) abort
   if !s:Enabled()
-    return
+    return ''
   endif
   let buffers = py3eval( '_vimspector_session.GetOutputBuffers() '
                        \ . ' if _vimspector_session else []' )
@@ -557,7 +626,7 @@ endfunction
 
 function! vimspector#CompleteExpr( ArgLead, CmdLine, CursorPos ) abort
   if !s:Enabled()
-    return
+    return ''
   endif
 
   let col = len( a:ArgLead )

--- a/autoload/vimspector/internal/neojob.vim
+++ b/autoload/vimspector/internal/neojob.vim
@@ -41,7 +41,6 @@ function! s:_OnEvent( session_id, chan_id, data, event ) abort
     py3 _VimspectorSession( vim.eval( 'a:session_id' ) ).OnServerStderr(
           \ '\n'.join( vim.eval( 'a:data' ) ) )
   elseif a:event ==# 'exit'
-    echom 'Channel exit with status ' . a:data
     redraw
     unlet s:jobs[ a:session_id ]
     py3 _VimspectorSession( vim.eval( 'a:session_id' ) ).OnServerExit(
@@ -53,7 +52,7 @@ function! vimspector#internal#neojob#StartDebugSession(
       \ session_id,
       \ config ) abort
   if has_key( s:jobs, a:session_id )
-    echom 'Not starging: Job is already running'
+    echom 'Not starting: Job is already running'
     redraw
     return v:false
   endif
@@ -112,7 +111,6 @@ function! vimspector#internal#neojob#StopDebugSession( session_id ) abort
   endif
 
   if vimspector#internal#neojob#JobIsRunning( s:jobs[ a:session_id ] )
-    echom 'Terminating job'
     redraw
     call jobstop( s:jobs[ a:session_id ] )
   endif

--- a/autoload/vimspector/internal/state.vim
+++ b/autoload/vimspector/internal/state.vim
@@ -32,16 +32,42 @@ function! vimspector#internal#state#Reset() abort
 
 import vim
 
+def _VimspectorMakeActive( session ):
+  global _vimspector_session
+
+  if '_vimspector_session' not in globals() or _vimspector_session is None:
+    _vimspector_session = session
+    return True
+
+  if _vimspector_session == session:
+    # nothing to do
+    return False
+
+  if _vimspector_session is not None:
+    _vimspector_session.SwitchFrom()
+
+  _vimspector_session = session
+  return True
+
+def _VimspectorSwitchTo( session ):
+  global _vimspector_session
+
+  if _VimspectorMakeActive( session ) and _vimspector_session is not None:
+    _vimspector_session.SwitchTo()
+
+def _VimspectorSession( session_id ):
+  return _vimspector_session_man.GetSession( int( session_id ) )
+
 _vimspector_session_man = __import__(
   "vimspector",
   fromlist=[ "session_manager" ] ).session_manager.Get()
 
-# Deprecated
-_vimspector_session = _vimspector_session_man.NewSession(
-  vim.eval( 's:prefix' ) )
+_vimspector_session_man.api_prefix = vim.eval( 's:prefix' )
+if '_vimspector_session' in globals() and _vimspector_session is not None:
+  _vimspector_session_man.DestroyRootSession( _vimspector_session,
+                                              _vimspector_session )
+_VimspectorMakeActive( _vimspector_session_man.NewSession() )
 
-def _VimspectorSession( session_id ):
-  return _vimspector_session_man.GetSession( int( session_id ) )
 
 EOF
   catch /.*/
@@ -56,6 +82,13 @@ EOF
   return v:true
 endfunction
 
+function! vimspector#internal#state#NewSession( options ) abort
+  py3 << EOF
+_VimspectorMakeActive(
+  _vimspector_session_man.NewSession( **vim.eval( 'a:options' ) ) )
+EOF
+endfunction
+
 function! vimspector#internal#state#GetAPIPrefix() abort
   return s:prefix
 endfunction
@@ -63,31 +96,26 @@ endfunction
 function! vimspector#internal#state#TabClosed( afile ) abort
   py3 << EOF
 
-# reset if:
-# - a tab closed
-# - the vimspector session exists
-# - the vimspector session does _not_ have a UI (which suggests that it was
-#   probably the vimspector UI tab that was closed)
-#
-# noevim helpfully provides the tab number that was closed in <afile>, so we
-# use that there (it also doesn't correctly invalidate tab objects:
-# https://github.com/neovim/neovim/issues/16327)
-#
-# TODO: set a tab-local variable, or a global which maps tabs to session IDs
-# This probably doesn't work now with multiple-sessions
-
-if '_vimspector_session' in globals() and _vimspector_session:
-  if int( vim.eval( 's:is_neovim' ) ) and _vimspector_session.IsUITab(
-    int( vim.eval( 'a:afile' ) ) ):
-    _vimspector_session.Reset( interactive = False )
-  elif not _vimspector_session.HasUI():
-    _vimspector_session.Reset( interactive = False )
+# Try to reset any session which was closed.
+if '_vimspector_session_man' in globals():
+  if int( vim.eval( 's:is_neovim' ) ):
+    # noevim helpfully provides the tab number that was closed in <afile>, so we
+    # use that there (it also doesn't correctly invalidate tab objects:
+    # https://github.com/neovim/neovim/issues/16327), so we can't use the same
+    # code for both. And as usual, when raising bugs against neovim, they are
+    # simply closed and never fixed. sigh.
+    s = _vimspector_session_man.FindSessionByTab( int( vim.eval( 'a:afile' ) ) )
+    if s:
+      s.Reset( interactive = False )
+  else:
+    for session in _vimspector_session_man.SessionsWithInvalidUI():
+      session.Reset( interactive = False )
 
 EOF
 endfunction
 
 function! vimspector#internal#state#SwitchToSession( id ) abort
-  py3 _vimspector_session = _VimspectorSession( vim.eval( 'a:id' ) )
+  py3 _VimspectorSwitchTo( _VimspectorSession( vim.eval( 'a:id' ) ) )
 endfunction
 
 
@@ -98,7 +126,7 @@ if '_vimspector_session_man' in globals():
     int( vim.eval( 'tabpagenr()' ) ) )
 
   if session is not None:
-    _vimspector_session = session
+    _VimspectorMakeActive( session )
 EOF
 endfunction
 

--- a/plugin/vimspector.vim
+++ b/plugin/vimspector.vim
@@ -148,6 +148,20 @@ elseif s:mappings ==# 'HUMAN'
   nmap <F12>        <Plug>VimspectorStepOut
 endif
 
+" Session commands
+command! -bar -nargs=?
+      \ VimspectorNewSession
+      \ call vimspector#NewSession( <f-args> )
+command! -bar -nargs=1 -complete=custom,vimspector#CompleteSessionName
+      \ VimspectorSwitchToSession
+      \ call vimspector#SwitchToSession( <f-args> )
+command! -bar -nargs=1
+      \ VimspectorRenameSession
+      \ call vimspector#RenameSession( <f-args> )
+command! -bar -nargs=1 -complete=custom,vimspector#CompleteSessionName
+      \ VimspectorDestroySession
+      \ call vimspector#DestroySession( <f-args> )
+
 command! -bar -nargs=1 -complete=custom,vimspector#CompleteExpr
       \ VimspectorWatch
       \ call vimspector#AddWatch( <f-args> )

--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -53,9 +53,11 @@ def _JumpToBreakpoint( qfbp ):
 
 
 class BreakpointsView( object ):
-  def __init__( self ):
+  def __init__( self, session_id ):
     self._win = None
     self._buffer = None
+    self._buffer_name = utils.BufferNameForSession( 'vimspector.Breakpoints',
+                                                    session_id )
     self._breakpoint_list = []
 
   def _HasWindow( self ):
@@ -88,8 +90,7 @@ class BreakpointsView( object ):
             vim.command( f'nnoremap <silent> <buffer> { mapping } '
                          ':<C-u>call '
                          f'vimspector#{ func }()<CR>' )
-        utils.SetUpHiddenBuffer( self._buffer,
-                                 "vimspector.Breakpoints" )
+        utils.SetUpHiddenBuffer( self._buffer, self._buffer_name )
 
       self._win = vim.current.window
 
@@ -223,7 +224,7 @@ class ProjectBreakpoints( object ):
     self._pending_send_breakpoints = []
 
 
-    self._breakpoints_view = BreakpointsView()
+    self._breakpoints_view = BreakpointsView( session_id )
 
     if not signs.SignDefined( 'vimspectorBP' ):
       signs.DefineSign( 'vimspectorBP',
@@ -429,11 +430,7 @@ class ProjectBreakpoints( object ):
 
   def ClearBreakpoints( self ):
     # These are the user-entered breakpoints.
-    for file_name, breakpoints in self._line_breakpoints.items():
-      for bp in breakpoints:
-        self._SignToLine( file_name, bp )
-        if 'sign_id' in bp:
-          signs.UnplaceSign( bp[ 'sign_id' ], 'VimspectorBP' )
+    self._HideBreakpoints()
 
     self._line_breakpoints = defaultdict( list )
     self._func_breakpoints = []
@@ -762,6 +759,11 @@ class ProjectBreakpoints( object ):
     } )
 
     self.UpdateUI()
+
+
+  def ClearUI( self ):
+    self._HideBreakpoints()
+    self._breakpoints_view.CloseBreakpoints()
 
 
   def UpdateUI( self, then = None ):
@@ -1114,6 +1116,15 @@ class ProjectBreakpoints( object ):
                            sign,
                            file_name,
                            line )
+
+  def _HideBreakpoints( self ):
+    for file_name, breakpoints in self._line_breakpoints.items():
+      for bp in breakpoints:
+        self._SignToLine( file_name, bp )
+        if 'sign_id' in bp:
+          signs.UnplaceSign( bp[ 'sign_id' ], 'VimspectorBP' )
+          del bp[ 'sign_id' ]
+
 
   def _SignToLine( self, file_name, bp ):
     if bp[ 'is_instruction_breakpoint' ]:

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -173,7 +173,7 @@ class DebugSession( object ):
     self._launch_complete = False
     self._on_init_complete_handlers = []
     self._server_capabilities = {}
-    self.ClearTemporaryBreakpoints()
+    self._breakpoints.ClearTemporaryBreakpoints()
 
 
   def GetConfigurations( self, adapters ):
@@ -2106,11 +2106,11 @@ class DebugSession( object ):
 
 
   def RunTo( self, file_name, line ):
-    self.ClearTemporaryBreakpoints()
-    self.SetLineBreakpoint( file_name,
-                            line,
-                            { 'temporary': True },
-                            lambda: self.Continue() )
+    self._breakpoints.ClearTemporaryBreakpoints()
+    self._breakpoints.AddTemporaryLineBreakpoint( file_name,
+                                                  line,
+                                                  { 'temporary': True },
+                                                  lambda: self.Continue() )
 
   @CurrentSession()
   @IfConnected()
@@ -2156,9 +2156,6 @@ class DebugSession( object ):
       },
     }, failure_handler )
 
-
-  def ClearTemporaryBreakpoints( self ):
-    return self._breakpoints.ClearTemporaryBreakpoints()
 
   def SetLineBreakpoint( self, file_name, line_num, options, then = None ):
     return self._breakpoints.SetLineBreakpoint( file_name,

--- a/python3/vimspector/output.py
+++ b/python3/vimspector/output.py
@@ -199,7 +199,7 @@ class OutputView( object ):
       out = utils.SetUpCommandBuffer(
         self._session_id,
         cmd,
-        utils.BufferNameForSession( category, self._session_id ),
+        category,
         self._api_prefix,
         completion_handler = completion_handler )
 

--- a/python3/vimspector/session_manager.py
+++ b/python3/vimspector/session_manager.py
@@ -15,6 +15,7 @@
 
 import typing
 from vimspector.debug_session import DebugSession
+from vimspector import utils
 
 # Singleton
 _session_manager = None
@@ -23,6 +24,7 @@ _session_manager = None
 class SessionManager:
   next_session_id: int
   sessions: typing.Dict[ int, DebugSession ]
+  api_prefix: str = ''
 
   def __init__( self ):
     self.Reset()
@@ -36,18 +38,78 @@ class SessionManager:
   def NewSession( self, *args, **kwargs ) -> DebugSession:
     session_id = self.next_session_id
     self.next_session_id += 1
-    session = DebugSession( session_id, self, *args, **kwargs )
+    session = DebugSession( session_id, self, self.api_prefix, *args, **kwargs )
     self.sessions[ session_id ] = session
 
     return session
 
 
   def DestroySession( self, session: DebugSession ):
-    del self.sessions[ session.session_id ]
+    try:
+      session = self.sessions.pop( session.session_id )
+    except KeyError:
+      return
+
+
+  def DestroyRootSession( self,
+                          session: DebugSession,
+                          active_session: DebugSession ):
+    if session.HasUI() or session.Connection():
+      utils.UserMessage( "Can't destroy active session; use VimspectorReset",
+                         error = True )
+      return active_session
+
+    try:
+      self.sessions.pop( session.session_id )
+      session.Destroy()
+    except KeyError:
+      utils.UserMessage( "Session doesn't exist", error = True )
+      return active_session
+
+    if active_session != session:
+      # OK, we're done. No need to change the active session
+      return active_session
+
+    # Return the first root session in the list to be the new active one
+    for existing_session in self.sessions.values():
+      if not existing_session.parent_session:
+        return existing_session
+
+    # There are somehow no non-root sessions. Clear the current one. We'll
+    # probably create a new one next time the user does anything.
+    return None
 
 
   def GetSession( self, session_id ) -> DebugSession:
     return self.sessions.get( session_id )
+
+
+  def GetSessionNames( self ) -> typing.List[ str ]:
+    return [ s.Name()
+             for s in self.sessions.values()
+             if not s.parent_session and s.Name() ]
+
+
+  def SessionsWithInvalidUI( self ):
+    for _, session in self.sessions.items():
+      if not session.parent_session and not session.HasUI():
+        yield session
+
+
+  def FindSessionByTab( self, tabnr: int ) -> DebugSession:
+    for _, session in self.sessions.items():
+      if session.HasUI() and session.IsUITab( tabnr ):
+        return session
+
+    return None
+
+
+  def FindSessionByName( self, name ) -> DebugSession:
+    for _, session in self.sessions.items():
+      if session.Name() == name:
+        return session
+
+    return None
 
 
   def SessionForTab( self, tabnr ) -> DebugSession:

--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -1087,13 +1087,7 @@ def Hex( val: int ):
 
 
 def BufferNameForSession( name, session_id ):
-  # if session_id == 0:
-  #   # Hack for backward compat - don't suffix with the ID for the "first"
-  #   # session
-  #   return name
-
-  # return f'{name}[{session_id}]'
-  return name
+  return f'{name}[{session_id}]'
 
 
 def ClearTextPropertiesForBuffer( buf ):

--- a/support/minimal_vimrc
+++ b/support/minimal_vimrc
@@ -1,3 +1,4 @@
+let g:vimspector_clean = 1
 let s:vimspector_path = expand( '<sfile>:p:h:h' )
 let g:vimspector_enable_mappings = 'HUMAN'
 exe 'source ' . s:vimspector_path . '/tests/vimrc'

--- a/tests/breakpoints.test.vim
+++ b/tests/breakpoints.test.vim
@@ -917,19 +917,20 @@ function! Test_ListBreakpoints()
 
   augroup Test_ListBreakpoints
     autocmd!
-    autocmd BufEnter,BufFilePost vimspector.Breakpoints
+    autocmd BufEnter,BufFilePost vimspector.Breakpoints*
           \ let g:Test_ListBreakpoints_Enter += 1
-    autocmd BufLeave vimspector.Breakpoints
+    autocmd BufLeave vimspector.Breakpoints*
           \ let g:Test_ListBreakpoints_Leave += 1
   augroup END
 
+  " vimspector.Breakpoints[0]
   " @show
   call vimspector#ListBreakpoints()
   " buffer is never actually empty
   call s:CheckBreakpointView( [ '' ] )
   " Cursor jumps to the breakpoint window
   call assert_equal( win_getid(), g:vimspector_session_windows.breakpoints )
-  call assert_equal( bufname(), 'vimspector.Breakpoints' )
+  call assert_match( 'vimspector.Breakpoints[\[0-9]\+]',  bufname() )
   call assert_equal( 1, g:Test_ListBreakpoints_Enter )
 
   call win_gotoid( main_win_id )

--- a/tests/tabpage.test.vim
+++ b/tests/tabpage.test.vim
@@ -175,14 +175,6 @@ endfunction
 
 function! Test_Close_Tab_With_Vimspector()
   call s:StartDebugging()
-  call vimspector#test#setup#WaitForReset()
-  call s:StartDebugging()
-  tabclose!
-  %bwipe!
-endfunction
-
-function! Test_Close_Tab_With_Vimspector()
-  call s:StartDebugging()
   tabedit newfile
   tabclose
 

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -12,14 +12,10 @@ function! TearDown()
 endfunction
 
 function! ConsoleBufferName()
-  return 'vimspector.Console'
+  " return 'vimspector.Console'
 
-  " let session_id = py3eval( '_vimspector_session.session_id' )
-  " if session_id == 0
-  "   return 'vimspector.Console'
-  " endif
-
-  " return 'vimspector.Console' .. session_id
+  let session_id = py3eval( '_vimspector_session.session_id' )
+  return 'vimspector.Console[' .. session_id .. ']'
 endfunction
 
 function! s:StartDebugging( ... )

--- a/tests/variables_compact.test.vim
+++ b/tests/variables_compact.test.vim
@@ -11,14 +11,8 @@ function! TearDown()
 endfunction
 
 function! ConsoleBufferName()
-  return 'vimspector.Console'
-
-  " let session_id = py3eval( '_vimspector_session.session_id' )
-  " if session_id == 0
-  "   return 'vimspector.Console'
-  " endif
-
-  " return 'vimspector.Console' .. session_id
+  let session_id = py3eval( '_vimspector_session.session_id' )
+  return 'vimspector.Console[' .. session_id .. ']'
 endfunction
 
 function! s:StartDebugging( ... )


### PR DESCRIPTION
This is a bit clunky but works, even for 2 root level sessions which themselves have child sessions.

You have the following facilities:

1. VimspectorNewSession <name> This creates a new session and makes it active. Optional name is used in place of the generated one when starting a launch.

2. Switching to a specific debug tab makes that session active. This is intuitive and probably the most common way to work with this.

3. Switching manually using VimspectorSwitchToSession <tab complete>.

4. vimspector#GetSessionName() useful for putting in a statusline. I used this:

```
function! BenGetCustomInfo()
  if !empty( &buftype )
    return ''
  endif

  if !exists( '*vimspector#GetSessionName' )
    return ''
  endif

  return vimspector#GetSessionName()
endfunction

" ... statusline stuff
" Custom info
set statusline+=%*
set statusline+=%(\ %.20{BenGetCustomInfo()}\ %)

```

TODO: The tests will fail due to the change in name of the session buffers.

Fixes #749 