### PR TITLE
Wipe out scratch buffers

### DIFF
--- a/python3/vimspector/utils.py
+++ b/python3/vimspector/utils.py
@@ -166,10 +166,9 @@ def CleanUpHiddenBuffer( buf ):
     return
 
   try:
-    vim.command( 'bdelete! {}'.format( buf.number ) )
+    vim.command( 'bwipeout! {}'.format( buf.number ) )
   except vim.error as e:
-    # FIXME: For now just ignore the "no buffers were deleted" error
-    if 'E516' not in str( e ):
+    if 'E517' not in str( e ):
       raise
 
 


### PR DESCRIPTION
Some people are really picky about their buffer numbers and not having unlisted, unloaded buffers in the buffer list. I personally don't care and like the fact that marks and stuff are retained between runs, but I don't care enough to really fight it. This is cleaner afterall.

Closes #879