### PR TITLE
make Go examples work with Go Modules

### DIFF
--- a/support/test/go/Stdio/.vimspector.json
+++ b/support/test/go/Stdio/.vimspector.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json",
   "configurations": {
-    "Run": {
+    "Run Main": {
       "adapter": "delve",
       "configuration": {
         "request": "launch",
         "mode": "debug",
-        "program": "${workspaceRoot}/cmd/main.go"
+        "program": "${workspaceRoot}/cmd",
+        "dlvCwd": "${workspaceRoot}"
       }
     }
   }

--- a/support/test/go/Stdio/go.mod
+++ b/support/test/go/Stdio/go.mod
@@ -1,3 +1,3 @@
 module stdiotest
 
-go 1.17
+go 1.24

--- a/support/test/go/hello_world/.vimspector.json
+++ b/support/test/go/hello_world/.vimspector.json
@@ -1,28 +1,12 @@
 {
   "configurations": {
-    "run-legacy": {
-      "adapter": "vscode-go",
-      "configuration": {
-        "request": "launch",
-        "program": "${workspaceRoot}/hello-world.go",
-        "mode": "debug",
-        "trace": true,
-        "env": { "GO111MODULE": "off" }
-      },
-      "breakpoints": {
-        "exception": {
-          "unrecovered-panic": ""
-        }
-      }
-    },
     "run-delve": {
       "adapter": "delve",
       "configuration": {
         "request": "launch",
-        "env": { "GO111MODULE": "off" },
-
         "mode": "debug", // debug|test
-        "program": "${workspaceRoot}/hello-world.go"
+        "program": "${workspaceRoot}",
+        "dlvCwd": "${workspaceRoot}"
 
         // "args": [],
         // "buildFlags": ...
@@ -33,6 +17,20 @@
         "exception": {
           "unrecovered-panic": "",
           "runtime-fatal-throw": ""
+        }
+      }
+    },
+    "run-legacy": {
+      "adapter": "vscode-go",
+      "configuration": {
+        "request": "launch",
+        "program": "${workspaceRoot}/hello-world.go",
+        "mode": "debug",
+        "trace": true
+      },
+      "breakpoints": {
+        "exception": {
+          "unrecovered-panic": ""
         }
       }
     }

--- a/support/test/go/hello_world/go.mod
+++ b/support/test/go/hello_world/go.mod
@@ -1,0 +1,3 @@
+module example.com/hello
+
+go 1.24

--- a/support/test/go/name-starts-with-vowel/.vimspector.json
+++ b/support/test/go/name-starts-with-vowel/.vimspector.json
@@ -1,29 +1,47 @@
 {
-    "configurations": {
-        "run-cmd": {
-            "adapter": "vscode-go",
-            "configuration": {
-                "request": "launch",
-                "program": "${workspaceRoot}/cmd/namestartswithvowel/main.go",
-                "mode": "debug",
-                "dlvToolPath": "$HOME/go/bin/dlv",
-                "dlvLoadConfig": {
-                    "maxArrayValues": 1000,
-                    "maxStringLen": 1000
-                }
-            }
-        },
-        "test-current-file": {
-            "adapter": "vscode-go",
-            "configuration": {
-                "request": "launch",
-                "mode": "test",
-                "program": "${fileDirname}",
-                "cwd": "${fileDirname}",
-                "dlvToolPath": "$GOPATH/bin/dlv",
-                "env": {},
-                "args": []
-            }
+  "configurations": {
+    "Run Main": {
+      "adapter": "delve",
+      "configuration": {
+        "request": "launch",
+        "mode": "debug",
+        "program": "${workspaceRoot}/cmd/namestartswithvowel",
+        "dlvCwd": "${workspaceRoot}"
+      }
+    },
+    "Test Current Package": {
+      "adapter": "delve",
+      "configuration": {
+        "request": "launch",
+        "mode": "test",
+        "program": "${fileDirname}",
+        "dlvCwd": "${fileDirname}"
+      }
+    },
+    "vscode-go-run-cmd": {
+      "adapter": "vscode-go",
+      "configuration": {
+        "request": "launch",
+        "program": "${workspaceRoot}/cmd/namestartswithvowel/main.go",
+        "mode": "debug",
+        "dlvToolPath": "$HOME/go/bin/dlv",
+        "dlvLoadConfig": {
+          "maxArrayValues": 1000,
+          "maxStringLen": 1000
         }
+      }
+    },
+    "vscode-go-test-current-file": {
+      "adapter": "vscode-go",
+      "configuration": {
+        "request": "launch",
+        "mode": "test",
+        "program": "${fileDirname}",
+        "cwd": "${fileDirname}",
+        "dlvToolPath": "$GOPATH/bin/dlv",
+        "env": {},
+        "args": []
+      }
     }
+  }
 }

--- a/support/test/go/name-starts-with-vowel/go.mod
+++ b/support/test/go/name-starts-with-vowel/go.mod
@@ -1,3 +1,3 @@
 module example.com
 
-go 1.16
+go 1.24

--- a/support/test/go/structs/.vimspector.json
+++ b/support/test/go/structs/.vimspector.json
@@ -1,5 +1,19 @@
 {
   "configurations": {
+    "run-delve": {
+      "adapter": "delve",
+      "configuration": {
+        "request": "launch",
+        "mode": "debug", // debug|test
+        "program": "${workspaceRoot}",
+        "dlvCwd": "${workspaceRoot}"
+
+        // "args": [],
+        // "buildFlags": ...
+        // "stackTraceDepth": ...,
+        // "showGlobalVariables": true,
+      }
+    },
     "run-legacy": {
       "adapter": "vscode-go",
       "configuration": {
@@ -8,21 +22,6 @@
         "mode": "debug",
         "trace": true,
         "env": { "GO111MODULE": "off" }
-      }
-    },
-    "run-delve": {
-      "adapter": "delve",
-      "configuration": {
-        "request": "launch",
-        "env": { "GO111MODULE": "off" },
-
-        "mode": "debug", // debug|test
-        "program": "${workspaceRoot}/hello-world.go"
-
-        // "args": [],
-        // "buildFlags": ...
-        // "stackTraceDepth": ...,
-        // "showGlobalVariables": true,
       }
     }
   }

--- a/support/test/go/structs/go.mod
+++ b/support/test/go/structs/go.mod
@@ -1,0 +1,3 @@
+module example.com/structs
+
+go 1.24


### PR DESCRIPTION
tl;dr Add the `dlvCwd` Delve launch config property so that Delve correctly finds our debuggee module. Remove `GO111MODULE=off` since we don't need it anymore.

Previously, we had issues with modules in #178, which we worked around in #180 by adding `GO111MODULE=off` to the examples. However, with Go Modules being the default way to write things now (two out of the first three [tutorials in Go's docs](https://go.dev/doc/) are about creating modules), we should probably get it working without that.

As a reminder (and for searchability), here's the error we get:

```
// launch config
"request": "launch",
"mode": "debug",
"program": "${fileDirname}",

Build Error: go build -o /path/to/someProject/__debug_bin -gcflags all=-N -l /path/to/someProject/someModule\ngo: go.mod file not found in current directory or any parent directory; see 'go help modules' (exit status 1)
```

No change when adding `"cwd": "${fileDirname}"` to the launch config.

The problem is most noticable in the `name-starts-with-vowel` example, where we import from a package from the same module (we get the error `no required module provides package example.com/internal/vowels`), and have tests for one of the packages (where we get the `go.mod file not found` error, but with `go test` instead of `go build`).

After a lot of trial and error, it turns out the cause of the issue is pretty simple, just Delve's CWD, and there are a few ways to get it working.

I found the right launch config option in the [godoc for the type](https://pkg.go.dev/github.com/go-delve/delve@master/service/dap#LaunchConfig) (ty @hyangah for the link in https://github.com/puremourning/vimspector/issues/186#issuecomment-953936853). `dlvCwd` got added in go-delve/delve#2660 and does this:

> When Delve needs to build the program (in debug/test modes), it will run the go command from this directory

So if we set `dlvCwd` to `${workspaceRoot}` or `${fileDirname}`, it will [make Delve set its own CWD](https://github.com/go-delve/delve/blob/efcc1fe030882f5768a0421b808d8b1e6b9ef75b/service/dap/server.go#L991), so when we run `go build`, we'll be in the correct module directory of the debuggee.