### PR TITLE
Add feature option to disable auto hovering

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,10 +126,12 @@ jobs:
           brew install $p || brew outdated $p || brew upgrade $p
         done
         brew reinstall icu4c
-        brew link --overwrite python
+        # neovim doesn't work on python 3.12
+        brew link --overwrite python@3.11
         brew link --overwrite vim
         brew link --overwrite go
-        pip3 install --user neovim
+        # https://github.com/neovim/pynvim/issues/538
+        pip install --user 'pynvim @ git+https://github.com/neovim/pynvim'
       name: 'Install vim and deps'
 
     - name: 'Install requirements'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,7 +122,7 @@ jobs:
         brew update-reset
         brew doctor || true
         brew cleanup || true
-        for p in vim go tcl-tk llvm lua luajit love neovim; do
+        for p in vim go tcl-tk llvm lua luajit love neovim coreutils; do
           brew install $p || brew outdated $p || brew upgrade $p
         done
         brew reinstall icu4c

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,12 +126,12 @@ jobs:
           brew install $p || brew outdated $p || brew upgrade $p
         done
         brew reinstall icu4c
-        # neovim doesn't work on python 3.12
-        brew link --overwrite python@3.11
+        brew link --overwrite python
         brew link --overwrite vim
         brew link --overwrite go
+        # latest neovim doesn't work on python 3.12
         # https://github.com/neovim/pynvim/issues/538
-        pip install --user 'pynvim @ git+https://github.com/neovim/pynvim'
+        pip3 install --user 'pynvim @ git+https://github.com/neovim/pynvim'
       name: 'Install vim and deps'
 
     - name: 'Install requirements'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,6 +173,19 @@ When contributing pull requests, I ask that:
 
 ### Running the tests locally
 
+Requirements for running the tests:
+
+* Linux or macOS
+* Supported Vim or Neovim version (ideally both)
+* acsiinema instaled (`pip3 install --user asciinema`)
+* `timeout` installed (on macOS: `brew install coreutils`)
+* various other dependencies for the individual debuggers.
+
+The simplest way to run the tests is using the container image, as all
+dependencies are there for you. If you decide not to, then the best way to work
+out what's required is to look at either the `Dockerfile` (for Linux) or the
+`.github/workflows/build.yaml` (for macOS).
+
 There are 2 ways:
 
 1. In the docker container. The CI tests for linux run in a container, so as to

--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ The following sections expand on the above brief overview.
 Vimspector requires:
 
 * One of:
-  * Vim 8.2 Huge build compiled with Python 3.10 or later
-  * Neovim 0.8 with Python 3.10 or later (experimental)
+  * Vim 8.2.4797 or later "huge" build compiled with Python 3.10 or later
+  * Neovim 0.8 with Python 3.10 or later
 * One of the following operating systems:
   * Linux
   * macOS Mojave or later
