### PR TITLE
Connection to gadgets on IPv6-enabled host is failing

### DIFF
--- a/autoload/vimspector/internal/channel.vim
+++ b/autoload/vimspector/internal/channel.vim
@@ -88,7 +88,7 @@ function! vimspector#internal#channel#StartDebugSession(
           \              )
   endif
 
-  let l:addr = get( a:config, 'host', '127.0.0.1' ) . ':' . a:config[ 'port' ]
+  let l:addr = get( a:config, 'host', 'localhost' ) . ':' . a:config[ 'port' ]
 
   echo 'Connecting to ' . l:addr . '... (waiting for up to 10 seconds)'
   " FIXME: This _always_ waits 10s; the neochannel version is quicker

--- a/autoload/vimspector/internal/neochannel.vim
+++ b/autoload/vimspector/internal/neochannel.vim
@@ -73,7 +73,7 @@ function! vimspector#internal#neochannel#StartDebugSession(
     endtry
   endif
 
-  let l:addr = get( a:config, 'host', '127.0.0.1' ) . ':' . a:config[ 'port' ]
+  let l:addr = get( a:config, 'host', 'localhost' ) . ':' . a:config[ 'port' ]
 
   let attempt = 1
   while attempt <= 10

--- a/docs/schema/vimspector.schema.json
+++ b/docs/schema/vimspector.schema.json
@@ -239,7 +239,7 @@
           "properties": {
             "host": {
               "type": "string",
-              "default": "127.0.0.1",
+              "default": "localhost",
               "description": "Connect to this host in multi-session mode"
             },
             "port": {


### PR DESCRIPTION
On hosts where IPv6 is enabled and preferred by the system, gadgets might be listening to ::1 instead of 127.0.0.1. In those situations, vimspector times out, unable to connect to the gadget even though they've both agreed about which port to use.

Changing the default host value to 'localhost' makes it possible for IPv6-enabled hosts to use the same default in vimspector than in the gadgets.