### PR TITLE
seq =1 in first message

### DIFF
--- a/python3/vimspector/debug_adapter_connection.py
+++ b/python3/vimspector/debug_adapter_connection.py
@@ -51,7 +51,7 @@ class DebugAdapterConnection( object ):
     self._buffer = bytes()
     self._handlers = handlers
     self._session_id = session_id
-    self._next_message_id = 0
+    self._next_message_id = 1
     self._outstanding_requests = {}
     self.async_timeout = async_timeout
     self.sync_timeout = sync_timeout


### PR DESCRIPTION
The DAP protocol (https://microsoft.github.io/debug-adapter-protocol/specification) requires that the first message has sequence number equal to 1. This requirement does not seem to be widely enforced however, but it does create a problem when using the latest version of lldb-dap directly, as it simply aborts the connection, making it completely unusable.