### PR TITLE
Fix thread state when stepping over

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -306,7 +306,7 @@ while true; do
     pushd ${TESTDIR} > /dev/null
       RUN="${RUN_TEST} --cmd \"${BASEDIR_CMD}\" \
                        --cmd 'au SwapExists * let v:swapchoice = \"e\"'\
-                       $tt $T"
+                       '$tt' '$T'"
 
       if ${ASCIINEMA} rec -q --cols $SCREENCOLS --rows $SCREENROWS --overwrite --command "${RUN}" $t.cast >&3 && [ -f $t.res ];  then
         echo "%PASS: $t PASSED"

--- a/tests/disassembly.test.vim
+++ b/tests/disassembly.test.vim
@@ -302,6 +302,7 @@ function! Test_Disassembly_StepInGranularity_API_Direct()
   "
   " Step over instruction
   call win_gotoid( g:vimspector_session_windows.code )
+  call cursor(1,1)
   call vimspector#StepIOver()
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 3, 1 )
   call WaitForAssert( {->
@@ -312,7 +313,6 @@ function! Test_Disassembly_StepInGranularity_API_Direct()
   " steps from code window are line steps
   call win_gotoid( winid )
   call vimspector#StepSOver()
-  call cursor(1,1)
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
   call WaitForAssert( {->
         \ vimspector#test#signs#AssertPCIsAtLineInBuffer( s:fn, 4 )
@@ -338,6 +338,7 @@ function! Test_Disassembly_StepInGranularity_API_Direct_CodeLLDB()
   "
   " Step over instruction
   call win_gotoid( g:vimspector_session_windows.code )
+  call cursor(1,1)
   call vimspector#StepIOver()
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:fn, 3, v:null )
   call WaitForAssert( {->
@@ -348,7 +349,6 @@ function! Test_Disassembly_StepInGranularity_API_Direct_CodeLLDB()
   " steps from code window are line steps
   call win_gotoid( winid )
   call vimspector#StepSOver()
-  call cursor(1,1)
   call vimspector#test#signs#AssertCursorIsAtLineInBuffer( s:buf, s:dpc, 1 )
   call WaitForAssert( {->
         \ vimspector#test#signs#AssertPCIsAtLineInBuffer( s:fn, 4 )


### PR DESCRIPTION
There was a suspicious TODO in the code, which was the main reason this was broken: We were unconditionally "continuing" all threads when doing StepOver. This is obviously wrong, and it's correct for StepIn, StepOut etc. -> Wait for the step response and only continue the thread that you stepped within.

Meanwhile I also noticed that the 'stopped' event handling was incorrect if we get a flood of stopped events for different threads. If we got 3 stopped events in quick succession, we'd end up dropping the middle one. This was because we only stored the latest-most pending request. Not sure why i thought that was a good idea, as the handler for the stoppped event includes the thread ID that was actully stopped.

This particularly affects the java debugger which is afaict the only one that doesn't set allThreadsStopped=true.

Fixes #865