### PR TITLE
Eddited MD syntax so there is a clickable link to dir path

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ The following features are not implemented for Windows:
 If you just want to try out vimspector without changing your vim config, there
 are example projects for a number of languages in `support/test`, including:
 
-* Python ([support/test/python/simple_python](support/test/python/simple_python))
+* Python `([support/test/python/simple_python](support/test/python/simple_python))`
 * Go ([support/test/go/hello_world](support/test/go/hello_world) and [support/test/go/name-starts-with-vowel](support/test/go/name-starts-with-vowel))
 * Nodejs ([support/test/node/simple](support/test/node/simple))
 * Chrome/Firefox ([support/test/web](support/test/web))

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ The following features are not implemented for Windows:
 If you just want to try out vimspector without changing your vim config, there
 are example projects for a number of languages in `support/test`, including:
 
-* Python `([support/test/python/simple_python](support/test/python/simple_python))`
+* Python ([support/test/python/simple_python](support/test/python/simple_python))
 * Go ([support/test/go/hello_world](support/test/go/hello_world) and [support/test/go/name-starts-with-vowel](support/test/go/name-starts-with-vowel))
 * Nodejs ([support/test/node/simple](support/test/node/simple))
 * Chrome/Firefox ([support/test/web](support/test/web))

--- a/README.md
+++ b/README.md
@@ -270,10 +270,10 @@ The following features are not implemented for Windows:
 If you just want to try out vimspector without changing your vim config, there
 are example projects for a number of languages in `support/test`, including:
 
-* Python (`support/test/python/simple_python`)
-* Go (`support/test/go/hello_world` and `support/test/go/name-starts-with-vowel`)
-* Nodejs (`support/test/node/simple`)
-* Chrome/Firefox (`support/test/web/`)
+* Python ([support/test/python/simple_python](support/test/python/simple_python))
+* Go ([support/test/go/hello_world](support/test/go/hello_world) and [support/test/go/name-starts-with-vowel](support/test/go/name-starts-with-vowel))
+* Nodejs ([support/test/node/simple](support/test/node/simple))
+* Chrome/Firefox ([support/test/web](support/test/web))
 * etc.
 
 To test one of these out, cd to the directory and run:


### PR DESCRIPTION
edit makes click able link to take reader to the path specified .  

see Images 
before 
![image](https://github.com/user-attachments/assets/42dd0e4c-9298-4914-91d0-5a647cf70892)
after 
![image](https://github.com/user-attachments/assets/8e97f3fd-e203-441b-9dd1-9726ec7129e8)


note : 
I made this change because I was going thru the docs and trying out vimspector.  I went to the go example and wished i could have clicked it.  if the comunity merges this change Ill go and fix the rest of the documentatoin

Thanks for making a great tool !