### PR TITLE
Bash argssstring

### DIFF
--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -332,6 +332,7 @@ GADGETS = {
           "type": "bashdb",
           "program": "${file}",
           "args": [],
+          "argsString": "",
           "env": {},
           "pathBash": "bash",
           "pathBashdb": "${BASHDB_HOME}/bashdb",


### PR DESCRIPTION
The undocumented required arguments:

```
export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {

    // Non-optional arguments are guaranteed to be defined in extension.ts: resolveDebugConfiguration().
    argsString: string;
    args: string[];
    env: object;
    cwd: string;
    cwdEffective: string;
    program: string;
    programEffective: string;
    pathBash: string;
    pathBashdb: string;
    pathBashdbLib: string;
    pathCat: string;
    pathMkfifo: string;
    pathPkill: string;
    terminalKind?: 'integrated' | 'external' | 'debugConsole';
    showDebugOutput?: boolean;
    /** enable logging the Debug Adapter Protocol */
    trace?: boolean;
}

```

From: https://github.com/rogalmic/vscode-bash-debug/blob/e9ae6ea07c05ce621d2f25b899b5560d000d9c57/src/bashDebug.ts#L17

"Resolved" sadly by client-side-specific code here: https://github.com/rogalmic/vscode-bash-debug/blob/e9ae6ea07c05ce621d2f25b899b5560d000d9c57/src/extension.ts#L46

Seems DAP following in LSP footsteps.

Fixes #766 