### PR TITLE
Use TCL8 on macOS in preference

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -113,7 +113,7 @@ jobs:
         brew update-reset
         brew doctor || true
         brew cleanup || true
-        for p in vim go tcl-tk llvm lua luajit love neovim coreutils; do
+        for p in vim go tcl-tk@8 llvm lua luajit love neovim coreutils; do
           brew install $p || brew outdated $p || brew upgrade $p
         done
         brew reinstall icu4c

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ runtime dependencies). They are categorised by their level of support:
 | C, C++, Rust, Jai, etc. | Tested       | `--enable-rust`, `--enable-c`, etc. | CodeLLDB                             | none                                         |
 | Python                  | Tested       | `--all` or `--enable-python`        | debugpy                              | Python 3                                     |
 | Go                      | Tested       | `--enable-go`                       | delve                                | Go 1.16+                                     |
-| TCL                     | Supported    | `--all` or `--enable-tcl`           | tclpro                               | TCL 8.5                                      |
+| TCL                     | Supported    | `--all` or `--enable-tcl`           | tclpro                               | TCL >= 8.5 < 9.0                                     |
 | Bourne Shell            | Supported    | `--all` or `--enable-bash`          | vscode-bash-debug                    | Bash v??                                     |
 | Lua                     | Tested       | `--all` or `--enable-lua`           | local-lua-debugger-vscode            | Node >=12.13.0, Npm, Lua interpreter         |
 | Node.js                 | Supported    | `--force-enable-node`               | vscode-js-debug                      | Node >= 18                                   |
@@ -1932,6 +1932,8 @@ for examk
 ## TCL
 
 * TCL (TclProDebug)
+
+Requires TCL 8.x. Does not work with TCL 9.
 
 See [my fork of TclProDebug](https://github.com/puremourning/TclProDebug) for instructions.
 

--- a/python3/vimspector/installer.py
+++ b/python3/vimspector/installer.py
@@ -436,10 +436,15 @@ def InstallTclProDebug( name, root, gadget ):
     #    '/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System'
     #    '/Library/Frameworks/Tcl.framework/Versions'
     #    '/Current',
-    for p in [ '/usr/local/opt/tcl-tk/lib', '/opt/homebrew/opt/tcl-tk/lib' ]:
-      if os.path.exists( os.path.join( p, 'tclConfig.sh' ) ):
-        configure.append( '--with-tcl=' + p )
-        break
+    for tcl in [ "tcl-tk@8", "tcl-tk" ]:
+      for p in [ f'/usr/local/opt/{tcl}/lib', f'/opt/homebrew/opt/{tcl}/lib' ]:
+        if os.path.exists( os.path.join( p, 'tclConfig.sh' ) ):
+          Print( f"Found tclConfig.sh in {p}" )
+          configure.append( '--with-tcl=' + p )
+          break
+      else:
+        continue
+      break
 
 
   with CurrentWorkingDir( os.path.join( root, 'lib', 'tclparser' ) ):


### PR DESCRIPTION
tclParser used by TCLProDebug doesn't compile on TCL 9. While that remains an upstream problem, try to find TCL 8 on macOS to fix CI at least.