@@ -1266,6 +1266,10 @@ All rules for `Variables and scopes` apply plus the following:
 
 ![variable eval hover](https://puremourning.github.io/vimspector-web/img/vimspector-variable-eval-hover.png)
 
+You can disable automatic hovering popup by settings
+`g:vimspector_enable_auto_hover=0` before starting the debug session. You can
+then map something to `<Plug>VimspectorBalloonEval` and trigger it manually.
+
 ## Watches
 
 The watch window is used to inspect variables and expressions. Expressions are
@@ -1293,6 +1297,10 @@ If you prefer a more verbose display for variables and watches, then you can
 value are displayed, with other data available from hovering the mouse or
 triggering `<Plug>VimspectorBalloonEval` on the line containing the value in the
 variables (or watches) window.
+
+You can disable automatic hovering popup by settings
+`g:vimspector_enable_auto_hover=0` before starting the debug session. You can
+then map something to `<Plug>VimspectorBalloonEval` and trigger it manually.
 
 ### Watch autocompletion
 

--- a/autoload/vimspector/internal/channel.vim
+++ b/autoload/vimspector/internal/channel.vim
@@ -121,6 +121,9 @@ function! vimspector#internal#channel#Send( session_id, msg ) abort
   catch /E631/
     " Channel is closed
     return 0
+  catch /E906/
+    " Channel is closed
+    return 0
   endtry
 endfunction
 

--- a/autoload/vimspector/internal/job.vim
+++ b/autoload/vimspector/internal/job.vim
@@ -145,6 +145,8 @@ function! vimspector#internal#job#Send( session_id, msg ) abort
     return 1
   catch /E631/
     return 0
+  catch /E906/
+    return 0
   endtry
 endfunction
 

--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -37,8 +37,9 @@ DEFAULTS = {
   'terminal_maxheight': 15,
   'terminal_minheight': 5,
 
-  # WinBar
+  # Features
   'enable_winbar':      True,
+  'enable_auto_hover':  True,
 
   # Session files
   'session_file_name': '.vimspector.session',

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -282,28 +282,29 @@ class VariablesView( object ):
         )
 
     # Set the (global!) balloon expr if supported
-    has_balloon      = int( vim.eval( "has( 'balloon_eval' )" ) )
-    has_balloon_term = int( vim.eval( "has( 'balloon_eval_term' )" ) )
-
     self._oldoptions = {}
-    if has_balloon or has_balloon_term:
-      self._oldoptions = {
-        'balloonexpr': vim.options[ 'balloonexpr' ],
-        'balloondelay': vim.options[ 'balloondelay' ],
-      }
-      vim.options[ 'balloonexpr' ] = (
-        "vimspector#internal#balloon#HoverEvalTooltip()"
-      )
+    if settings.Bool( 'enable_auto_hover' ):
+      has_balloon      = int( vim.eval( "has( 'balloon_eval' )" ) )
+      has_balloon_term = int( vim.eval( "has( 'balloon_eval_term' )" ) )
 
-      vim.options[ 'balloondelay' ] = 250
+      if has_balloon or has_balloon_term:
+        self._oldoptions = {
+          'balloonexpr': vim.options[ 'balloonexpr' ],
+          'balloondelay': vim.options[ 'balloondelay' ],
+        }
+        vim.options[ 'balloonexpr' ] = (
+          "vimspector#internal#balloon#HoverEvalTooltip()"
+        )
 
-    if has_balloon:
-      self._oldoptions[ 'ballooneval' ] = vim.options[ 'ballooneval' ]
-      vim.options[ 'ballooneval' ] = True
+        vim.options[ 'balloondelay' ] = 250
 
-    if has_balloon_term:
-      self._oldoptions[ 'balloonevalterm' ] = vim.options[ 'balloonevalterm' ]
-      vim.options[ 'balloonevalterm' ] = True
+      if has_balloon:
+        self._oldoptions[ 'ballooneval' ] = vim.options[ 'ballooneval' ]
+        vim.options[ 'ballooneval' ] = True
+
+      if has_balloon_term:
+        self._oldoptions[ 'balloonevalterm' ] = vim.options[ 'balloonevalterm' ]
+        vim.options[ 'balloonevalterm' ] = True
 
 
   def Clear( self ):

--- a/python3/vimspector/vendor/json_minify.py
+++ b/python3/vimspector/vendor/json_minify.py
@@ -40,7 +40,7 @@ import re
 # Vimspector modification: strip_space defaults to False; we don't actually want
 # to minify - we just want to strip comments.
 def minify(string, strip_space=False):
-    tokenizer = re.compile('"|(/\*)|(\*/)|(//)|\n|\r')
+    tokenizer = re.compile(r'"|(/\*)|(\*/)|(//)|\n|\r')
     end_slashes_re = re.compile(r'(\\)*$')
 
     in_string = False

--- a/run_tests
+++ b/run_tests
@@ -129,10 +129,17 @@ VERSION_OPTIONS=$([ "$IS_NVIM" -ne 0 ] && echo '--headless' || echo '--not-a-ter
 
 RUN_VIM="${VIM_EXE} -N --clean ${VERSION_OPTIONS}"
 
+if which timeout >/dev/null 2>&1; then
+  TIMEOUT_SCRIPT="timeout --verbose --foreground --kill-after 7m 5m"
+else
+  TIMEOUT_SCRIPT=""
+  echo "WARNING: No timeout found, not using timeout"
+fi
+
 # There seems to be a race condition with the way asciinema sets the pty size.
 # It does fork() then if is_child: execvpe(...) else: set_pty_size(). This means
 # the child might read the pty size before it's set. So we use a 1s sleepy.
-RUN_TEST="sleep 1 && ${RUN_VIM} -S lib/run_test.vim"
+RUN_TEST="sleep 1 && ${TIMEOUT_SCRIPT} ${RUN_VIM} -S lib/run_test.vim"
 
 # We use fd 3 for vim's output. Send it to stdout if not already redirected
 # Note: can't use ${out_fd} in a redirect because redirects happen before
@@ -143,7 +150,7 @@ fi
 
 # Basic pre-flight check that vim and python work
 # ffs neovim https://github.com/neovim/neovim/issues/14438
-if ${RUN_VIM} -u support/test_python3.vim .fail; then
+if ${TIMEOUT_SCRIPT} ${RUN_VIM} -u support/test_python3.vim .fail; then
   rm -f .fail
   echo "$VIM_EXE appears to have working python3 support. Let's go..."
 else

--- a/run_tests
+++ b/run_tests
@@ -136,6 +136,14 @@ else
   echo "WARNING: No timeout found, not using timeout"
 fi
 
+# Check that vim's python support actual works, else we can't run tests
+if ! ${TIMEOUT_SCRIPT} ${RUN_VIM} --cmd "py3 import vim; vim.command( 'qa!' )" --cmd "cquit!"; then
+  echo "Vim's python support doesn't work. Cannot run tests" >&2
+  exit 1
+else
+  echo "Vim's python support works. Let's go..."
+fi
+
 # There seems to be a race condition with the way asciinema sets the pty size.
 # It does fork() then if is_child: execvpe(...) else: set_pty_size(). This means
 # the child might read the pty size before it's set. So we use a 1s sleepy.

--- a/tests/ci/image/Dockerfile
+++ b/tests/ci/image/Dockerfile
@@ -5,6 +5,8 @@ ENV LC_ALL C.UTF-8
 ARG GOARCH=amd64
 ARG GOVERSION=1.20.1
 ARG NODE_MAJOR=18
+ARG VIM_VERSION=v8.2.4797
+
 
 RUN apt-get update && \
   apt-get install -y curl \
@@ -80,8 +82,6 @@ RUN apt-get -y autoremove
 
 ## cleanup of files from setup
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ARG VIM_VERSION=v8.2.4797
 
 ENV CONF_ARGS "--with-features=huge \
                --enable-python3interp \

--- a/tests/ci/image/Dockerfile
+++ b/tests/ci/image/Dockerfile
@@ -6,6 +6,7 @@ ARG GOARCH=amd64
 ARG GOVERSION=1.20.1
 ARG NODE_MAJOR=18
 ARG VIM_VERSION=v8.2.4797
+ARG NVIM_VERSION=v0.8.3
 
 
 RUN apt-get update && \
@@ -40,9 +41,25 @@ RUN apt-get update && \
                      nodejs \
                      pkg-config \
                      lua5.1 \
-                     luajit && \
-  pip3 install neovim
-
+                     luajit \
+                     lua5.1-dev \
+                     luajit-5.1-dev \
+                     libsdl2-dev \
+                     libopenal-dev \
+                     libfreetype6-dev \
+                     libmodplug-dev \
+                     libvorbis-dev \
+                     libtheora-dev \
+                     libmpg123-dev \
+                     ninja-build \
+                     gettext \
+                     cmake \
+                     unzip \
+                     curl && \
+  apt-get -y autoremove && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+  pip3 install neovim && \
+  pip install "git+https://github.com/puremourning/asciinema@exit_code#egg=asciinema"
 
 RUN ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime && \
   dpkg-reconfigure --frontend noninteractive tzdata
@@ -51,21 +68,10 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1 \
                         --slave   /usr/bin/g++ g++ /usr/bin/g++-8
 
 RUN curl -LO https://golang.org/dl/go${GOVERSION}.linux-${GOARCH}.tar.gz && \
-    tar -C /usr/local -xzvf go${GOVERSION}.linux-${GOARCH}.tar.gz
-
-RUN update-alternatives --install /usr/local/bin/go go /usr/local/go/bin/go 1
+    tar -C /usr/local -xzvf go${GOVERSION}.linux-${GOARCH}.tar.gz && \
+    update-alternatives --install /usr/local/bin/go go /usr/local/go/bin/go 1
 
 # In order for love to work on arm64, we have to build it ourselves
-RUN apt-get -y install lua5.1-dev \
-                       luajit-5.1-dev \
-                       libsdl2-dev \
-                       libopenal-dev \
-                       libfreetype6-dev \
-                       libmodplug-dev \
-                       libvorbis-dev \
-                       libtheora-dev \
-                       libmpg123-dev
-
 RUN curl -LO https://github.com/love2d/love/releases/download/11.3/love-11.3-linux-src.tar.gz && \
     tar zxvf love-11.3-linux-src.tar.gz && \
     cd love-11.3 && \
@@ -75,13 +81,6 @@ RUN curl -LO https://github.com/love2d/love/releases/download/11.3/love-11.3-lin
     cd .. && \
     rm -rf love-11.3 && \
     rm -f love-11.3-linux-src.tar.gz
-
-RUN apt-get install -y ninja-build gettext cmake unzip curl
-
-RUN apt-get -y autoremove
-
-## cleanup of files from setup
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV CONF_ARGS "--with-features=huge \
                --enable-python3interp \
@@ -98,8 +97,6 @@ RUN mkdir -p $HOME/vim && \
     cd && \
     rm -rf $HOME/vim
 
-ARG NVIM_VERSION=v0.8.3
-
 RUN mkdir -p $HOME/nvim && \
     cd $HOME/nvim && \
     git clone --depth 1 --branch ${NVIM_VERSION} https://github.com/neovim/neovim && \
@@ -114,9 +111,6 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh \
         | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet && \
         update-alternatives --install /usr/bin/dotnet dotnet \
                                                       /usr/share/dotnet/dotnet 1
-
-# test requirements
-RUN pip install "git+https://github.com/puremourning/asciinema@exit_code#egg=asciinema"
 
 # clean up
 RUN rm -rf ~/.cache

--- a/tests/lib/autoload/vimspector/test/setup.vim
+++ b/tests/lib/autoload/vimspector/test/setup.vim
@@ -66,7 +66,7 @@ function! vimspector#test#setup#WaitForReset() abort
   call WaitForAssert( {->
         \ assert_true( pyxeval( '_vimspector_session is None or ' .
         \                       '_vimspector_session._uiTab is None' ) )
-        \ }, 10000 )
+        \ }, g:test_long_timeout )
 
   call vimspector#test#signs#AssertSignGroupEmpty( 'VimspectorCode' )
 endfunction
