### PR TITLE
Expand references in calculus function arguments

### DIFF
--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -672,7 +672,15 @@ def ExpandReferencesInString( orig_s,
       key = e.name + e.arg_hash
 
       if e.name in calculus:
-        mapping[ key ] = calculus[ e.name ]( *e.args )
+        # Expand any recursive mappings in the args.... eeeek
+        new_args = []
+        for arg in e.args:
+          new_args.append( ExpandReferencesInObject( arg,
+                                                     mapping,
+                                                     calculus,
+                                                     user_choices ) )
+
+        mapping[ key ] = calculus[ e.name ]( *new_args )
         _logger.debug( "Put %s into mapping for %s with args %s",
                        key,
                        e.name,

--- a/tests/python/Test_ExpandReferencesInDict.py
+++ b/tests/python/Test_ExpandReferencesInDict.py
@@ -134,11 +134,15 @@ class TestExpandReferencesInDict( unittest.TestCase ):
         'in': {
           'variables_list': {
             'not_in_list': '${is_in_list( "x", [ "y", "z" ] )}',
-            'in_list': '${is_in_list( "x", [ "y", "x", "z" ] )}',
+            'in_list': '${is_in_list( "x", [ "${why}", "x", "z" ] )}',
             'not_in_listj#json': '${is_in_list( "x", [ "y", "z" ] )}',
-            'in_listj#json': '${is_in_list( "x", [ "y", "x", "z" ] )}',
+            'in_listj#json':
+              '${is_in_list( "x", [ "${why}", "x", "${zed}" ] )}',
           },
-          'mapping': {},
+          'mapping': {
+            'why': 'y',
+            'zed': 'z'
+          },
           'calculus': {
             'is_in_list':
               lambda needle, haystack: 'true' if needle in haystack else 'false'


### PR DESCRIPTION
This allows for the use of variables as arguments to functions.

In particular, the following is now possible:

     "configuration": {
       "request": "attach",
       "processId": "${PickProcess(\"${programName}\")}",
       "program": "$BUILD/platform/bin64/${programName}",
       "expresssions": "native"
     }

The result is that you're asked for the program _name_ and it filters for that, and uses it as the binary.

Doesn't work for function-calls-inside-function-calls because of not enough escaping levels for parameters, but that's probably OK. The above is a real use case however, and it works.

This is mad, gnarly stuff which probably shouldn't be used, but that's also true of the whole of this entire macro-templating system, which honestly needs to be compeltely ditched!