### PR TITLE
Update Delve version in gadgets.py

### DIFF
--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -353,7 +353,7 @@ GADGETS = {
                                                              gadget ),
     'all': {
       'path': 'github.com/go-delve/delve/cmd/dlv',
-      'version': '1.20.1',
+      'version': '1.21.0',
     },
     'adapters': {
       "delve": {


### PR DESCRIPTION
Delve 1.21.0 is required to debug programs compiled with Go 1.21