@@ -80,7 +80,7 @@ function! vimspector#test#setup#WaitForSessionReset( session_id ) abort
   call WaitForAssert( {->
         \ assert_true( pyxeval( s ..' is None or ' .
         \                       s .. '._uiTab is None' ) )
-        \ }, 10000 )
+        \ }, g:test_long_timeout )
 endfunction
 
 function! vimspector#test#setup#Reset() abort

--- a/tests/lib/autoload/vimspector/test/setup.vim
+++ b/tests/lib/autoload/vimspector/test/setup.vim
@@ -107,6 +107,7 @@ function! vimspector#test#setup#PushGlobal( name, value ) abort
   endif
 
   let old_value = get( g:, a:name, v:null )
+  call TestLog( 'Overriding ' . a:name . ' to ' . string( a:value ) )
   call add( s:g_stack[ a:name ], old_value )
   let g:[ a:name ] = a:value
 
@@ -119,6 +120,7 @@ function! vimspector#test#setup#PopGlobal( name ) abort
   endif
 
   let old_value = s:g_stack[ a:name ][ -1 ]
+  call TestLog( 'Restoring ' . a:name . ' to ' . string( old_value ) )
   call remove( s:g_stack[ a:name ], -1 )
 
   if old_value is v:null
@@ -139,6 +141,7 @@ function! vimspector#test#setup#PushOption( name, value ) abort
 
   let old_value = v:null
   execute 'let old_value = &' . a:name
