### PR TITLE
Update delve to 1.22 for compatibility with latest go

### DIFF
--- a/python3/vimspector/gadgets.py
+++ b/python3/vimspector/gadgets.py
@@ -353,7 +353,7 @@ GADGETS = {
                                                              gadget ),
     'all': {
       'path': 'github.com/go-delve/delve/cmd/dlv',
-      'version': '1.21.0',
+      'version': '1.22.1',
     },
     'adapters': {
       "delve": {


### PR DESCRIPTION
Maybe this will fix CI flakes.