### PR TITLE
Check capabilities before sending instruction breakpoints

### DIFF
--- a/python3/vimspector/breakpoints.py
+++ b/python3/vimspector/breakpoints.py
@@ -959,7 +959,8 @@ class ProjectBreakpoints( object ):
           failure_handler = response_received
         )
 
-    if self._disassembly_manager:
+    if self._disassembly_manager and self._server_capabilities.get(
+      'supportsInstructionBreakpoints' ):
       for connection in self._connections:
         breakpoints = []
         bp_idxs = []


### PR DESCRIPTION
Servers can support disassembly without instruction breakpoints.