+  call TestLog( 'Overriding &' . a:name . ' to ' . string( a:value ) )
   call add( s:o_stack[ a:name ], old_value )
   execute 'set ' . a:name . '=' . a:value
   return old_value
@@ -150,6 +153,7 @@ function! vimspector#test#setup#PopOption( name ) abort
   endif
 
   let old_value = s:o_stack[ a:name ][ -1 ]
+  call TestLog( 'Restoring &' . a:name . ' to ' . string( old_value ) )
   call remove( s:o_stack[ a:name ], -1 )
 
   execute 'set ' . a:name . '=' . old_value

--- a/tests/lib/autoload/vimspector/test/signs.vim
+++ b/tests/lib/autoload/vimspector/test/signs.vim
@@ -10,10 +10,10 @@ function! vimspector#test#signs#AssertCursorIsAtLineInBuffer( buffer,
         \ assert_equal( fnamemodify( a:buffer, ':p' ),
         \               fnamemodify( bufname( '%' ), ':p' ),
         \               'Current buffer' )
-        \ }, 15000 )
+        \ }, g:test_long_timeout )
   call WaitForAssert( {->
         \ assert_equal( a:line, line( '.' ), 'Current line' )
-        \ }, 15000 )
+        \ }, g:test_long_timeout )
   if a:column isnot v:null
     call assert_equal( a:column, col( '.' ), 'Current column' )
   endif

