### PR TITLE
documentation: Correct spelling error for gdbserver example

### DIFF
--- a/doc/vimspector-ref.txt
+++ b/doc/vimspector-ref.txt
@@ -1068,7 +1068,7 @@ gdbserver and have to tell cpptools a few more options.
               "gdbserver",
               "--once",
               "--no-startup-with-shell",
-              "--disable-randomisation",
+              "--disable-randomization",
               "0.0.0.0:${port}",
               "%CMD%"
             ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1021,7 +1021,7 @@ and have to tell cpptools a few more options.
             "gdbserver",
             "--once",
             "--no-startup-with-shell",
-            "--disable-randomisation",
+            "--disable-randomization",
             "0.0.0.0:${port}",
             "%CMD%"
           ]


### PR DESCRIPTION
The --disable-randomization argument was spelled the British way, which keeps gdbserver from starting correctly