### PR TITLE
Update README.md with Lazy.nvim plugin manager info

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,16 @@ There are 2 installation methods:
    Plugin 'puremourning/vimspector'
    ```
 
-2. Install some 'gadgets' (debug adapters) - see [here for installation commands](#install-some-gadgets) and [select gadgets to install](#supported-languages)
-3. Configure your project's debug profiles (create `.vimspector.json`, or set
+   For Lazy.nvim, use:
+
+   ```vim
+   return { "puremourning/vimspector" }
+   ```
+
+   and launch `:Lazy load vimspector` for the first start.
+
+3. Install some 'gadgets' (debug adapters) - see [here for installation commands](#install-some-gadgets) and [select gadgets to install](#supported-languages)
+4. Configure your project's debug profiles (create `.vimspector.json`, or set
    `g:vimspector_configurations`) - see the [reference guide][vimspector-ref]
 
 The following sections expand on the above brief overview.


### PR DESCRIPTION
I had quite some trouble to finally load properly vimspector with [Lazy.nvim](https://github.com/folke/lazy.nvim) package manager.

Running `:Lazy load vimspector` once, after Vimspector having been installed by Lazy.nvim, make all Vimspector functions and features available.

I guess that it sources vimspector's `autoload/` directory.