--- a/tests/lib/plugin/shared.vim
+++ b/tests/lib/plugin/shared.vim
@@ -112,12 +112,12 @@ endfunction
 " In neovim, py3eval( 'None' ) returns v:null, and v:none does not exist
 function! AssertNull( actual ) abort
   return assert_equal( type( v:null ), type( a:actual ),
-      \ 'actual: ' .. a:actual  )
+      \ 'Expected null, but actually: ' .. a:actual  )
 endfunction
 
 function! AssertNotNull( actual ) abort
   return assert_notequal( type( v:null ), type( a:actual ),
-      \ 'actual: ' .. a:actual  )
+      \ 'Expected not null, but actually: ' .. a:actual  )
 endfunction
 
 function! AssertMatchList( expected, actual ) abort
@@ -174,4 +174,14 @@ function! FunctionBreakOnBrace() abort
   " between x86 and arm
   return trim( system( 'uname -m' ) ) ==# 'x86_64'
         \ && trim( system( 'uname -s' ) ) ==# 'Linux'
+endfunction
+
+function MoveMouseToPositionInWindow( win_id, line, colum ) abort
+  let pos = screenpos( a:win_id, a:line, a:colum )
+  return MoveMouseTo( pos.row, pos.col )
+endfunction
+
+function! MoveMouseTo( screen_line, screen_column ) abort
+  call test_setmouse( a:screen_line, a:screen_column )
+  call feedkeys("\<MouseMove>", 'xt')
 endfunction

--- a/tests/lib/plugin/shared.vim
+++ b/tests/lib/plugin/shared.vim
@@ -17,7 +17,7 @@ endif
 " When running into the timeout an exception is thrown, thus the function does
 " not return.
 func WaitFor(expr, ...)
-  let timeout = get(a:000, 0, 10000)
+  let timeout = get(a:000, 0, g:test_long_timeout)
   let slept = s:WaitForCommon(a:expr, v:null, timeout)
   if slept < 0
     throw 'WaitFor() timed out after ' . timeout . ' msec'
@@ -34,7 +34,7 @@ endfunc
 "
 " Return zero for success, one for failure (like the assert function).
 func WaitForAssert(assert, ...)
-  let timeout = get(a:000, 0, 5000)
+  let timeout = get(a:000, 0, g:test_timeout)
   if s:WaitForCommon(v:null, a:assert, timeout) < 0
     return 1
   endif

--- a/tests/lib/run_test.vim
+++ b/tests/lib/run_test.vim
@@ -39,6 +39,11 @@ let g:vimspector_batch_mode = 1
 " Let a test take up to 1 minute, unless debugging
 let s:single_test_timeout = 60000
 
+" Timeouts in milliseconds
+let g:test_long_timeout = 15000
+let g:test_timeout = 5000
+let g:test_short_timeout = 1000
+
 " Restrict the runtimepath to the exact minimum needed for testing
 let &runtimepath = getcwd() . '/lib'
 set runtimepath+=$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after

