### PR TITLE
Limit the number of variable children drawn WIP

### DIFF
--- a/python3/vimspector/settings.py
+++ b/python3/vimspector/settings.py
@@ -24,6 +24,7 @@ DEFAULTS = {
   'bottombar_height':   10,
   'disassembly_height': 20,
   'variables_display_mode': 'compact', # compact/full
+  'max_variable_children': 200,
 
   # For ui_mode = 'horizontal':
   'sidebar_width':      50,

--- a/python3/vimspector/variables.py
+++ b/python3/vimspector/variables.py
@@ -683,7 +683,16 @@ class VariablesView( object ):
 
   def _DrawVariables( self, view, variables, indent_len, is_short = False ):
     assert indent_len > 0
-    for variable in variables:
+    max_variable_children = settings.Int( 'max_variable_children' )
+    for idx, variable in enumerate(variables):
+      if idx >= max_variable_children:
+        utils.AppendToBuffer(
+          view.buf,
+          f"{indent}... {len(variables) - max_variable_children} more",
+          hl = 'WarningMsg'
+        )
+        break
+
       text = ''
       # We borrow 1 space of indent to draw the change marker
       indent = ' ' * ( indent_len - 1 )


### PR DESCRIPTION
Added a new setting 'max_variable_children' defaulting to 200. This is pretty lame, but could help with pathological cases like #889.

Better options for the future:
 - allow <CR> on the ... to show "everything"
 - implement paging properly
 - also make the code less inefficient.