### PR TITLE
Fix backtrace when CodeLLDB produces a line of 0

### DIFF
--- a/python3/vimspector/stack_trace.py
+++ b/python3/vimspector/stack_trace.py
@@ -706,7 +706,8 @@ class StackTraceView( object ):
                            self._buf.name,
                            line )
 
-          if utils.BufferExists( frame[ 'source' ][ 'path' ] ):
+          if ( utils.BufferExists( frame[ 'source' ][ 'path' ] )
+               and frame[ 'line' ] ):
             sign_id = len( self._top_of_stack_signs ) + 100
             self._top_of_stack_signs.append( sign_id )
             signs.PlaceSign( sign_id,

--- a/support/test/cpp/simple_c_program/.vimspector.json
+++ b/support/test/cpp/simple_c_program/.vimspector.json
@@ -51,6 +51,11 @@
     },
     "CodeLLDB": {
       "adapter": "CodeLLDB",
+      "variables": {
+        "BUILDME": {
+          "shell": "g++ -o ${workspaceRoot}/test -g -std=c++17 ${workspaceRoot}/test_c.cpp"
+        }
+      },
       "configuration": {
         "request": "launch",
         "expressions": "native",


### PR DESCRIPTION
Sometimes when stepping by instruction, we get a stack trade with a line of 0. This causes a backtrace in Vim when trying to place a sign on that line. Skip this error.

Fixes #944