--- a/tests/manual/image/Dockerfile
+++ b/tests/manual/image/Dockerfile
@@ -3,11 +3,8 @@ ARG ARCH=x86_64
 FROM puremourning/vimspector:test-${ARCH}
 
 RUN apt-get update && \
-  apt-get -y dist-upgrade && \
-  apt-get -y install sudo
-
-## cleanup of files from setup
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  apt-get -y install sudo && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN useradd -ms /bin/bash -d /home/dev -G sudo dev && \
     echo "dev:dev" | chpasswd && \

--- a/tests/mappings.test.vim
+++ b/tests/mappings.test.vim
@@ -354,7 +354,7 @@ function! Test_Partial_Mappings_Dict_Override()
   py3 <<EOF
 from unittest import mock
 with mock.patch( 'vimspector.utils.InputSave' ):
-  vim.eval( 'feedkeys( "\<Tab>\<C-u>100\<CR>", "xt" )' )
+  vim.eval( r'feedkeys( "\<Tab>\<C-u>100\<CR>", "xt" )' )
 EOF
 
   call WaitForAssert( {->

--- a/tests/memory.test.vim
+++ b/tests/memory.test.vim
@@ -111,7 +111,7 @@ function! Test_DumpMemory_VariableWindow()
   py3 <<EOF
 from unittest import mock
 with mock.patch( 'vimspector.utils.InputSave' ):
-  vim.eval( 'feedkeys( ",m\<C-u>5\<CR>\<CR>", "xt" )' )
+  vim.eval( r'feedkeys( ",m\<C-u>5\<CR>\<CR>", "xt" )' )
 EOF
   call WaitForAssert( {->
         \   AssertMatchList(
@@ -238,7 +238,7 @@ function! Test_DumpMemory_WatchWindow()
   py3 <<EOF
 from unittest import mock
 with mock.patch( 'vimspector.utils.InputSave' ):
-  vim.eval( 'feedkeys( ",m\<C-u>1\<CR>\<CR>", "xt" )' )
+  vim.eval( r'feedkeys( ",m\<C-u>1\<CR>\<CR>", "xt" )' )
 EOF
   call WaitForAssert( {->
         \   AssertMatchList(

--- a/tests/tabpage.test.vim
+++ b/tests/tabpage.test.vim
@@ -33,7 +33,7 @@ function! Test_Step_With_Different_Tabpage()
   let vimspector_tabnr = tabpagenr()
   call WaitForAssert( {->
         \ assert_equal( 'simple.cpp', bufname( '%' ), 'Current buffer' )
-        \ }, 10000 )
+        \ }, g:test_long_timeout )
   call assert_equal( 15, line( '.' ), 'Current line' )
   call assert_equal( 1, col( '.' ), 'Current column' )
 

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -759,6 +759,132 @@ function! Test_VariableEval()
   %bwipe!
 endfunction
 
+function! Test_VariableEval_Hover()
+  call SkipNeovim()
+  let fn =  'testdata/cpp/simple/struct.cpp'
+  call s:StartDebugging( #{ fn: fn, line: 24, col: 1, launch: #{
+        \   configuration: 'run-to-breakpoint'
+        \ } } )
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 26, 1 )
+
+  "evaluate the prev line
+  call MoveMouseToPositionInWindow( g:vimspector_session_windows.code, 24, 8 )
+
+  call WaitForAssert( {->
+        \   AssertNotNull( g:vimspector_session_windows.eval )
+        \ } )
+
+  call WaitForAssert( {->
+        \   AssertMatchList(
+        \     [
+        \       '{...}',
+        \       ' - i: 0',
+        \       ' - c: 0 ''\\0\{1,3}''',
+        \       ' - fffff: 0',
+        \       ' + another_test: ',
+        \     ],
+        \     getbufline( winbufnr( g:vimspector_session_windows.eval ),
+        \                 1,
+        \                 '$' )
+        \   )
+        \ } )
+
+  "Close
+  call MoveMouseToPositionInWindow( g:vimspector_session_windows.code, 1, 1 )
+  call WaitForAssert( {->
+        \ AssertNull( g:vimspector_session_windows.eval )
+        \ } )
+  call WaitForAssert( {->
+        \ assert_equal( len( popup_list() ), 0 ) } )
+
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
+function! SetUp_Test_VariableEval_HoverDisabled()
+  call vimspector#test#setup#PushOption( 'balloondelay', 10 )
+  call vimspector#test#setup#PushGlobal( 'vimspector_enable_auto_hover', 0 )
+endfunction
+
+function! TearDown_Test_VariableEval_HoverDisabled()
+  call vimspector#test#setup#PopOption( 'balloondelay' )
+  call vimspector#test#setup#PopGlobal( 'vimspector_enable_auto_hover' )
+endfunction
+
+function! Test_VariableEval_HoverDisabled()
+  call SkipNeovim()
+
+  let fn =  'testdata/cpp/simple/struct.cpp'
+  call s:StartDebugging( #{ fn: fn, line: 24, col: 1, launch: #{
+        \   configuration: 'run-to-breakpoint'
+        \ } } )
+
+  call vimspector#StepOver()
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 26, 1 )
+
+  "evaluate the prev line
+  call MoveMouseToPositionInWindow( g:vimspector_session_windows.code, 24, 8 )
+
+  " balloondelay is 10ms + need some time for the popup to appear. And CI can be
+  " very slow, so let's be super conservative and wait a whole 5s to be super
+  " sure that we actually don't show a popup.
+  sleep 5000m
+
+  call WaitForAssert( {->
+        \   AssertNull( g:vimspector_session_windows.eval )
+        \ } )
+  call WaitForAssert( {->
+        \ assert_equal( len( popup_list() ), 0 ) } )
+
+  " leader is ,
+  xmap <buffer> <Leader>d <Plug>VimspectorBalloonEval
+  nmap <buffer> <Leader>d <Plug>VimspectorBalloonEval
+
+  "evaluate the prev line
+  call setpos( '.', [ 0, 24, 8 ] )
+  call vimspector#test#signs#AssertCursorIsAtLineInBuffer( fn, 24, 8 )
+  call feedkeys( ',d', 'xt' )
+
+  call WaitForAssert( {->
+        \   AssertNotNull( g:vimspector_session_windows.eval )
+        \ } )
+  call WaitForAssert( {->
+        \ assert_equal( len( popup_list() ), 1 ) } )
+
+  call WaitForAssert( {->
+        \   AssertMatchList(
+        \     [
+        \       '{...}',
+        \       ' - i: 0',
+        \       ' - c: 0 ''\\0\{1,3}''',
+        \       ' - fffff: 0',
+        \       ' + another_test: ',
+        \     ],
+        \     getbufline( winbufnr( g:vimspector_session_windows.eval ),
+        \                 1,
+        \                 '$' )
+        \   )
+        \ } )
+
+  "Close
+  call MoveMouseToPositionInWindow( g:vimspector_session_windows.code, 1, 1 )
+  sleep 20m
+  call WaitForAssert( {->
+        \   AssertNotNull( g:vimspector_session_windows.eval )
+        \ } )
+
+  call feedkeys( "\<Esc>", 'xt' )
+  call WaitForAssert( {->
+        \ AssertNull( g:vimspector_session_windows.eval )
+        \ } )
+  call WaitForAssert( {->
+        \ assert_equal( len( popup_list() ), 0 ) } )
+  call vimspector#test#setup#Reset()
+  %bwipe!
+endfunction
+
 function! Test_VariableEvalExpand()
   call SkipNeovim()
   let fn =  'testdata/cpp/simple/struct.cpp'

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -804,6 +804,7 @@ function! Test_VariableEval_Hover()
 endfunction
 
 function! SetUp_Test_VariableEval_HoverDisabled()
