### PR TITLE
Fix expanding variables after restart

### DIFF
--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -103,8 +103,9 @@ class WatchResult( Expandable ):
   def MemoryReference( self ):
     return self.result.get( 'memoryReference' )
 
-  def Update( self, result ):
+  def Update( self, connection, result ):
     self.changed = False
+    self.connection = connection
     if self.result[ 'result' ] != result[ 'result' ]:
       self.changed = True
     self.result = result
@@ -141,8 +142,9 @@ class Variable( Expandable ):
   def MemoryReference( self ):
     return self.variable.get( 'memoryReference' )
 
-  def Update( self, variable ):
+  def Update( self, connection, variable ):
     self.changed = False
+    self.connection = connection
     if self.variable[ 'value' ] != variable[ 'value' ]:
       self.changed = True
     self.variable = variable
@@ -429,7 +431,7 @@ class VariablesView( object ):
       if watch.result is None or watch.result.connection != connection:
         watch.result = WatchResult( connection, message[ 'body' ] )
       else:
-        watch.result.Update( message[ 'body' ] )
+        watch.result.Update( connection, message[ 'body' ] )
 
       popup_win_id = utils.CreateTooltip( [], is_hover )
       # record the global eval window id
@@ -534,7 +536,7 @@ class VariablesView( object ):
 
   def _UpdateWatchExpression( self, watch: Watch, message: dict ):
     if watch.result is not None:
-      watch.result.Update( message[ 'body' ] )
+      watch.result.Update( watch.connection, message[ 'body' ] )
     else:
       watch.result = WatchResult( watch.connection, message[ 'body' ] )
 
@@ -648,7 +650,7 @@ class VariablesView( object ):
           },
         } )
 
-      variable.Update( new_variable )
+      variable.Update( variable.connection, new_variable )
       view.draw()
 
     def failure_handler( reason, message ):
@@ -822,7 +824,7 @@ class VariablesView( object ):
       if not found:
         variable = Variable( parent.connection, parent, variable_body )
       else:
-        variable.Update( variable_body )
+        variable.Update( parent.connection, variable_body )
 
       new_variables.append( variable )
 


### PR DESCRIPTION
We use the connection property of the result when expanding, so we need to update it when we get a new result. Most of the time this will be NOP but in the case of a variable which is carried over from a previous session, it will change the first time we refresh it.

Fixes #789 