### PR TITLE
[python/debugpy] update sha256 for debugpy

### DIFF
--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -115,7 +115,7 @@ GADGETS = {
       'version': '1.7.0',
       'file_name': 'v1.7.0.zip',
       'checksum':
-        ''
+        '31c17f6dbce76bdc4da358a4e9b0167903dc5341076dbc1743f89bc1368b9bc7'
     },
     'do': lambda name, root, gadget: installer.InstallDebugpy( name,
                                                                root,


### PR DESCRIPTION
![image](https://github.com/puremourning/vimspector/assets/13466943/055d8514-d8b1-4ec6-8519-30b8ca1555bc)


without `checksum`, we have to redownload debugpy.zip