+  call SkipNeovim()
   call vimspector#test#setup#PushOption( 'balloondelay', 10 )
   call vimspector#test#setup#PushGlobal( 'vimspector_enable_auto_hover', 0 )
 endfunction
@@ -814,8 +815,6 @@ function! TearDown_Test_VariableEval_HoverDisabled()
 endfunction
 
 function! Test_VariableEval_HoverDisabled()
-  call SkipNeovim()
-
   let fn =  'testdata/cpp/simple/struct.cpp'
   call s:StartDebugging( #{ fn: fn, line: 24, col: 1, launch: #{
         \   configuration: 'run-to-breakpoint'

--- a/tests/variables.test.vim
+++ b/tests/variables.test.vim
@@ -1027,7 +1027,7 @@ function! Test_SetVariableValue_Local()
   py3 <<EOF
 from unittest import mock
 with mock.patch( 'vimspector.utils.InputSave' ):
-  vim.eval( 'feedkeys( "\<C-CR>\<C-u>100\<CR>", "xt" )' )
+  vim.eval( r'feedkeys( "\<C-CR>\<C-u>100\<CR>", "xt" )' )
 EOF
 
   call WaitForAssert( {->
@@ -1152,7 +1152,7 @@ function! Test_SetVariableValue_Watch()
   py3 <<EOF
 from unittest import mock
 with mock.patch( 'vimspector.utils.InputSave' ):
-  vim.eval( 'feedkeys( ",\<CR>\<C-u>100\<CR>", "xt" )' )
+  vim.eval( r'feedkeys( ",\<CR>\<C-u>100\<CR>", "xt" )' )
 EOF
 
 
@@ -1244,7 +1244,7 @@ function! Test_SetVariableValue_Balloon()
   py3 <<EOF
 from unittest import mock
 with mock.patch( 'vimspector.utils.InputSave' ):
-  vim.eval( 'feedkeys( "\<C-CR>\<C-u>100\<CR>", "xt" )' )
+  vim.eval( r'feedkeys( "\<C-CR>\<C-u>100\<CR>", "xt" )' )
 EOF
 
   call WaitForAssert( {->

--- a/tests/variables_compact.test.vim
+++ b/tests/variables_compact.test.vim
@@ -899,7 +899,7 @@ function! Test_SetVariableValue_Local()
   py3 <<EOF
 from unittest import mock
 with mock.patch( 'vimspector.utils.InputSave' ):
-  vim.eval( 'feedkeys( "\<C-CR>\<C-u>100\<CR>", "xt" )' )
+  vim.eval( r'feedkeys( "\<C-CR>\<C-u>100\<CR>", "xt" )' )
 EOF
 
   call WaitForAssert( {->
@@ -1024,7 +1024,7 @@ function! Test_SetVariableValue_Watch()
   py3 <<EOF
 from unittest import mock
 with mock.patch( 'vimspector.utils.InputSave' ):
-  vim.eval( 'feedkeys( ",\<CR>\<C-u>100\<CR>", "xt" )' )
+  vim.eval( r'feedkeys( ",\<CR>\<C-u>100\<CR>", "xt" )' )
 EOF
 
 
@@ -1116,7 +1116,7 @@ function! Test_SetVariableValue_Balloon()
   py3 <<EOF
 from unittest import mock
 with mock.patch( 'vimspector.utils.InputSave' ):
-  vim.eval( 'feedkeys( "\<C-CR>\<C-u>100\<CR>", "xt" )' )
+  vim.eval( r'feedkeys( "\<C-CR>\<C-u>100\<CR>", "xt" )' )
 EOF
 
   call WaitForAssert( {->

--- a/tests/vimrc
+++ b/tests/vimrc
@@ -9,6 +9,11 @@ if exists( '$VIMSPECTOR_TEST_BASE' )
   let g:vimspector_base_dir = g:vimspector_test_plugin_path .. '/' .. $VIMSPECTOR_TEST_BASE
 endif
 
+if has('nvim' ) && exists( 'g:vimspector_base_dir' )
+  \ && isdirectory( g:vimspector_base_dir . '/nvim_env' )
+  let g:python3_host_prog = g:vimspector_base_dir . '/nvim_env/bin/python'
+endif
+
 let &runtimepath = &runtimepath . ',' . g:vimspector_test_plugin_path
 
 filetype plugin indent on


### PR DESCRIPTION
3 people have now asked for this, and I can sort of see why you might want to do it. So you can now disable the mouse balloon feature with g:vimspector_enable_auto_hover=0.

Default remains on, of course.

Closes #496