### PR TITLE
Minor docs fixes - missing reference and switch from http to https for puremourning.github.io

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1305,6 +1305,7 @@ and is provided just as an example.
 [dap]: https://microsoft.github.io/debug-adapter-protocol/
 [schema]: http://puremourning.github.io/vimspector/schema/vimspector.schema.json
 [gadget-schema]: http://puremourning.github.io/vimspector/schema/gadgets.schema.json
+[website-getting-started]: https://puremourning.github.io/vimspector-web/#getting-started
 [YouCompleteMe]: https://github.com/ycm-core/YouCompleteMe
 [lsp-examples]: https://github.com/ycm-core/lsp-examples
 [vscode-json]: https://github.com/vscode-langservers/vscode-json-languageserver

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1303,8 +1303,8 @@ This configuration can be adapted to any other LSP-based editor configuration
 and is provided just as an example.
 
 [dap]: https://microsoft.github.io/debug-adapter-protocol/
-[schema]: http://puremourning.github.io/vimspector/schema/vimspector.schema.json
-[gadget-schema]: http://puremourning.github.io/vimspector/schema/gadgets.schema.json
+[schema]: https://puremourning.github.io/vimspector/schema/vimspector.schema.json
+[gadget-schema]: https://puremourning.github.io/vimspector/schema/gadgets.schema.json
 [website-getting-started]: https://puremourning.github.io/vimspector-web/#getting-started
 [YouCompleteMe]: https://github.com/ycm-core/YouCompleteMe
 [lsp-examples]: https://github.com/ycm-core/lsp-examples


### PR DESCRIPTION
A couple of trivial docs fixes - add one missing reference and switch from http to https for puremourning.github.io