### PR TITLE
Normalise path letters on Windows

### DIFF
--- a/python3/vimspector/core_utils.py
+++ b/python3/vimspector/core_utils.py
@@ -99,4 +99,8 @@ def override( target_dict: typing.MutableMapping,
 
 def NormalizePath( filepath ):
   absolute_path = os.path.abspath( filepath )
+  # Normalise windows drive letters to uppercase
+  drive, tail = os.path.splitdrive( absolute_path )
+  if drive:
+    absolute_path = drive.upper() + tail
   return absolute_path if os.path.isfile( absolute_path ) else filepath


### PR DESCRIPTION
paths on windows are not case-sensitive, and we're not really good about equivalent paths with differing case. However, it would be nice to believe that normpath() deals with that. Which, of course, it doesn't.

For the most part though it works, with the frustrating exception of drive letters. So we hack it to normalise drive letters to uppercase, which prevents duplicate paths appearing in the breakpoints lists.

Fixes #898